### PR TITLE
feat: add OpenCode local installation support

### DIFF
--- a/.opencode/bun.lock
+++ b/.opencode/bun.lock
@@ -1,0 +1,39 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.1.25",
+        "gray-matter": "^4.0.3",
+        "zod": "^4.1.8",
+      },
+    },
+  },
+  "packages": {
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.25", "", { "dependencies": { "@opencode-ai/sdk": "1.1.25", "zod": "4.1.8" } }, "sha512-oTUWS446H/j7z3pdzo3cOrB5N87XZ/RKdgPD8yHv/rLX92B4YQHjOqggVQ56Q+1VEnN0jxzhoqRylv/0ZEts/Q=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.25", "", {}, "sha512-mWUX489ArEF2ICg3iZsx2VQaGS3Z2j/dwAJDacao9t7dGDzjOIaacPw2weZ10zld7XmT9V9C0PM/A5lDZ52J+w=="],
+
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
+
+    "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
+
+    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+  }
+}

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@opencode-ai/plugin": "1.1.25",
+    "gray-matter": "^4.0.3",
+    "zod": "^4.1.8"
+  }
+}

--- a/.opencode/plugin/hyperpowers-safety.ts
+++ b/.opencode/plugin/hyperpowers-safety.ts
@@ -1,3 +1,69 @@
-import plugin from "../../packages/opencode-plugin/src/index"
+import type { Plugin } from "@opencode-ai/plugin"
+
+const isEnvFile = (filePath: string) => {
+  const parts = filePath.split("/")
+  const base = parts[parts.length - 1] ?? filePath
+
+  if (base === ".env.example") return false
+  if (base === ".env") return true
+  if (base.startsWith(".env.")) return true
+
+  return filePath.includes("/.env")
+}
+
+const isGitHook = (filePath: string) => filePath.includes("/.git/hooks/")
+
+const isPreCommitHook = (filePath: string) =>
+  filePath.endsWith("/.git/hooks/pre-commit") || filePath.includes("/.git/hooks/pre-commit")
+
+const shouldBlockBash = (command: string) => {
+  const c = command.toLowerCase()
+
+  if (c.includes(".git/hooks/pre-commit") || c.includes(".git\\hooks\\pre-commit")) {
+    return "Modifying .git/hooks/pre-commit is blocked"
+  }
+
+  if (c.includes("git push") && (c.includes("--force") || c.includes("-f"))) {
+    return "Force-push is blocked by default"
+  }
+
+  if (c.includes("rm -rf") || c.includes("rm -fr")) {
+    return "Destructive deletes (rm -rf) are blocked by default"
+  }
+
+  return null
+}
+
+const deny = (reason: string) => {
+  throw new Error(`Hyperpowers safety guardrail: ${reason}`)
+}
+
+const plugin: Plugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      const tool = input.tool
+      const args = output.args ?? {}
+
+      if (tool === "read") {
+        const filePath = String(args.filePath ?? "")
+        if (filePath && isEnvFile(filePath)) deny("Reading .env files is not allowed")
+      }
+
+      if (tool === "edit" || tool === "write") {
+        const filePath = String(args.filePath ?? "")
+        if (!filePath) return
+        if (isPreCommitHook(filePath)) deny("Direct edits to .git/hooks/pre-commit are not allowed")
+        if (isGitHook(filePath)) deny("Direct edits to .git/hooks/* are not allowed")
+      }
+
+      if (tool === "bash") {
+        const command = String(args.command ?? "")
+        if (!command) return
+        const blockReason = shouldBlockBash(command)
+        if (blockReason) deny(blockReason)
+      }
+    },
+  }
+}
 
 export default plugin

--- a/.opencode/plugin/hyperpowers-skills.ts
+++ b/.opencode/plugin/hyperpowers-skills.ts
@@ -1,0 +1,145 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { tool } from "@opencode-ai/plugin"
+import matter from "gray-matter"
+import { z } from "zod"
+import { dirname, relative, sep } from "node:path"
+
+const ToolNameSchema = z
+  .string()
+  .regex(/^[a-z0-9_]+$/, "Tool names must be lowercase with underscores")
+
+const normalizeAllowedTools = (tools: string[] | undefined) => {
+  if (!tools) return undefined
+  const normalized = tools
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .map((t) => t.toLowerCase())
+
+  // Minimal enforcement: ensure names are plausible and non-empty.
+  // (Actual permission enforcement is handled by OpenCode permissions.)
+  const unique = Array.from(new Set(normalized))
+  return unique.length ? unique : undefined
+}
+
+const SkillFrontmatterSchema = z.object({
+  name: z
+    .string()
+    .regex(/^[a-z0-9-]+$/, "Name must be lowercase alphanumeric with hyphens")
+    .min(1),
+  description: z.string().min(20, "Description must be at least 20 characters for discoverability"),
+  license: z.string().optional(),
+  "allowed-tools": z.array(z.string()).optional(),
+  metadata: z.record(z.string()).optional(),
+})
+
+type Skill = {
+  name: string
+  description: string
+  allowedTools?: string[]
+  fullPath: string
+  content: string
+  toolName: string
+}
+
+const generateToolName = (skillPath: string, baseDir: string) => {
+  const rel = relative(baseDir, skillPath)
+  const dirPath = dirname(rel)
+  const components = dirPath.split(sep).filter((c) => c !== ".")
+  return "skills_" + components.join("_").replace(/-/g, "_")
+}
+
+const discoverSkillFiles = async (dir: string) => {
+  const files: string[] = []
+
+  // Discover skills recursively.
+  for await (const path of new Bun.Glob("**/SKILL.md").scan({ cwd: dir })) {
+    files.push(`${dir}/${path}`)
+  }
+
+  return files
+}
+
+const parseSkill = async (skillPath: string, baseDir: string): Promise<Skill | null> => {
+  try {
+    const raw = await Bun.file(skillPath).text()
+    const { data, content } = matter(raw)
+
+    const fm = SkillFrontmatterSchema.safeParse(data)
+    if (!fm.success) return null
+
+    // Validate name matches directory name
+    const dirName = skillPath.split("/").slice(-2, -1)[0]
+    if (!dirName || fm.data.name !== dirName) return null
+
+    const toolName = generateToolName(skillPath, baseDir)
+    const tn = ToolNameSchema.safeParse(toolName)
+    if (!tn.success) return null
+
+    return {
+      name: fm.data.name,
+      description: fm.data.description,
+      allowedTools: normalizeAllowedTools(fm.data["allowed-tools"]),
+      fullPath: dirname(skillPath),
+      content: content.trim(),
+      toolName,
+    }
+  } catch {
+    return null
+  }
+}
+
+const hyperpowersSkillsPlugin: Plugin = async (ctx) => {
+  const projectSkills = `${ctx.directory}/.opencode/skills`
+  const userSkills = `${process.env.HOME}/.opencode/skills`
+  const xdgSkills = `${process.env.XDG_CONFIG_HOME ?? `${process.env.HOME}/.config`}/opencode/skills`
+
+  const bases = [xdgSkills, userSkills, projectSkills]
+
+  const tools: Record<string, any> = {}
+
+  for (const baseDir of bases) {
+    const exists = await Bun.file(baseDir).exists()
+    if (!exists) continue
+
+    const skillFiles = await discoverSkillFiles(baseDir)
+
+    for (const skillPath of skillFiles) {
+      const skill = await parseSkill(skillPath, baseDir)
+      if (!skill) continue
+
+      tools[skill.toolName] = tool({
+        description: skill.description,
+        args: {},
+        async execute(_args: any, toolCtx: any) {
+          const sessionID = toolCtx.sessionID
+
+          const sendSilentPrompt = (text: string) =>
+
+            ctx.client.session.prompt({
+              path: { id: sessionID },
+              body: {
+                noReply: true,
+                parts: [{ type: "text", text }],
+              },
+            })
+
+          await sendSilentPrompt(`The "${skill.name}" skill is loading\n${skill.name}`)
+
+          if (skill.allowedTools && skill.allowedTools.length > 0) {
+            await sendSilentPrompt(
+              `Allowed tools for this skill: ${skill.allowedTools.join(", ")}`
+            )
+          }
+
+          await sendSilentPrompt(`Base directory for this skill: ${skill.fullPath}\n\n${skill.content}`)
+
+          return `Launching skill: ${skill.name}`
+        },
+      })
+    }
+  }
+
+  return { tool: tools }
+}
+
+export default hyperpowersSkillsPlugin

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This enables:
 
 This is the fully local path: no `"plugin": [...]` in `opencode.json`.
 
-1. Copy the `.opencode/` directory into your project (or use this repo directly).
+1. Copy `opencode.json` and the `.opencode/` directory into your project.
 2. Install plugin dependencies locally:
 
 ```bash
@@ -154,6 +154,8 @@ Notes:
 - Skill tools are provided by the local skills loader plugin: `.opencode/plugin/hyperpowers-skills.ts`.
 - Safety guardrails are provided by: `.opencode/plugin/hyperpowers-safety.ts`.
 - `bun install` downloads dependencies (e.g. `@opencode-ai/plugin`, `gray-matter`, `zod`) but does not require installing any OpenCode plugins via npm.
+
+**Portability:** `.opencode/plugin/hyperpowers-safety.ts` and `.opencode/plugin/hyperpowers-skills.ts` are self-contained, so copying `.opencode/` to another repo works.
 
 **Option C: Install the safety plugin into any OpenCode project (npm)**
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ opencode
 This enables:
 - Commands from `.opencode/command/*.md` (invoked as `/<command>`, e.g. `/brainstorm`)
 - Agents from `.opencode/agent/*.md` (e.g. `@code-reviewer`, `@test-runner`)
-- Skills via `opencode-skills` auto-discovery from `.opencode/skills/hyperpowers-*`
+- Skills via local skill discovery from `.opencode/skills/`
 - Safety guardrails plugin from `.opencode/plugin/hyperpowers-safety.ts`
 
 **Verify in OpenCode:**
@@ -131,25 +131,44 @@ This enables:
 - Verify skills tools exist by running any Hyperpowers command (they reference tools like `skills_hyperpowers_brainstorming`)
 - Optional safety check: try reading `.env` (it should be blocked by the safety plugin)
 
-**Option B: Install the safety plugin into any OpenCode project (npm)**
+**Option B: Install locally (no OpenCode plugin installs)**
 
-1. Add the plugin to your project's `opencode.json`:
+This is the fully local path: no `"plugin": [...]` in `opencode.json`.
+
+1. Copy the `.opencode/` directory into your project (or use this repo directly).
+2. Install plugin dependencies locally:
+
+```bash
+cd .opencode
+bun install
+cd ..
+```
+
+3. Start OpenCode from the project root:
+
+```bash
+opencode
+```
+
+Notes:
+- Skill tools are provided by the local skills loader plugin: `.opencode/plugin/hyperpowers-skills.ts`.
+- Safety guardrails are provided by: `.opencode/plugin/hyperpowers-safety.ts`.
+- `bun install` downloads dependencies (e.g. `@opencode-ai/plugin`, `gray-matter`, `zod`) but does not require installing any OpenCode plugins via npm.
+
+**Option C: Install the safety plugin into any OpenCode project (npm)**
+
+If you prefer a config-only install, add the plugin to your project's `opencode.json`:
 
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "opencode-skills",
     "@dpolishuk/hyperpowers-opencode"
   ]
 }
 ```
 
-2. Restart OpenCode.
-
-Notes:
-- `@dpolishuk/hyperpowers-opencode` ships safety guardrails (blocks reading `.env*`, editing `.git/hooks/*`, `git push --force`, and `rm -rf`).
-- Hyperpowers skills/commands/agents are repo-scoped. If you want them in another project, copy the `.opencode/` directory into that project (or package them separately).
+Then restart OpenCode.
 
 ### Claude Code
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": [
-    "opencode-skills"
-  ],
+  "plugin": [],
   "mcp": {
     "perplexity-mcp": {
       "type": "local",


### PR DESCRIPTION
## Summary
- Add OpenCode integration artifacts under `.opencode/`: commands, agents, skills, and safety plugins
- Add a local skills-loader plugin so OpenCode works without installing `opencode-skills` via npm
- Document OpenCode install + verification steps in `README.md`

## Test Plan
- [x] `cd packages/opencode-plugin && bun install && bun run typecheck && bun run build`
- [ ] Run OpenCode from repo root: `opencode`
  - Verify `/brainstorm`
  - Verify `@code-reviewer`