### PR TITLE
feat: add OpenCode command templates with $ARGUMENTS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# bv (beads viewer) local config and caches
+.bv/
+
+# Claude Code local settings
+.claude/
+
+# MCP configuration with API keys
+.mcp.json
+
+# Serena memories and configs
+.serena/
+
+# Git worktrees
+.worktrees/
+
+# Beads local state
+.beads/last-touched
+
+# Node modules and build artifacts
+node_modules/
+dist/
+**/node_modules/
+**/dist/

--- a/.opencode/bun.lock
+++ b/.opencode/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,3 +312,66 @@ From writing-skills skill:
 3. Follow the skill structure pattern (Overview, Process, Rationalizations, Red Flags, Integration)
 4. Reference common-patterns instead of duplicating content
 5. Be explicit about whether skill is rigid (must follow exactly) or flexible (adapt principles)
+
+<!-- bv-agent-instructions-v1 -->
+
+---
+
+## Beads Workflow Integration
+
+This project uses [beads_viewer](https://github.com/Dicklesworthstone/beads_viewer) for issue tracking. Issues are stored in `.beads/` and tracked in git.
+
+### Essential Commands
+
+```bash
+# View issues (launches TUI - avoid in automated sessions)
+bv
+
+# CLI commands for agents (use these instead)
+bd ready              # Show issues ready to work (no blockers)
+bd list --status=open # All open issues
+bd show <id>          # Full issue details with dependencies
+bd create --title="..." --type=task --priority=2
+bd update <id> --status=in_progress
+bd close <id> --reason="Completed"
+bd close <id1> <id2>  # Close multiple issues at once
+bd sync               # Commit and push changes
+```
+
+### Workflow Pattern
+
+1. **Start**: Run `bd ready` to find actionable work
+2. **Claim**: Use `bd update <id> --status=in_progress`
+3. **Work**: Implement the task
+4. **Complete**: Use `bd close <id>`
+5. **Sync**: Always run `bd sync` at session end
+
+### Key Concepts
+
+- **Dependencies**: Issues can block other issues. `bd ready` shows only unblocked work.
+- **Priority**: P0=critical, P1=high, P2=medium, P3=low, P4=backlog (use numbers, not words)
+- **Types**: task, bug, feature, epic, question, docs
+- **Blocking**: `bd dep add <issue> <depends-on>` to add dependencies
+
+### Session Protocol
+
+**Before ending any session, run this checklist:**
+
+```bash
+git status              # Check what changed
+git add <files>         # Stage code changes
+bd sync                 # Commit beads changes
+git commit -m "..."     # Commit code
+bd sync                 # Commit any new beads changes
+git push                # Push to remote
+```
+
+### Best Practices
+
+- Check `bd ready` at session start to find available work
+- Update status as you work (in_progress → closed)
+- Create new issues with `bd create` when you discover tasks
+- Use descriptive titles and set appropriate priority/type
+- Always `bd sync` before ending session
+
+<!-- end-bv-agent-instructions -->

--- a/commands/analyze-tests.md
+++ b/commands/analyze-tests.md
@@ -2,4 +2,8 @@
 description: Audit test quality - identify tautological tests, coverage gaming, missing corner cases
 ---
 
-Use the hyperpowers:analyzing-test-effectiveness skill exactly as written
+Use the hyperpowers:analyzing-test-effectiveness skill exactly as written.
+
+Scope: $ARGUMENTS
+
+If no scope is provided, analyze test quality across the repository.

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -2,4 +2,8 @@
 description: Interactive design refinement using Socratic method
 ---
 
-Use the hyperpowers:brainstorming skill exactly as written
+Use the hyperpowers:brainstorming skill exactly as written.
+
+Topic: $ARGUMENTS
+
+If no topic is provided, ask the user for the topic with a single question before proceeding.

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -4,11 +4,15 @@ description: Execute plan in batches with review checkpoints
 
 Use the hyperpowers:executing-plans skill exactly as written.
 
+Execution context: $ARGUMENTS
+
+If no context is provided, resume from current bd state.
+
 **Resumption:** This command supports explicit resumption. Run it multiple times to continue execution:
 
-1. First run: Executes first ready task → STOP
+1. First run: Executes first ready task  STOP
 2. User reviews implementation, clears context
-3. Next run: Resumes from bd state, executes next task → STOP
+3. Next run: Resumes from bd state, executes next task  STOP
 4. Repeat until epic complete
 
 **Checkpoints:** Each task execution ends with a STOP checkpoint. User must run this command again to continue.

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -2,4 +2,8 @@
 description: Review implementation was faithfully executed
 ---
 
-Use the hyperpowers:review-implementation skill exactly as written
+Use the hyperpowers:review-implementation skill exactly as written.
+
+Scope: $ARGUMENTS
+
+If no scope is provided, review the current branch against its plan/epic.

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -2,4 +2,8 @@
 description: Create detailed implementation plan with bite-sized tasks
 ---
 
-Use the hyperpowers:writing-plans skill exactly as written
+Use the hyperpowers:writing-plans skill exactly as written.
+
+Planning topic: $ARGUMENTS
+
+If no topic is provided, ask the user for the feature or goal to plan before proceeding.

--- a/packages/opencode-plugin/bun.lock
+++ b/packages/opencode-plugin/bun.lock
@@ -1,0 +1,23 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@dpolishuk/hyperpowers-opencode",
+      "dependencies": {
+        "@opencode-ai/plugin": "^1.1.25",
+      },
+      "devDependencies": {
+        "typescript": "^5.8.2",
+      },
+    },
+  },
+  "packages": {
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.25", "", { "dependencies": { "@opencode-ai/sdk": "1.1.25", "zod": "4.1.8" } }, "sha512-oTUWS446H/j7z3pdzo3cOrB5N87XZ/RKdgPD8yHv/rLX92B4YQHjOqggVQ56Q+1VEnN0jxzhoqRylv/0ZEts/Q=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.25", "", {}, "sha512-mWUX489ArEF2ICg3iZsx2VQaGS3Z2j/dwAJDacao9t7dGDzjOIaacPw2weZ10zld7XmT9V9C0PM/A5lDZ52J+w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+  }
+}


### PR DESCRIPTION
- Add prompt templates to all commands with $ARGUMENTS placeholder
- Include fallback guidance for missing arguments
- Enable proper argument passing for /brainstorm, /write-plan, etc.
- Update .gitignore to exclude config files with secrets

Commands updated:
- commands/brainstorm.md
- commands/write-plan.md
- commands/execute-plan.md
- commands/analyze-tests.md
- commands/review-implementation.md