### PR TITLE
feat: add comprehensive Pi coding agent (pi.dev) support

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -40,3 +40,4 @@
 {"id":"int-d451306b","kind":"field_change","created_at":"2026-03-27T12:28:19.856527056Z","actor":"Dmitry Polishuk","issue_id":"myhyperpowers-4fz","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-f930beca","kind":"field_change","created_at":"2026-03-27T12:30:31.362025812Z","actor":"Dmitry Polishuk","issue_id":"myhyperpowers-4fz","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-4b7dcb87","kind":"field_change","created_at":"2026-03-27T12:30:32.098478967Z","actor":"Dmitry Polishuk","issue_id":"myhyperpowers-2ol","extra":{"field":"status","new_value":"open","old_value":"closed"}}
+{"id":"int-6e59bfcb","kind":"field_change","created_at":"2026-03-28T12:12:03.948378396Z","actor":"Dmitry Polishuk","issue_id":"myhyperpowers-gqn","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Pi extension, AGENTS.md, and installer entry created"}}

--- a/.pi/AGENTS.md
+++ b/.pi/AGENTS.md
@@ -22,6 +22,7 @@ You have hyperpowers — structured workflows for software development.
 | `/setup-models` | Configure Pi model providers (Anthropic, OpenAI, Ollama) |
 | `/review-parallel` | Run 3 parallel review subagents (quality, implementation, simplification) |
 | `/review-branch` | Review code in isolated subprocess (won't affect main session) |
+| `/configure-routing` | Configure which model each subagent type uses |
 
 ## Subagent Tool
 
@@ -31,11 +32,16 @@ The `hyperpowers_subagent` tool delegates tasks to isolated Pi subprocesses:
 Use the hyperpowers_subagent tool with task: "Review src/auth.ts for security issues"
 ```
 
-The subagent runs with its own context, executes the task, and returns only the result. Use it for:
-- Code reviews (isolated context)
-- Test running (captures output without polluting main session)
-- Research tasks (separate investigation)
-- Parallel work (dispatch multiple subagents simultaneously)
+The subagent runs with its own context, executes the task, and returns only the result. Specify a `type` to route to a configured model:
+
+```
+hyperpowers_subagent(task: "Review code", type: "review")      → uses fast model
+hyperpowers_subagent(task: "Analyze arch", type: "validation")  → uses capable model
+```
+
+Types: `review` (fast), `research` (balanced), `validation` (capable), `test-runner` (fast)
+
+Configure models per type: `/configure-routing`
 
 ## Core Principles
 

--- a/.pi/AGENTS.md
+++ b/.pi/AGENTS.md
@@ -32,16 +32,17 @@ The `hyperpowers_subagent` tool delegates tasks to isolated Pi subprocesses:
 Use the hyperpowers_subagent tool with task: "Review src/auth.ts for security issues"
 ```
 
-The subagent runs with its own context, executes the task, and returns only the result. Specify a `type` for abstract routing, or add `agent` for a concrete override:
+The subagent runs with its own context, executes the task, and returns only the result. Specify a `type` for abstract routing, add `agent` for a concrete override, or set `model` for a one-off explicit override:
 
 ```
 hyperpowers_subagent(task: "Review code", type: "review")
 hyperpowers_subagent(task: "Review auth.ts", type: "review", agent: "code-reviewer")
 hyperpowers_subagent(task: "Analyze architecture", type: "validation", agent: "autonomous-reviewer")
+hyperpowers_subagent(task: "Use a specific model just once", model: "anthropic/claude-opus-4-5", type: "review")
 ```
 
 Routing precedence:
-1. Explicit tool-call model
+1. Explicit tool-call `model`
 2. Concrete `agent` override
 3. Abstract `type` override
 4. Default route

--- a/.pi/AGENTS.md
+++ b/.pi/AGENTS.md
@@ -22,7 +22,7 @@ You have hyperpowers — structured workflows for software development.
 | `/setup-models` | Configure Pi model providers (Anthropic, OpenAI, Ollama) |
 | `/review-parallel` | Run 3 parallel review subagents (quality, implementation, simplification) |
 | `/review-branch` | Review code in isolated subprocess (won't affect main session) |
-| `/configure-routing` | Interactive TUI wizard to configure subagent model routing |
+| `/configure-routing` | Interactive TUI wizard to configure subagent type defaults and concrete agent overrides |
 
 ## Subagent Tool
 
@@ -32,16 +32,24 @@ The `hyperpowers_subagent` tool delegates tasks to isolated Pi subprocesses:
 Use the hyperpowers_subagent tool with task: "Review src/auth.ts for security issues"
 ```
 
-The subagent runs with its own context, executes the task, and returns only the result. Specify a `type` to route to a configured model:
+The subagent runs with its own context, executes the task, and returns only the result. Specify a `type` for abstract routing, or add `agent` for a concrete override:
 
 ```
-hyperpowers_subagent(task: "Review code", type: "review")      → uses fast model
-hyperpowers_subagent(task: "Analyze arch", type: "validation")  → uses capable model
+hyperpowers_subagent(task: "Review code", type: "review")
+hyperpowers_subagent(task: "Review auth.ts", type: "review", agent: "code-reviewer")
+hyperpowers_subagent(task: "Analyze architecture", type: "validation", agent: "autonomous-reviewer")
 ```
+
+Routing precedence:
+1. Explicit tool-call model
+2. Concrete `agent` override
+3. Abstract `type` override
+4. Default route
+5. Inherit current session model
 
 Types: `review` (fast), `research` (balanced), `validation` (capable), `test-runner` (fast)
 
-Configure models per type: `/configure-routing`
+Configure models per type or concrete agent: `/configure-routing`
 
 ## Core Principles
 

--- a/.pi/AGENTS.md
+++ b/.pi/AGENTS.md
@@ -22,7 +22,7 @@ You have hyperpowers — structured workflows for software development.
 | `/setup-models` | Configure Pi model providers (Anthropic, OpenAI, Ollama) |
 | `/review-parallel` | Run 3 parallel review subagents (quality, implementation, simplification) |
 | `/review-branch` | Review code in isolated subprocess (won't affect main session) |
-| `/configure-routing` | Configure which model each subagent type uses |
+| `/configure-routing` | Interactive TUI wizard to configure subagent model routing |
 
 ## Subagent Tool
 

--- a/.pi/AGENTS.md
+++ b/.pi/AGENTS.md
@@ -19,6 +19,7 @@ You have hyperpowers — structured workflows for software development.
 | `/analyze-tests` | Audit test quality |
 | `/verify` | Verify before claiming complete |
 | `/routing-settings` | Configure agent model routing |
+| `/setup-models` | Configure Pi model providers (Anthropic, OpenAI, Ollama) |
 
 ## Core Principles
 

--- a/.pi/AGENTS.md
+++ b/.pi/AGENTS.md
@@ -20,6 +20,22 @@ You have hyperpowers — structured workflows for software development.
 | `/verify` | Verify before claiming complete |
 | `/routing-settings` | Configure agent model routing |
 | `/setup-models` | Configure Pi model providers (Anthropic, OpenAI, Ollama) |
+| `/review-parallel` | Run 3 parallel review subagents (quality, implementation, simplification) |
+| `/review-branch` | Review code in isolated subprocess (won't affect main session) |
+
+## Subagent Tool
+
+The `hyperpowers_subagent` tool delegates tasks to isolated Pi subprocesses:
+
+```
+Use the hyperpowers_subagent tool with task: "Review src/auth.ts for security issues"
+```
+
+The subagent runs with its own context, executes the task, and returns only the result. Use it for:
+- Code reviews (isolated context)
+- Test running (captures output without polluting main session)
+- Research tasks (separate investigation)
+- Parallel work (dispatch multiple subagents simultaneously)
 
 ## Core Principles
 

--- a/.pi/AGENTS.md
+++ b/.pi/AGENTS.md
@@ -1,0 +1,32 @@
+# Hyperpowers for Pi
+
+You have hyperpowers — structured workflows for software development.
+
+## Available Commands
+
+| Command | What It Does |
+|---------|-------------|
+| `/brainstorm` | Interactive design refinement before coding |
+| `/write-plan` | Create detailed implementation plan |
+| `/execute-plan` | Execute plan with review checkpoints |
+| `/execute-ralph` | Execute entire epic autonomously |
+| `/review-impl` | Verify implementation matches spec |
+| `/recall` | Search long-term memory from previous sessions |
+| `/refactor` | Refactor code safely with tests green |
+| `/fix-bug` | Systematic bug fixing workflow |
+| `/debug` | Debug with tools and agents |
+| `/tdd` | Test-driven development cycle |
+| `/analyze-tests` | Audit test quality |
+| `/verify` | Verify before claiming complete |
+| `/routing-settings` | Configure agent model routing |
+
+## Core Principles
+
+1. **Check for relevant skills before ANY task** — if a command exists for it, use it
+2. **Brainstorm before coding** — design first, code second
+3. **Verify before completion** — evidence over assertions
+4. **Test-driven when possible** — RED, GREEN, REFACTOR
+
+## Memory
+
+If memsearch is installed, memories from previous sessions are automatically recalled on session start. Use `/recall` to search manually.

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -47,7 +47,6 @@ const SKILLS = [
   { command: "tdd", skill: "test-driven-development", description: "Test-driven development: RED-GREEN-REFACTOR" },
   { command: "analyze-tests", skill: "analyzing-test-effectiveness", description: "Audit test quality for tautological tests" },
   { command: "verify", skill: "verification-before-completion", description: "Verify work before claiming complete" },
-  { command: "routing-settings", skill: "routing-settings", description: "Configure agent model routing (use /configure-routing for Pi TUI wizard)" },
 ]
 
 function loadSkillContent(skillName: string): string | null {
@@ -315,6 +314,13 @@ export default function (pi: any) {
       },
     })
   }
+
+  pi.registerCommand("routing-settings", {
+    description: "Open the Pi-native routing wizard for subagent type defaults and concrete agent overrides",
+    handler: async (_args: unknown, _ctx: any) => {
+      return "Use /configure-routing to manage Pi Hyperpowers routing. This Pi-native workflow edits ~/.pi/agent/extensions/hyperpowers/routing.json via the extension wizard, rather than Claude Code agent frontmatter."
+    },
+  })
 
   // Model setup wizard — generates ~/.pi/agent/models.json
   pi.registerCommand("setup-models", {

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -1,18 +1,21 @@
 /**
  * Hyperpowers extension for Pi coding agent (pi.dev)
  *
- * Registers all hyperpowers skills as slash commands and provides
- * memsearch long memory integration via session_start hook.
+ * Registers all hyperpowers skills as slash commands, provides
+ * memsearch long memory integration, and subagent delegation tool.
  */
 
 import { readFileSync, existsSync } from "node:fs"
-import { execSync, spawn } from "node:child_process"
-import { join, resolve } from "node:path"
+import { execFileSync, spawnSync } from "node:child_process"
+import { join, resolve, basename } from "node:path"
 import { Type } from "@sinclair/typebox"
 
-// Resolve the hyperpowers repo root (extension is at .pi/extensions/hyperpowers/)
+// Resolve skill paths: try extension-local skills first, then repo root
 const EXTENSION_DIR = import.meta.dir ?? __dirname
-const REPO_ROOT = resolve(EXTENSION_DIR, "..", "..", "..")
+const SKILLS_DIRS = [
+  join(EXTENSION_DIR, "skills"),                        // installed: ~/.pi/agent/extensions/hyperpowers/skills/
+  resolve(EXTENSION_DIR, "..", "..", "..", "skills"),    // dev: repo root skills/
+]
 
 // Skills to register as slash commands
 const SKILLS = [
@@ -32,13 +35,8 @@ const SKILLS = [
 ]
 
 function loadSkillContent(skillName: string): string | null {
-  // Try multiple locations for skill files
-  const paths = [
-    join(REPO_ROOT, "skills", skillName, "SKILL.md"),
-    join(REPO_ROOT, "skills", `${skillName}`, "SKILL.md"),
-  ]
-
-  for (const p of paths) {
+  for (const dir of SKILLS_DIRS) {
+    const p = join(dir, skillName, "SKILL.md")
     if (existsSync(p)) {
       try {
         return readFileSync(p, "utf8")
@@ -52,13 +50,16 @@ function loadSkillContent(skillName: string): string | null {
 
 function recallMemories(cwd: string): string | null {
   try {
-    const projectName = cwd.split("/").pop() || "project"
-    const result = execSync(
-      `timeout 5 memsearch search "recent work on ${projectName}" --top-k 5 --format compact 2>/dev/null || true`,
-      { cwd, encoding: "utf8", timeout: 6000 },
-    )
-    if (result.trim() && !result.startsWith("No results")) {
-      return result.trim()
+    const projectName = basename(cwd) || "project"
+    // Use spawnSync with argv array to avoid shell injection
+    const result = spawnSync("memsearch", ["search", `recent work on ${projectName}`, "--top-k", "5", "--format", "compact"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 5000,
+    })
+    const output = result.stdout?.trim() || ""
+    if (output && !output.startsWith("No results")) {
+      return output
     }
   } catch {
     // memsearch not installed or failed — skip silently
@@ -107,24 +108,7 @@ No config needed — built-in. Just set \`OPENAI_API_KEY\` env var.
       "apiKey": "ollama",
       "models": [
         { "id": "llama3.1:8b", "name": "Llama 3.1 8B" },
-        { "id": "qwen2.5-coder:7b", "name": "Qwen 2.5 Coder 7B" },
-        { "id": "deepseek-coder-v2:16b", "name": "DeepSeek Coder V2" }
-      ]
-    }
-  }
-}
-\`\`\`
-
-### Custom OpenAI-compatible API
-\`\`\`json
-{
-  "providers": {
-    "my-proxy": {
-      "baseUrl": "https://your-proxy.example.com/v1",
-      "api": "openai-completions",
-      "apiKey": "your-key",
-      "models": [
-        { "id": "model-name", "name": "Display Name", "contextWindow": 128000 }
+        { "id": "qwen2.5-coder:7b", "name": "Qwen 2.5 Coder 7B" }
       ]
     }
   }
@@ -133,14 +117,8 @@ No config needed — built-in. Just set \`OPENAI_API_KEY\` env var.
 
 ## Tips
 - Switch models during session: \`/model\` or \`Ctrl+L\`
-- Use fast models for routine tasks, capable models for complex reasoning
 - Set \`"reasoning": true\` for models that support extended thinking
 - Set \`"cost"\` to track token spending
-
-## Recommended Setup for Hyperpowers
-- **Main model**: Claude Sonnet 4.5 or GPT-5.1 (balanced)
-- **Fast tasks**: Claude Haiku 4.5 or local Ollama model
-- **Complex reasoning**: Claude Opus 4.5 with \`"reasoning": true\`
 
 Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
     },
@@ -150,24 +128,27 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
   pi.registerTool({
     name: "hyperpowers_subagent",
     label: "Subagent",
-    description: "Delegate a task to an isolated Pi subagent. The subagent runs in a separate process with its own context, executes the task, and returns the result. Use for: code review, test running, research, or any task that benefits from isolated context.",
+    description: "Delegate a task to an isolated Pi subagent. Runs in a separate process with its own context. Use for code review, test running, research, or any task benefiting from isolated context.",
     parameters: Type.Object({
       task: Type.String({ description: "The task for the subagent to perform" }),
-      maxTokens: Type.Optional(Type.Number({ description: "Max output tokens (default: 4096)" })),
     }),
-    async execute(params: { task: string; maxTokens?: number }) {
+    async execute(params: { task: string }) {
       try {
-        const result = execSync(
-          `pi --print -- ${JSON.stringify(params.task)}`,
-          {
-            encoding: "utf8",
-            timeout: 120000, // 2 minute timeout
-            maxBuffer: 1024 * 1024 * 10, // 10MB
-            cwd: process.cwd(),
-          },
-        )
+        // Use spawnSync with argv array to prevent shell injection
+        const result = spawnSync("pi", ["--print", "--", params.task], {
+          encoding: "utf8",
+          timeout: 120000,
+          maxBuffer: 1024 * 1024 * 10,
+          cwd: process.cwd(),
+        })
+        const output = result.stdout?.trim() || ""
+        if (result.status !== 0) {
+          return {
+            content: [{ type: "text" as const, text: `Subagent failed (exit ${result.status}): ${result.stderr?.trim() || output || "unknown error"}` }],
+          }
+        }
         return {
-          content: [{ type: "text" as const, text: result.trim() || "(subagent returned empty result)" }],
+          content: [{ type: "text" as const, text: output || "(subagent returned empty result)" }],
         }
       } catch (err: any) {
         return {
@@ -177,7 +158,7 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
     },
   })
 
-  // Parallel review — dispatches multiple subagents for review
+  // Parallel review — dispatches multiple subagents
   pi.registerCommand("review-parallel", {
     description: "Run 3 parallel review subagents: quality, implementation, simplification",
     handler: async (_args: unknown, ctx: any) => {
@@ -192,30 +173,22 @@ Run these 3 reviews using the hyperpowers_subagent tool IN PARALLEL:
    "Verify the recent changes achieve their stated goals. Check git log --oneline -5 for context. Return PASS or ISSUES_FOUND with missing items."
 
 3. **Simplification review**: Use hyperpowers_subagent with task:
-   "Check for over-engineering in recent changes. Look for unnecessary abstractions, premature generalization. Return PASS or ISSUES_FOUND with recommendations."
+   "Check for over-engineering in recent changes. Look for unnecessary abstractions. Return PASS or ISSUES_FOUND with recommendations."
 
 After all 3 complete, summarize the results in a table.`
     },
   })
 
-  // Session-aware review using Pi's session branching
+  // Session-aware review
   pi.registerCommand("review-branch", {
-    description: "Review code in a branched session context (isolated, won't affect main session)",
+    description: "Review code in an isolated subprocess (won't affect main session)",
     handler: async (_args: unknown, ctx: any) => {
       return `# Branched Review
 
-To review code without affecting your main session context:
-
-1. Use the hyperpowers_subagent tool to delegate the review task
-2. The subagent runs in a completely isolated Pi process
-3. Its context, tool calls, and findings don't pollute your main session
-4. Only the final result comes back
-
-This is Pi's equivalent of Claude Code's "context: fork" — full isolation via subprocess.
+Use the hyperpowers_subagent tool to delegate the review. The subagent runs in a completely isolated Pi process — its context won't affect your main session.
 
 Example: Call hyperpowers_subagent with task:
-"Read the files changed in the last commit (git diff HEAD~1 --name-only), then review each file for bugs, security issues, and code quality. Provide a structured report."
-`
+"Read the files changed in the last commit (git diff HEAD~1 --name-only), then review each file for bugs, security issues, and code quality. Provide a structured report."`
     },
   })
 

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -12,6 +12,13 @@ import { homedir } from "node:os"
 import { join, resolve, basename } from "node:path"
 import { Type } from "@sinclair/typebox"
 import { Container, SelectList, Text, Spacer } from "@mariozechner/pi-tui"
+import {
+  normalizeRoutingConfig,
+  resolveRoutingEntry,
+  serializeRoutingConfig,
+  type RoutingConfig,
+  type RoutingMap,
+} from "./routing"
 
 // Resolve skill paths: try extension-local skills first, then repo root
 const EXTENSION_DIR = import.meta.dir ?? __dirname
@@ -53,31 +60,25 @@ function loadSkillContent(skillName: string): string | null {
 }
 
 // Subagent routing config
-type SubagentRouting = Record<string, { model?: string; effort?: string }>
-
-function loadRoutingConfig(): SubagentRouting {
+function loadRoutingConfig(): RoutingConfig {
   try {
     if (existsSync(ROUTING_CONFIG_PATH)) {
-      const config = JSON.parse(readFileSync(ROUTING_CONFIG_PATH, "utf8"))
-      return config.subagents || {}
+      return normalizeRoutingConfig(JSON.parse(readFileSync(ROUTING_CONFIG_PATH, "utf8")))
     }
   } catch { /* skip */ }
-  return {}
+  return normalizeRoutingConfig({})
 }
 
-function saveRoutingConfig(subagents: SubagentRouting): void {
-  const config = {
-    _comment: "Model format: 'provider/model' (e.g., 'anthropic/claude-haiku-4-5', 'ollama/llama3.1:8b') or 'inherit' for session model",
-    subagents,
-  }
-  writeFileSync(ROUTING_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf8")
+function saveRoutingConfig(config: RoutingConfig): void {
+  writeFileSync(ROUTING_CONFIG_PATH, serializeRoutingConfig(config), "utf8")
 }
 
-function getSubagentModel(type: string): string | null {
-  const routing = loadRoutingConfig()
-  const entry = routing[type] || routing["default"]
-  if (!entry?.model || entry.model === "inherit") return null
-  return entry.model
+function getRoutingMap(config: RoutingConfig): RoutingMap {
+  return config.subagents
+}
+
+function resolveSubagentRouting(type?: string, agent?: string, explicitModel?: string) {
+  return resolveRoutingEntry(loadRoutingConfig(), { type, agent, explicitModel })
 }
 
 // Discover available models from Pi's built-in providers and models.json
@@ -125,28 +126,34 @@ const SUBAGENT_TYPES = [
 ]
 
 // Presets for quick configuration
-const PRESETS: Record<string, SubagentRouting> = {
-  "cost-optimized": {
-    review: { model: "anthropic/claude-haiku-4-5" },
-    research: { model: "anthropic/claude-haiku-4-5" },
-    validation: { model: "anthropic/claude-sonnet-4-5" },
-    "test-runner": { model: "anthropic/claude-haiku-4-5" },
-    default: { model: "inherit" },
-  },
-  performance: {
-    review: { model: "anthropic/claude-sonnet-4-5" },
-    research: { model: "anthropic/claude-sonnet-4-5" },
-    validation: { model: "anthropic/claude-opus-4-5" },
-    "test-runner": { model: "anthropic/claude-haiku-4-5" },
-    default: { model: "inherit" },
-  },
-  "all-inherit": {
-    review: { model: "inherit" },
-    research: { model: "inherit" },
-    validation: { model: "inherit" },
-    "test-runner": { model: "inherit" },
-    default: { model: "inherit" },
-  },
+const PRESETS: Record<string, RoutingConfig> = {
+  "cost-optimized": normalizeRoutingConfig({
+    subagents: {
+      review: { model: "anthropic/claude-haiku-4-5" },
+      research: { model: "anthropic/claude-haiku-4-5" },
+      validation: { model: "anthropic/claude-sonnet-4-5" },
+      "test-runner": { model: "anthropic/claude-haiku-4-5" },
+      default: { model: "inherit" },
+    },
+  }),
+  performance: normalizeRoutingConfig({
+    subagents: {
+      review: { model: "anthropic/claude-sonnet-4-5" },
+      research: { model: "anthropic/claude-sonnet-4-5" },
+      validation: { model: "anthropic/claude-opus-4-5" },
+      "test-runner": { model: "anthropic/claude-haiku-4-5" },
+      default: { model: "inherit" },
+    },
+  }),
+  "all-inherit": normalizeRoutingConfig({
+    subagents: {
+      review: { model: "inherit" },
+      research: { model: "inherit" },
+      validation: { model: "inherit" },
+      "test-runner": { model: "inherit" },
+      default: { model: "inherit" },
+    },
+  }),
 }
 
 function recallMemories(cwd: string): string | null {
@@ -350,17 +357,18 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
   pi.registerTool({
     name: "hyperpowers_subagent",
     label: "Subagent",
-    description: "Delegate a task to an isolated Pi subagent. Optionally specify a type (review, research, validation, test-runner) to route to a configured model. Runs in a separate process with its own context.",
+    description: "Delegate a task to an isolated Pi subagent. Optionally specify a concrete agent and/or abstract type to route to a configured model. Runs in a separate process with its own context.",
     parameters: Type.Object({
       task: Type.String({ description: "The task for the subagent to perform" }),
       type: Type.Optional(Type.String({ description: "Subagent type for model routing: review, research, validation, test-runner (optional, uses routing.json config)" })),
+      agent: Type.Optional(Type.String({ description: "Concrete Hyperpowers agent name for routing precedence (optional, e.g. code-reviewer, internet-researcher, autonomous-reviewer)" })),
     }),
-    async execute(_toolCallId: string, params: { task: string; type?: string }, _signal?: unknown, _update?: unknown, ctx?: any) {
+    async execute(_toolCallId: string, params: { task: string; type?: string; agent?: string }, _signal?: unknown, _update?: unknown, ctx?: any) {
       try {
         const args = ["--print"]
-        const model = params.type ? getSubagentModel(params.type) : null
-        if (model) {
-          args.push("--model", model)
+        const routing = resolveSubagentRouting(params.type, params.agent)
+        if (routing.model) {
+          args.push("--model", routing.model)
         }
         args.push("--", params.task)
 
@@ -396,10 +404,11 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
       // Main wizard loop
       while (true) {
         const routing = loadRoutingConfig()
+        const subagentRouting = getRoutingMap(routing)
 
         // Build current config display for the main menu title
         const configLines = SUBAGENT_TYPES.map(({ type }) => {
-          const entry = routing[type]
+          const entry = subagentRouting[type]
           const model = entry?.model || "inherit"
           const effort = entry?.effort ? ` (effort: ${entry.effort})` : ""
           return `  ${type.padEnd(12)} -> ${model}${effort}`
@@ -416,7 +425,7 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
             // Current routing table
             container.addChild(new Text(theme.fg("accent", "Current Configuration:")))
             for (const { type } of SUBAGENT_TYPES) {
-              const entry = routing[type]
+              const entry = subagentRouting[type]
               const model = entry?.model || "inherit"
               const effort = entry?.effort ? ` (effort: ${entry.effort})` : ""
               const modelStr = model === "inherit"
@@ -481,7 +490,7 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
         if (action === "single") {
           // Choose which subagent to configure
           const agentItems: SelectItem[] = SUBAGENT_TYPES.map(({ type, description, recommended }) => {
-            const current = routing[type]?.model || "inherit"
+            const current = subagentRouting[type]?.model || "inherit"
             return {
               label: `${type} (current: ${current})`,
               value: type,
@@ -517,8 +526,8 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
 
           if (selectedModel === null) continue
 
-          const updated = { ...routing }
-          updated[agentType] = { ...updated[agentType], model: selectedModel }
+          const updated = loadRoutingConfig()
+          updated.subagents[agentType] = { ...updated.subagents[agentType], model: selectedModel }
           saveRoutingConfig(updated)
           ctx.ui.notify(`${agentType} -> ${selectedModel}`, "success")
         }
@@ -527,7 +536,7 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
       // Return summary after wizard closes
       const finalRouting = loadRoutingConfig()
       const lines = SUBAGENT_TYPES.map(({ type }) => {
-        const entry = finalRouting[type]
+        const entry = finalRouting.subagents[type]
         const model = entry?.model || "inherit"
         return `  ${type}: ${model}`
       })

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -5,13 +5,15 @@
  * memsearch long memory integration, and subagent delegation tool.
  */
 
-import { readFileSync, existsSync } from "node:fs"
-import { execFileSync, spawnSync } from "node:child_process"
+import { readFileSync, existsSync, writeFileSync } from "node:fs"
+import { spawnSync } from "node:child_process"
+import { homedir } from "node:os"
 import { join, resolve, basename } from "node:path"
 import { Type } from "@sinclair/typebox"
 
 // Resolve skill paths: try extension-local skills first, then repo root
 const EXTENSION_DIR = import.meta.dir ?? __dirname
+const ROUTING_CONFIG_PATH = join(EXTENSION_DIR, "routing.json")
 const SKILLS_DIRS = [
   join(EXTENSION_DIR, "skills"),                        // installed: ~/.pi/agent/extensions/hyperpowers/skills/
   resolve(EXTENSION_DIR, "..", "..", "..", "skills"),    // dev: repo root skills/
@@ -46,6 +48,26 @@ function loadSkillContent(skillName: string): string | null {
     }
   }
   return null
+}
+
+// Subagent routing config
+type SubagentRouting = Record<string, { model?: string; effort?: string }>
+
+function loadRoutingConfig(): SubagentRouting {
+  try {
+    if (existsSync(ROUTING_CONFIG_PATH)) {
+      const config = JSON.parse(readFileSync(ROUTING_CONFIG_PATH, "utf8"))
+      return config.subagents || {}
+    }
+  } catch { /* skip */ }
+  return {}
+}
+
+function getSubagentModel(type: string): string | null {
+  const routing = loadRoutingConfig()
+  const entry = routing[type] || routing["default"]
+  if (!entry?.model || entry.model === "inherit") return null
+  return entry.model
 }
 
 function recallMemories(cwd: string): string | null {
@@ -124,18 +146,26 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
     },
   })
 
-  // Subagent tool — delegates tasks to isolated Pi subprocess
+  // Subagent tool — delegates tasks to isolated Pi subprocess with model routing
   pi.registerTool({
     name: "hyperpowers_subagent",
     label: "Subagent",
-    description: "Delegate a task to an isolated Pi subagent. Runs in a separate process with its own context. Use for code review, test running, research, or any task benefiting from isolated context.",
+    description: "Delegate a task to an isolated Pi subagent. Optionally specify a type (review, research, validation, test-runner) to route to a configured model. Runs in a separate process with its own context.",
     parameters: Type.Object({
       task: Type.String({ description: "The task for the subagent to perform" }),
+      type: Type.Optional(Type.String({ description: "Subagent type for model routing: review, research, validation, test-runner (optional, uses routing.json config)" })),
     }),
-    async execute(params: { task: string }) {
+    async execute(params: { task: string; type?: string }) {
       try {
-        // Use spawnSync with argv array to prevent shell injection
-        const result = spawnSync("pi", ["--print", "--", params.task], {
+        // Build command with optional model routing
+        const args = ["--print"]
+        const model = params.type ? getSubagentModel(params.type) : null
+        if (model) {
+          args.push("--model", model)
+        }
+        args.push("--", params.task)
+
+        const result = spawnSync("pi", args, {
           encoding: "utf8",
           timeout: 120000,
           maxBuffer: 1024 * 1024 * 10,
@@ -158,6 +188,65 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
     },
   })
 
+  // Subagent routing configuration
+  pi.registerCommand("configure-routing", {
+    description: "Configure which model each subagent type uses (routing.json)",
+    handler: async (_args: unknown, ctx: any) => {
+      const current = loadRoutingConfig()
+      const currentDisplay = Object.keys(current).length > 0
+        ? Object.entries(current).map(([k, v]) => `  ${k}: ${(v as any).model || "inherit"}`).join("\n")
+        : "  (no routing configured — all subagents use the session model)"
+
+      return `# Subagent Model Routing
+
+## Current Configuration
+${currentDisplay}
+
+## How to Configure
+
+Edit \`${ROUTING_CONFIG_PATH}\` with your model assignments:
+
+\`\`\`json
+{
+  "subagents": {
+    "review": { "model": "claude-haiku-4-5" },
+    "research": { "model": "claude-sonnet-4-5" },
+    "validation": { "model": "claude-opus-4-5" },
+    "test-runner": { "model": "claude-haiku-4-5" },
+    "default": { "model": "inherit" }
+  }
+}
+\`\`\`
+
+## Subagent Types
+
+| Type | Purpose | Recommended Model |
+|------|---------|-------------------|
+| \`review\` | Code review, quality checks | Fast (haiku) — high volume |
+| \`research\` | Codebase investigation, API docs | Balanced (sonnet) |
+| \`validation\` | Final review, complex analysis | Capable (opus) |
+| \`test-runner\` | Run tests, check results | Fast (haiku) |
+| \`default\` | Any untyped subagent | \`inherit\` (session model) |
+
+## Usage
+
+When calling the hyperpowers_subagent tool, specify the type:
+
+\`\`\`
+hyperpowers_subagent(task: "Review auth.ts", type: "review")
+→ runs with claude-haiku-4-5
+
+hyperpowers_subagent(task: "Analyze architecture", type: "validation")
+→ runs with claude-opus-4-5
+\`\`\`
+
+## Quick Setup
+
+To write a cost-optimized config now, use the Edit tool to create:
+\`${ROUTING_CONFIG_PATH}\``
+    },
+  })
+
   // Parallel review — dispatches multiple subagents
   pi.registerCommand("review-parallel", {
     description: "Run 3 parallel review subagents: quality, implementation, simplification",
@@ -166,13 +255,13 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
 
 Run these 3 reviews using the hyperpowers_subagent tool IN PARALLEL:
 
-1. **Quality review**: Use hyperpowers_subagent with task:
+1. **Quality review**: Use hyperpowers_subagent with type: "review", task:
    "Review the recent code changes for bugs, security issues, and race conditions. Check git diff HEAD~1. Return PASS or ISSUES_FOUND with file:line references."
 
-2. **Implementation review**: Use hyperpowers_subagent with task:
+2. **Implementation review**: Use hyperpowers_subagent with type: "validation", task:
    "Verify the recent changes achieve their stated goals. Check git log --oneline -5 for context. Return PASS or ISSUES_FOUND with missing items."
 
-3. **Simplification review**: Use hyperpowers_subagent with task:
+3. **Simplification review**: Use hyperpowers_subagent with type: "review", task:
    "Check for over-engineering in recent changes. Look for unnecessary abstractions. Return PASS or ISSUES_FOUND with recommendations."
 
 After all 3 complete, summarize the results in a table.`

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -362,16 +362,17 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
   pi.registerTool({
     name: "hyperpowers_subagent",
     label: "Subagent",
-    description: "Delegate a task to an isolated Pi subagent. Optionally specify a concrete agent and/or abstract type to route to a configured model. Runs in a separate process with its own context.",
+    description: "Delegate a task to an isolated Pi subagent. Optionally specify an explicit model, a concrete agent, and/or an abstract type to route to a configured model. Runs in a separate process with its own context.",
     parameters: Type.Object({
       task: Type.String({ description: "The task for the subagent to perform" }),
+      model: Type.Optional(Type.String({ description: "Explicit one-off provider/model override with highest precedence (optional)" })),
       type: Type.Optional(Type.String({ description: "Subagent type for model routing: review, research, validation, test-runner (optional, uses routing.json config)" })),
       agent: Type.Optional(Type.String({ description: "Concrete Hyperpowers agent name for routing precedence (optional, e.g. code-reviewer, internet-researcher, autonomous-reviewer)" })),
     }),
-    async execute(_toolCallId: string, params: { task: string; type?: string; agent?: string }, _signal?: unknown, _update?: unknown, ctx?: any) {
+    async execute(_toolCallId: string, params: { task: string; model?: string; type?: string; agent?: string }, _signal?: unknown, _update?: unknown, ctx?: any) {
       try {
         const args = ["--print"]
-        const routing = resolveSubagentRouting(params.type, params.agent)
+        const routing = resolveSubagentRouting(params.type, params.agent, params.model)
         if (routing.model) {
           args.push("--model", routing.model)
         }

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -13,9 +13,14 @@ import { join, resolve, basename } from "node:path"
 import { Type } from "@sinclair/typebox"
 import { Container, SelectList, Text, Spacer } from "@mariozechner/pi-tui"
 import {
+  HYPERPOWERS_AGENTS,
   normalizeRoutingConfig,
+  resetAllAgentOverrides,
   resolveRoutingEntry,
   serializeRoutingConfig,
+  withAgentModel,
+  withSubagentModel,
+  withoutAgentOverride,
   type RoutingConfig,
   type RoutingMap,
 } from "./routing"
@@ -399,31 +404,20 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
 
   // TUI-based routing wizard — interactive model assignment
   pi.registerCommand("configure-routing", {
-    description: "Interactive TUI wizard to configure subagent model routing",
+    description: "Interactive TUI wizard to configure Hyperpowers subagent type defaults and concrete agent overrides",
     handler: async (_args: unknown, ctx: any) => {
-      // Main wizard loop
       while (true) {
         const routing = loadRoutingConfig()
         const subagentRouting = getRoutingMap(routing)
 
-        // Build current config display for the main menu title
-        const configLines = SUBAGENT_TYPES.map(({ type }) => {
-          const entry = subagentRouting[type]
-          const model = entry?.model || "inherit"
-          const effort = entry?.effort ? ` (effort: ${entry.effort})` : ""
-          return `  ${type.padEnd(12)} -> ${model}${effort}`
-        })
-
-        // Step 1: Choose action
         const action = await ctx.ui.custom<string | null>(
-          (tui: any, theme: any, _keybindings: any, done: (v: string | null) => void) => {
+          (_tui: any, theme: any, _keybindings: any, done: (v: string | null) => void) => {
             const container = new Container()
 
             container.addChild(new Text(theme.fg("accent", theme.bold("Hyperpowers Routing Wizard"))))
             container.addChild(new Spacer(1))
 
-            // Current routing table
-            container.addChild(new Text(theme.fg("accent", "Current Configuration:")))
+            container.addChild(new Text(theme.fg("accent", "Subagent Type Defaults:")))
             for (const { type } of SUBAGENT_TYPES) {
               const entry = subagentRouting[type]
               const model = entry?.model || "inherit"
@@ -431,14 +425,32 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
               const modelStr = model === "inherit"
                 ? theme.fg("muted", "inherit (session model)")
                 : theme.fg("success", model)
-              container.addChild(new Text(
-                `  ${theme.bold(type.padEnd(12))} ${modelStr}${effort}`
-              ))
+              container.addChild(new Text(`  ${theme.bold(type.padEnd(12))} ${modelStr}${effort}`))
+            }
+
+            container.addChild(new Spacer(1))
+            container.addChild(new Text(theme.fg("accent", "Concrete Agent Overrides:")))
+            if (Object.keys(routing.agents).length === 0) {
+              container.addChild(new Text(`  ${theme.fg("muted", "(none configured)")}`))
+            } else {
+              for (const agent of HYPERPOWERS_AGENTS) {
+                const entry = routing.agents[agent.name]
+                if (!entry) continue
+                const model = entry.model || "inherit"
+                const effort = entry.effort ? ` (effort: ${entry.effort})` : ""
+                const modelStr = model === "inherit"
+                  ? theme.fg("muted", "inherit (session model)")
+                  : theme.fg("success", model)
+                container.addChild(new Text(`  ${theme.bold(agent.name.padEnd(24))} ${modelStr}${effort}`))
+              }
             }
             container.addChild(new Spacer(1))
 
             const actions: SelectItem[] = [
-              { label: "Configure single agent", value: "single", description: "Set model for one subagent type" },
+              { label: "Configure subagent type default", value: "single", description: "Set model for one abstract subagent type" },
+              { label: "Configure concrete agent override", value: "agent", description: "Set model for one Hyperpowers agent name" },
+              { label: "Reset one concrete agent override", value: "reset-agent", description: "Remove one per-agent override and fall back to type/default" },
+              { label: "Reset all concrete agent overrides", value: "reset-agents", description: "Keep type defaults, remove per-agent overrides" },
               { label: "Apply preset", value: "preset", description: "Cost-optimized, performance, or all-inherit" },
               { label: "Reset all to inherit", value: "reset", description: "All subagents use session model" },
               { label: "Done", value: "done", description: "Save and exit wizard" },
@@ -460,14 +472,43 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
                 return true
               },
             }
-          }
+          },
         )
 
         if (!action || action === "done") break
 
         if (action === "reset") {
           saveRoutingConfig(PRESETS["all-inherit"])
-          ctx.ui.notify("All subagents reset to inherit", "success")
+          ctx.ui.notify("All subagent defaults and concrete agent overrides reset to inherit", "success")
+          continue
+        }
+
+        if (action === "reset-agents") {
+          saveRoutingConfig(resetAllAgentOverrides(routing))
+          ctx.ui.notify("All concrete agent overrides removed", "success")
+          continue
+        }
+
+        if (action === "reset-agent") {
+          const configuredAgents: SelectItem[] = HYPERPOWERS_AGENTS
+            .filter((agent) => routing.agents[agent.name])
+            .map((agent) => ({
+              label: `${agent.name} (current: ${routing.agents[agent.name]?.model || "inherit"})`,
+              value: agent.name,
+              description: `${agent.group} | falls back to ${agent.type}`,
+            }))
+
+          if (configuredAgents.length === 0) {
+            ctx.ui.notify("No concrete agent overrides are currently configured", "warning")
+            continue
+          }
+
+          configuredAgents.push({ label: "Back", value: null, description: "Return to main menu" })
+          const agentName = await createSelectUI(configuredAgents, "Select Concrete Agent Override to Reset", ctx)
+          if (!agentName) continue
+
+          saveRoutingConfig(withoutAgentOverride(routing, agentName))
+          ctx.ui.notify(`Removed concrete override for ${agentName}`, "success")
           continue
         }
 
@@ -487,8 +528,20 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
           continue
         }
 
+        const models = discoverModels()
+        const providers = [...new Set(models.map((m) => m.provider))]
+        const modelItems: SelectItem[] = [
+          { label: "inherit (use session model)", value: "inherit", description: "Subagent uses whatever model the session is running" },
+        ]
+        for (const provider of providers) {
+          const providerModels = models.filter((m) => m.provider === provider)
+          for (const m of providerModels) {
+            modelItems.push({ label: m.label, value: m.model, description: provider })
+          }
+        }
+        modelItems.push({ label: "Back", value: null, description: "Return to previous menu" })
+
         if (action === "single") {
-          // Choose which subagent to configure
           const agentItems: SelectItem[] = SUBAGENT_TYPES.map(({ type, description, recommended }) => {
             const current = subagentRouting[type]?.model || "inherit"
             return {
@@ -502,44 +555,59 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
           const agentType = await createSelectUI(agentItems, "Select Subagent Type", ctx)
           if (!agentType) continue
 
-          // Choose model — searchable list grouped by provider
-          const models = discoverModels()
-          const providers = [...new Set(models.map((m) => m.provider))]
-
-          const modelItems: SelectItem[] = [
-            { label: "inherit (use session model)", value: "inherit", description: "Subagent uses whatever model the session is running" },
-          ]
-          for (const provider of providers) {
-            const providerModels = models.filter((m) => m.provider === provider)
-            for (const m of providerModels) {
-              modelItems.push({ label: m.label, value: m.model, description: provider })
-            }
-          }
-          modelItems.push({ label: "Back", value: null, description: "Return to agent selection" })
-
           const selectedModel = await createSearchableSelectUI(
             modelItems,
-            `Select Model for "${agentType}"`,
+            `Select Model for subagent type "${agentType}"`,
             "Type to filter, Enter to select, Esc to go back",
             ctx,
           )
 
           if (selectedModel === null) continue
 
-          const updated = loadRoutingConfig()
-          updated.subagents[agentType] = { ...updated.subagents[agentType], model: selectedModel }
-          saveRoutingConfig(updated)
+          saveRoutingConfig(withSubagentModel(routing, agentType, selectedModel))
           ctx.ui.notify(`${agentType} -> ${selectedModel}`, "success")
+          continue
+        }
+
+        if (action === "agent") {
+          const agentItems: SelectItem[] = HYPERPOWERS_AGENTS.map((agent) => {
+            const current = routing.agents[agent.name]?.model || "inherit"
+            return {
+              label: `${agent.name} (current: ${current})`,
+              value: agent.name,
+              description: `${agent.group} | fallback type: ${agent.type} | ${agent.description}`,
+            }
+          })
+          agentItems.push({ label: "Back", value: null, description: "Return to main menu" })
+
+          const agentName = await createSelectUI(agentItems, "Select Concrete Hyperpowers Agent", ctx)
+          if (!agentName) continue
+
+          const selectedModel = await createSearchableSelectUI(
+            modelItems,
+            `Select Model for concrete agent "${agentName}"`,
+            "Type to filter, Enter to select, Esc to go back",
+            ctx,
+          )
+
+          if (selectedModel === null) continue
+
+          saveRoutingConfig(withAgentModel(routing, agentName, selectedModel))
+          ctx.ui.notify(`${agentName} -> ${selectedModel}`, "success")
         }
       }
 
-      // Return summary after wizard closes
       const finalRouting = loadRoutingConfig()
-      const lines = SUBAGENT_TYPES.map(({ type }) => {
-        const entry = finalRouting.subagents[type]
-        const model = entry?.model || "inherit"
-        return `  ${type}: ${model}`
-      })
+      const lines = [
+        ...SUBAGENT_TYPES.map(({ type }) => {
+          const entry = finalRouting.subagents[type]
+          const model = entry?.model || "inherit"
+          return `  type:${type} -> ${model}`
+        }),
+        ...HYPERPOWERS_AGENTS
+          .filter((agent) => finalRouting.agents[agent.name])
+          .map((agent) => `  agent:${agent.name} -> ${finalRouting.agents[agent.name]?.model || "inherit"}`),
+      ]
       return `Routing configuration saved:\n${lines.join("\n")}\n\nConfig file: ${ROUTING_CONFIG_PATH}`
     },
   })

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -204,15 +204,17 @@ ${currentDisplay}
 
 ## How to Configure
 
+Use \`provider/model\` format (same as Pi's models.json). This ensures the right provider is used when multiple providers offer models with similar names.
+
 Edit \`${ROUTING_CONFIG_PATH}\` with your model assignments:
 
 \`\`\`json
 {
   "subagents": {
-    "review": { "model": "claude-haiku-4-5" },
-    "research": { "model": "claude-sonnet-4-5" },
-    "validation": { "model": "claude-opus-4-5" },
-    "test-runner": { "model": "claude-haiku-4-5" },
+    "review": { "model": "anthropic/claude-haiku-4-5" },
+    "research": { "model": "anthropic/claude-sonnet-4-5" },
+    "validation": { "model": "anthropic/claude-opus-4-5" },
+    "test-runner": { "model": "anthropic/claude-haiku-4-5" },
     "default": { "model": "inherit" }
   }
 }
@@ -234,10 +236,10 @@ When calling the hyperpowers_subagent tool, specify the type:
 
 \`\`\`
 hyperpowers_subagent(task: "Review auth.ts", type: "review")
-→ runs with claude-haiku-4-5
+→ runs with anthropic/claude-haiku-4-5
 
 hyperpowers_subagent(task: "Analyze architecture", type: "validation")
-→ runs with claude-opus-4-5
+→ runs with anthropic/claude-opus-4-5
 \`\`\`
 
 ## Quick Setup

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -1,0 +1,93 @@
+/**
+ * Hyperpowers extension for Pi coding agent (pi.dev)
+ *
+ * Registers all hyperpowers skills as slash commands and provides
+ * memsearch long memory integration via session_start hook.
+ */
+
+import { readFileSync, existsSync } from "node:fs"
+import { execSync } from "node:child_process"
+import { join, resolve } from "node:path"
+
+// Resolve the hyperpowers repo root (extension is at .pi/extensions/hyperpowers/)
+const EXTENSION_DIR = import.meta.dir ?? __dirname
+const REPO_ROOT = resolve(EXTENSION_DIR, "..", "..", "..")
+
+// Skills to register as slash commands
+const SKILLS = [
+  { command: "brainstorm", skill: "brainstorming", description: "Interactive design refinement using Socratic questioning" },
+  { command: "write-plan", skill: "writing-plans", description: "Create detailed implementation plan with bite-sized tasks" },
+  { command: "execute-plan", skill: "executing-plans", description: "Execute plan in batches with review checkpoints" },
+  { command: "execute-ralph", skill: "execute-ralph", description: "Execute entire epic autonomously without stopping" },
+  { command: "review-impl", skill: "review-implementation", description: "Verify implementation matches requirements" },
+  { command: "recall", skill: "recall", description: "Search long-term memory from previous sessions" },
+  { command: "refactor", skill: "refactoring-safely", description: "Refactor code with tests staying green" },
+  { command: "fix-bug", skill: "fixing-bugs", description: "Systematic bug fixing workflow" },
+  { command: "debug", skill: "debugging-with-tools", description: "Systematic debugging using debuggers and agents" },
+  { command: "tdd", skill: "test-driven-development", description: "Test-driven development: RED-GREEN-REFACTOR" },
+  { command: "analyze-tests", skill: "analyzing-test-effectiveness", description: "Audit test quality for tautological tests" },
+  { command: "verify", skill: "verification-before-completion", description: "Verify work before claiming complete" },
+  { command: "routing-settings", skill: "routing-settings", description: "Configure agent model routing" },
+]
+
+function loadSkillContent(skillName: string): string | null {
+  // Try multiple locations for skill files
+  const paths = [
+    join(REPO_ROOT, "skills", skillName, "SKILL.md"),
+    join(REPO_ROOT, "skills", `${skillName}`, "SKILL.md"),
+  ]
+
+  for (const p of paths) {
+    if (existsSync(p)) {
+      try {
+        return readFileSync(p, "utf8")
+      } catch {
+        continue
+      }
+    }
+  }
+  return null
+}
+
+function recallMemories(cwd: string): string | null {
+  try {
+    const projectName = cwd.split("/").pop() || "project"
+    const result = execSync(
+      `timeout 5 memsearch search "recent work on ${projectName}" --top-k 5 --format compact 2>/dev/null || true`,
+      { cwd, encoding: "utf8", timeout: 6000 },
+    )
+    if (result.trim() && !result.startsWith("No results")) {
+      return result.trim()
+    }
+  } catch {
+    // memsearch not installed or failed — skip silently
+  }
+  return null
+}
+
+export default function (pi: any) {
+  // Register each skill as a slash command
+  for (const { command, skill, description } of SKILLS) {
+    pi.registerCommand(command, {
+      description,
+      handler: async (_args: unknown, ctx: any) => {
+        const content = loadSkillContent(skill)
+        if (content) {
+          return content
+        }
+        return `Skill "${skill}" not found. Make sure hyperpowers is installed correctly.`
+      },
+    })
+  }
+
+  // Memory recall on session start
+  pi.on("session_start", async (event: any) => {
+    const cwd = event?.cwd || process.cwd()
+    const memories = recallMemories(cwd)
+    if (memories) {
+      return {
+        context: `## Long-term Memory (memsearch)\nThe following memories from previous sessions may be relevant:\n\n${memories}\n\nUse these as background context. Do not repeat them unless asked.`,
+      }
+    }
+  })
+}

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -35,7 +35,7 @@ const SKILLS = [
   { command: "tdd", skill: "test-driven-development", description: "Test-driven development: RED-GREEN-REFACTOR" },
   { command: "analyze-tests", skill: "analyzing-test-effectiveness", description: "Audit test quality for tautological tests" },
   { command: "verify", skill: "verification-before-completion", description: "Verify work before claiming complete" },
-  { command: "routing-settings", skill: "routing-settings", description: "Configure agent model routing" },
+  { command: "routing-settings", skill: "routing-settings", description: "Configure agent model routing (use /configure-routing for Pi TUI wizard)" },
 ]
 
 function loadSkillContent(skillName: string): string | null {
@@ -355,7 +355,7 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
       task: Type.String({ description: "The task for the subagent to perform" }),
       type: Type.Optional(Type.String({ description: "Subagent type for model routing: review, research, validation, test-runner (optional, uses routing.json config)" })),
     }),
-    async execute(_toolCallId: string, params: { task: string; type?: string }) {
+    async execute(_toolCallId: string, params: { task: string; type?: string }, _signal?: unknown, _update?: unknown, ctx?: any) {
       try {
         const args = ["--print"]
         const model = params.type ? getSubagentModel(params.type) : null
@@ -364,11 +364,13 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
         }
         args.push("--", params.task)
 
+        // Use session cwd if available, fall back to process.cwd()
+        const cwd = ctx?.cwd || process.cwd()
         const result = spawnSync("pi", args, {
           encoding: "utf8",
           timeout: 120000,
           maxBuffer: 1024 * 1024 * 10,
-          cwd: process.cwd(),
+          cwd,
         })
         const output = result.stdout?.trim() || ""
         if (result.status !== 0) {

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -80,6 +80,71 @@ export default function (pi: any) {
     })
   }
 
+  // Model setup wizard — generates ~/.pi/agent/models.json
+  pi.registerCommand("setup-models", {
+    description: "Configure Pi model providers (Anthropic, OpenAI, Ollama, etc.)",
+    handler: async (_args: unknown, ctx: any) => {
+      return `# Pi Model Setup
+
+To configure your AI model providers, edit \`~/.pi/agent/models.json\`.
+
+## Quick Setup Examples
+
+### Anthropic (Claude)
+No config needed — built-in. Just set \`ANTHROPIC_API_KEY\` env var.
+
+### OpenAI
+No config needed — built-in. Just set \`OPENAI_API_KEY\` env var.
+
+### Ollama (local models, free)
+\`\`\`json
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "models": [
+        { "id": "llama3.1:8b", "name": "Llama 3.1 8B" },
+        { "id": "qwen2.5-coder:7b", "name": "Qwen 2.5 Coder 7B" },
+        { "id": "deepseek-coder-v2:16b", "name": "DeepSeek Coder V2" }
+      ]
+    }
+  }
+}
+\`\`\`
+
+### Custom OpenAI-compatible API
+\`\`\`json
+{
+  "providers": {
+    "my-proxy": {
+      "baseUrl": "https://your-proxy.example.com/v1",
+      "api": "openai-completions",
+      "apiKey": "your-key",
+      "models": [
+        { "id": "model-name", "name": "Display Name", "contextWindow": 128000 }
+      ]
+    }
+  }
+}
+\`\`\`
+
+## Tips
+- Switch models during session: \`/model\` or \`Ctrl+L\`
+- Use fast models for routine tasks, capable models for complex reasoning
+- Set \`"reasoning": true\` for models that support extended thinking
+- Set \`"cost"\` to track token spending
+
+## Recommended Setup for Hyperpowers
+- **Main model**: Claude Sonnet 4.5 or GPT-5.1 (balanced)
+- **Fast tasks**: Claude Haiku 4.5 or local Ollama model
+- **Complex reasoning**: Claude Opus 4.5 with \`"reasoning": true\`
+
+Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
+    },
+  })
+
   // Memory recall on session start
   pi.on("session_start", async (event: any) => {
     const cwd = event?.cwd || process.cwd()

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -2,7 +2,8 @@
  * Hyperpowers extension for Pi coding agent (pi.dev)
  *
  * Registers all hyperpowers skills as slash commands, provides
- * memsearch long memory integration, and subagent delegation tool.
+ * memsearch long memory integration, subagent delegation tool,
+ * and TUI-based routing wizard.
  */
 
 import { readFileSync, existsSync, writeFileSync } from "node:fs"
@@ -10,6 +11,7 @@ import { spawnSync } from "node:child_process"
 import { homedir } from "node:os"
 import { join, resolve, basename } from "node:path"
 import { Type } from "@sinclair/typebox"
+import { Container, SelectList, Text, Spacer } from "@mariozechner/pi-tui"
 
 // Resolve skill paths: try extension-local skills first, then repo root
 const EXTENSION_DIR = import.meta.dir ?? __dirname
@@ -27,7 +29,7 @@ const SKILLS = [
   { command: "execute-ralph", skill: "execute-ralph", description: "Execute entire epic autonomously without stopping" },
   { command: "review-impl", skill: "review-implementation", description: "Verify implementation matches requirements" },
   { command: "recall", skill: "recall", description: "Search long-term memory from previous sessions" },
-  { command: "refactor", skill: "refactoring-safely", description: "Refactor code with tests staying green" },
+  { command: "refactor", skill: "refactoring-safely", description: "Refactor code safely with tests green" },
   { command: "fix-bug", skill: "fixing-bugs", description: "Systematic bug fixing workflow" },
   { command: "debug", skill: "debugging-with-tools", description: "Systematic debugging using debuggers and agents" },
   { command: "tdd", skill: "test-driven-development", description: "Test-driven development: RED-GREEN-REFACTOR" },
@@ -63,6 +65,14 @@ function loadRoutingConfig(): SubagentRouting {
   return {}
 }
 
+function saveRoutingConfig(subagents: SubagentRouting): void {
+  const config = {
+    _comment: "Model format: 'provider/model' (e.g., 'anthropic/claude-haiku-4-5', 'ollama/llama3.1:8b') or 'inherit' for session model",
+    subagents,
+  }
+  writeFileSync(ROUTING_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf8")
+}
+
 function getSubagentModel(type: string): string | null {
   const routing = loadRoutingConfig()
   const entry = routing[type] || routing["default"]
@@ -70,10 +80,78 @@ function getSubagentModel(type: string): string | null {
   return entry.model
 }
 
+// Discover available models from Pi's built-in providers and models.json
+function discoverModels(): Array<{ provider: string; model: string; label: string }> {
+  const models: Array<{ provider: string; model: string; label: string }> = []
+
+  // Built-in models (always available)
+  const builtins: Record<string, string[]> = {
+    anthropic: ["claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"],
+    openai: ["o3", "o3-mini", "o4-mini", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"],
+    google: ["gemini-2.5-pro", "gemini-2.5-flash"],
+  }
+  for (const [provider, ids] of Object.entries(builtins)) {
+    for (const id of ids) {
+      models.push({ provider, model: `${provider}/${id}`, label: `${provider}/${id}` })
+    }
+  }
+
+  // Custom models from ~/.pi/agent/models.json
+  try {
+    const modelsPath = join(homedir(), ".pi", "agent", "models.json")
+    if (existsSync(modelsPath)) {
+      const config = JSON.parse(readFileSync(modelsPath, "utf8"))
+      for (const [provider, providerConfig] of Object.entries(config.providers || {})) {
+        for (const m of (providerConfig as any).models || []) {
+          const id = m.id || m.name
+          if (id) {
+            models.push({ provider, model: `${provider}/${id}`, label: `${provider}/${id}` })
+          }
+        }
+      }
+    }
+  } catch { /* skip */ }
+
+  return models
+}
+
+// Subagent types with descriptions
+const SUBAGENT_TYPES = [
+  { type: "review", description: "Code review, quality checks", recommended: "Fast (haiku)" },
+  { type: "research", description: "Codebase investigation, API docs", recommended: "Balanced (sonnet)" },
+  { type: "validation", description: "Final review, complex analysis", recommended: "Capable (opus)" },
+  { type: "test-runner", description: "Run tests, check results", recommended: "Fast (haiku)" },
+  { type: "default", description: "Any untyped subagent", recommended: "inherit (session model)" },
+]
+
+// Presets for quick configuration
+const PRESETS: Record<string, SubagentRouting> = {
+  "cost-optimized": {
+    review: { model: "anthropic/claude-haiku-4-5" },
+    research: { model: "anthropic/claude-haiku-4-5" },
+    validation: { model: "anthropic/claude-sonnet-4-5" },
+    "test-runner": { model: "anthropic/claude-haiku-4-5" },
+    default: { model: "inherit" },
+  },
+  performance: {
+    review: { model: "anthropic/claude-sonnet-4-5" },
+    research: { model: "anthropic/claude-sonnet-4-5" },
+    validation: { model: "anthropic/claude-opus-4-5" },
+    "test-runner": { model: "anthropic/claude-haiku-4-5" },
+    default: { model: "inherit" },
+  },
+  "all-inherit": {
+    review: { model: "inherit" },
+    research: { model: "inherit" },
+    validation: { model: "inherit" },
+    "test-runner": { model: "inherit" },
+    default: { model: "inherit" },
+  },
+}
+
 function recallMemories(cwd: string): string | null {
   try {
     const projectName = basename(cwd) || "project"
-    // Use spawnSync with argv array to avoid shell injection
     const result = spawnSync("memsearch", ["search", `recent work on ${projectName}`, "--top-k", "5", "--format", "compact"], {
       cwd,
       encoding: "utf8",
@@ -87,6 +165,128 @@ function recallMemories(cwd: string): string | null {
     // memsearch not installed or failed — skip silently
   }
   return null
+}
+
+// TUI wizard helpers
+interface SelectItem {
+  label: string
+  value: string | null
+  description: string
+}
+
+function createSelectUI(
+  items: SelectItem[],
+  title: string,
+  ctx: any,
+  maxVisible = 10,
+): Promise<string | null> {
+  return ctx.ui.custom<string | null>(
+    (tui: any, theme: any, _keybindings: any, done: (v: string | null) => void) => {
+      const container = new Container()
+      container.addChild(new Text(theme.fg("accent", theme.bold(title))))
+      container.addChild(new Spacer(1))
+
+      const selectList = new SelectList(
+        items,
+        Math.min(items.length, maxVisible),
+        {
+          selectedPrefix: (text: string) => theme.fg("accent", text),
+          description: (text: string) => theme.fg("muted", text),
+          scrollInfo: (text: string) => theme.fg("muted", text),
+          noMatch: (text: string) => theme.fg("warning", text),
+        }
+      )
+      selectList.onSelect = (item: any) => done(item.value)
+      container.addChild(selectList)
+
+      return {
+        render(width: number) { return container.render(width) },
+        invalidate() { container.invalidate() },
+        handleInput(data: string) {
+          if (data === "\x1b") { done(null); return true }
+          selectList.handleInput(data)
+          return true
+        },
+      }
+    }
+  )
+}
+
+function createSearchableSelectUI(
+  items: SelectItem[],
+  title: string,
+  subtitle: string,
+  ctx: any,
+): Promise<string | null> {
+  return ctx.ui.custom<string | null>(
+    (tui: any, theme: any, _keybindings: any, done: (v: string | null) => void) => {
+      const container = new Container()
+      container.addChild(new Text(theme.fg("accent", theme.bold(title))))
+      container.addChild(new Text(theme.fg("muted", subtitle)))
+      container.addChild(new Spacer(1))
+
+      let filterText = ""
+
+      const selectList = new SelectList(
+        items,
+        Math.min(items.length, 12),
+        {
+          selectedPrefix: (text: string) => theme.fg("accent", text),
+          description: (text: string) => theme.fg("muted", text),
+          scrollInfo: (text: string) => theme.fg("muted", text),
+          noMatch: (text: string) => theme.fg("warning", text),
+        }
+      )
+      selectList.onSelect = (item: any) => done(item.value)
+      container.addChild(selectList)
+
+      const applyFilter = () => {
+        if (!filterText) {
+          selectList.setItems(items)
+          return
+        }
+        const q = filterText.toLowerCase()
+        const filtered = items.filter((item) =>
+          item.label.toLowerCase().includes(q) ||
+          item.description.toLowerCase().includes(q)
+        )
+        selectList.setItems(filtered.length > 0 ? filtered : [
+          { label: `No match for "${filterText}"`, value: null, description: "Backspace to clear" },
+        ])
+      }
+
+      return {
+        render(width: number) { return container.render(width) },
+        invalidate() { container.invalidate() },
+        handleInput(data: string) {
+          // Printable character — add to filter
+          if (data.length === 1 && data >= " " && data <= "~") {
+            filterText += data
+            applyFilter()
+            return true
+          }
+          // Backspace — remove from filter
+          if (data === "\x7f" || data === "\b") {
+            filterText = filterText.slice(0, -1)
+            applyFilter()
+            return true
+          }
+          // Escape — clear filter or exit
+          if (data === "\x1b") {
+            if (filterText) {
+              filterText = ""
+              applyFilter()
+            } else {
+              done(null)
+            }
+            return true
+          }
+          selectList.handleInput(data)
+          return true
+        },
+      }
+    }
+  )
 }
 
 export default function (pi: any) {
@@ -157,7 +357,6 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
     }),
     async execute(_toolCallId: string, params: { task: string; type?: string }) {
       try {
-        // Build command with optional model routing
         const args = ["--print"]
         const model = params.type ? getSubagentModel(params.type) : null
         if (model) {
@@ -188,64 +387,149 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
     },
   })
 
-  // Subagent routing configuration
+  // TUI-based routing wizard — interactive model assignment
   pi.registerCommand("configure-routing", {
-    description: "Configure which model each subagent type uses (routing.json)",
+    description: "Interactive TUI wizard to configure subagent model routing",
     handler: async (_args: unknown, ctx: any) => {
-      const current = loadRoutingConfig()
-      const currentDisplay = Object.keys(current).length > 0
-        ? Object.entries(current).map(([k, v]) => `  ${k}: ${(v as any).model || "inherit"}`).join("\n")
-        : "  (no routing configured — all subagents use the session model)"
+      // Main wizard loop
+      while (true) {
+        const routing = loadRoutingConfig()
 
-      return `# Subagent Model Routing
+        // Build current config display for the main menu title
+        const configLines = SUBAGENT_TYPES.map(({ type }) => {
+          const entry = routing[type]
+          const model = entry?.model || "inherit"
+          const effort = entry?.effort ? ` (effort: ${entry.effort})` : ""
+          return `  ${type.padEnd(12)} -> ${model}${effort}`
+        })
 
-## Current Configuration
-${currentDisplay}
+        // Step 1: Choose action
+        const action = await ctx.ui.custom<string | null>(
+          (tui: any, theme: any, _keybindings: any, done: (v: string | null) => void) => {
+            const container = new Container()
 
-## How to Configure
+            container.addChild(new Text(theme.fg("accent", theme.bold("Hyperpowers Routing Wizard"))))
+            container.addChild(new Spacer(1))
 
-Use \`provider/model\` format (same as Pi's models.json). This ensures the right provider is used when multiple providers offer models with similar names.
+            // Current routing table
+            container.addChild(new Text(theme.fg("accent", "Current Configuration:")))
+            for (const { type } of SUBAGENT_TYPES) {
+              const entry = routing[type]
+              const model = entry?.model || "inherit"
+              const effort = entry?.effort ? ` (effort: ${entry.effort})` : ""
+              const modelStr = model === "inherit"
+                ? theme.fg("muted", "inherit (session model)")
+                : theme.fg("success", model)
+              container.addChild(new Text(
+                `  ${theme.bold(type.padEnd(12))} ${modelStr}${effort}`
+              ))
+            }
+            container.addChild(new Spacer(1))
 
-Edit \`${ROUTING_CONFIG_PATH}\` with your model assignments:
+            const actions: SelectItem[] = [
+              { label: "Configure single agent", value: "single", description: "Set model for one subagent type" },
+              { label: "Apply preset", value: "preset", description: "Cost-optimized, performance, or all-inherit" },
+              { label: "Reset all to inherit", value: "reset", description: "All subagents use session model" },
+              { label: "Done", value: "done", description: "Save and exit wizard" },
+            ]
 
-\`\`\`json
-{
-  "subagents": {
-    "review": { "model": "anthropic/claude-haiku-4-5" },
-    "research": { "model": "anthropic/claude-sonnet-4-5" },
-    "validation": { "model": "anthropic/claude-opus-4-5" },
-    "test-runner": { "model": "anthropic/claude-haiku-4-5" },
-    "default": { "model": "inherit" }
-  }
-}
-\`\`\`
+            const selectList = new SelectList(actions, actions.length, {
+              selectedPrefix: (text: string) => theme.fg("accent", text),
+              description: (text: string) => theme.fg("muted", text),
+            })
+            selectList.onSelect = (item: any) => done(item.value)
+            container.addChild(selectList)
 
-## Subagent Types
+            return {
+              render(width: number) { return container.render(width) },
+              invalidate() { container.invalidate() },
+              handleInput(data: string) {
+                if (data === "\x1b") { done("done"); return true }
+                selectList.handleInput(data)
+                return true
+              },
+            }
+          }
+        )
 
-| Type | Purpose | Recommended Model |
-|------|---------|-------------------|
-| \`review\` | Code review, quality checks | Fast (haiku) — high volume |
-| \`research\` | Codebase investigation, API docs | Balanced (sonnet) |
-| \`validation\` | Final review, complex analysis | Capable (opus) |
-| \`test-runner\` | Run tests, check results | Fast (haiku) |
-| \`default\` | Any untyped subagent | \`inherit\` (session model) |
+        if (!action || action === "done") break
 
-## Usage
+        if (action === "reset") {
+          saveRoutingConfig(PRESETS["all-inherit"])
+          ctx.ui.notify("All subagents reset to inherit", "success")
+          continue
+        }
 
-When calling the hyperpowers_subagent tool, specify the type:
+        if (action === "preset") {
+          const presetItems: SelectItem[] = [
+            { label: "Cost-optimized", value: "cost-optimized", description: "Haiku for review/research/test, Sonnet for validation" },
+            { label: "Performance", value: "performance", description: "Sonnet for review/research, Opus for validation, Haiku for tests" },
+            { label: "All inherit", value: "all-inherit", description: "All subagents use your current session model" },
+            { label: "Back", value: null, description: "Return to main menu" },
+          ]
 
-\`\`\`
-hyperpowers_subagent(task: "Review auth.ts", type: "review")
-→ runs with anthropic/claude-haiku-4-5
+          const presetName = await createSelectUI(presetItems, "Select Preset", ctx)
+          if (presetName && PRESETS[presetName]) {
+            saveRoutingConfig(PRESETS[presetName])
+            ctx.ui.notify(`Applied "${presetName}" preset`, "success")
+          }
+          continue
+        }
 
-hyperpowers_subagent(task: "Analyze architecture", type: "validation")
-→ runs with anthropic/claude-opus-4-5
-\`\`\`
+        if (action === "single") {
+          // Choose which subagent to configure
+          const agentItems: SelectItem[] = SUBAGENT_TYPES.map(({ type, description, recommended }) => {
+            const current = routing[type]?.model || "inherit"
+            return {
+              label: `${type} (current: ${current})`,
+              value: type,
+              description: `${description} | recommended: ${recommended}`,
+            }
+          })
+          agentItems.push({ label: "Back", value: null, description: "Return to main menu" })
 
-## Quick Setup
+          const agentType = await createSelectUI(agentItems, "Select Subagent Type", ctx)
+          if (!agentType) continue
 
-To write a cost-optimized config now, use the Edit tool to create:
-\`${ROUTING_CONFIG_PATH}\``
+          // Choose model — searchable list grouped by provider
+          const models = discoverModels()
+          const providers = [...new Set(models.map((m) => m.provider))]
+
+          const modelItems: SelectItem[] = [
+            { label: "inherit (use session model)", value: "inherit", description: "Subagent uses whatever model the session is running" },
+          ]
+          for (const provider of providers) {
+            const providerModels = models.filter((m) => m.provider === provider)
+            for (const m of providerModels) {
+              modelItems.push({ label: m.label, value: m.model, description: provider })
+            }
+          }
+          modelItems.push({ label: "Back", value: null, description: "Return to agent selection" })
+
+          const selectedModel = await createSearchableSelectUI(
+            modelItems,
+            `Select Model for "${agentType}"`,
+            "Type to filter, Enter to select, Esc to go back",
+            ctx,
+          )
+
+          if (selectedModel === null) continue
+
+          const updated = { ...routing }
+          updated[agentType] = { ...updated[agentType], model: selectedModel }
+          saveRoutingConfig(updated)
+          ctx.ui.notify(`${agentType} -> ${selectedModel}`, "success")
+        }
+      }
+
+      // Return summary after wizard closes
+      const finalRouting = loadRoutingConfig()
+      const lines = SUBAGENT_TYPES.map(({ type }) => {
+        const entry = finalRouting[type]
+        const model = entry?.model || "inherit"
+        return `  ${type}: ${model}`
+      })
+      return `Routing configuration saved:\n${lines.join("\n")}\n\nConfig file: ${ROUTING_CONFIG_PATH}`
     },
   })
 

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -6,8 +6,9 @@
  */
 
 import { readFileSync, existsSync } from "node:fs"
-import { execSync } from "node:child_process"
+import { execSync, spawn } from "node:child_process"
 import { join, resolve } from "node:path"
+import { Type } from "@sinclair/typebox"
 
 // Resolve the hyperpowers repo root (extension is at .pi/extensions/hyperpowers/)
 const EXTENSION_DIR = import.meta.dir ?? __dirname
@@ -142,6 +143,79 @@ No config needed — built-in. Just set \`OPENAI_API_KEY\` env var.
 - **Complex reasoning**: Claude Opus 4.5 with \`"reasoning": true\`
 
 Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
+    },
+  })
+
+  // Subagent tool — delegates tasks to isolated Pi subprocess
+  pi.registerTool({
+    name: "hyperpowers_subagent",
+    label: "Subagent",
+    description: "Delegate a task to an isolated Pi subagent. The subagent runs in a separate process with its own context, executes the task, and returns the result. Use for: code review, test running, research, or any task that benefits from isolated context.",
+    parameters: Type.Object({
+      task: Type.String({ description: "The task for the subagent to perform" }),
+      maxTokens: Type.Optional(Type.Number({ description: "Max output tokens (default: 4096)" })),
+    }),
+    async execute(params: { task: string; maxTokens?: number }) {
+      try {
+        const result = execSync(
+          `pi --print -- ${JSON.stringify(params.task)}`,
+          {
+            encoding: "utf8",
+            timeout: 120000, // 2 minute timeout
+            maxBuffer: 1024 * 1024 * 10, // 10MB
+            cwd: process.cwd(),
+          },
+        )
+        return {
+          content: [{ type: "text" as const, text: result.trim() || "(subagent returned empty result)" }],
+        }
+      } catch (err: any) {
+        return {
+          content: [{ type: "text" as const, text: `Subagent failed: ${err.message || String(err)}` }],
+        }
+      }
+    },
+  })
+
+  // Parallel review — dispatches multiple subagents for review
+  pi.registerCommand("review-parallel", {
+    description: "Run 3 parallel review subagents: quality, implementation, simplification",
+    handler: async (_args: unknown, ctx: any) => {
+      return `# Parallel Review
+
+Run these 3 reviews using the hyperpowers_subagent tool IN PARALLEL:
+
+1. **Quality review**: Use hyperpowers_subagent with task:
+   "Review the recent code changes for bugs, security issues, and race conditions. Check git diff HEAD~1. Return PASS or ISSUES_FOUND with file:line references."
+
+2. **Implementation review**: Use hyperpowers_subagent with task:
+   "Verify the recent changes achieve their stated goals. Check git log --oneline -5 for context. Return PASS or ISSUES_FOUND with missing items."
+
+3. **Simplification review**: Use hyperpowers_subagent with task:
+   "Check for over-engineering in recent changes. Look for unnecessary abstractions, premature generalization. Return PASS or ISSUES_FOUND with recommendations."
+
+After all 3 complete, summarize the results in a table.`
+    },
+  })
+
+  // Session-aware review using Pi's session branching
+  pi.registerCommand("review-branch", {
+    description: "Review code in a branched session context (isolated, won't affect main session)",
+    handler: async (_args: unknown, ctx: any) => {
+      return `# Branched Review
+
+To review code without affecting your main session context:
+
+1. Use the hyperpowers_subagent tool to delegate the review task
+2. The subagent runs in a completely isolated Pi process
+3. Its context, tool calls, and findings don't pollute your main session
+4. Only the final result comes back
+
+This is Pi's equivalent of Claude Code's "context: fork" — full isolation via subprocess.
+
+Example: Call hyperpowers_subagent with task:
+"Read the files changed in the last commit (git diff HEAD~1 --name-only), then review each file for bugs, security issues, and code quality. Provide a structured report."
+`
     },
   })
 

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -155,7 +155,7 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
       task: Type.String({ description: "The task for the subagent to perform" }),
       type: Type.Optional(Type.String({ description: "Subagent type for model routing: review, research, validation, test-runner (optional, uses routing.json config)" })),
     }),
-    async execute(params: { task: string; type?: string }) {
+    async execute(_toolCallId: string, params: { task: string; type?: string }) {
       try {
         // Build command with optional model routing
         const args = ["--print"]

--- a/.pi/extensions/hyperpowers/package.json
+++ b/.pi/extensions/hyperpowers/package.json
@@ -1,9 +1,12 @@
 {
   "name": "hyperpowers-pi-extension",
   "version": "2.13.0",
-  "description": "Hyperpowers skills and workflows for Pi coding agent",
+  "description": "Hyperpowers skills, subagents, and workflows for Pi coding agent",
   "main": "index.ts",
   "keywords": ["pi-package"],
   "author": "Dmitry Polishuk",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.0"
+  }
 }

--- a/.pi/extensions/hyperpowers/package.json
+++ b/.pi/extensions/hyperpowers/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "hyperpowers-pi-extension",
+  "version": "2.13.0",
+  "description": "Hyperpowers skills and workflows for Pi coding agent",
+  "main": "index.ts",
+  "keywords": ["pi-package"],
+  "author": "Dmitry Polishuk",
+  "license": "MIT"
+}

--- a/.pi/extensions/hyperpowers/package.json
+++ b/.pi/extensions/hyperpowers/package.json
@@ -7,6 +7,8 @@
   "author": "Dmitry Polishuk",
   "license": "MIT",
   "dependencies": {
-    "@sinclair/typebox": "^0.34.0"
+    "@sinclair/typebox": "^0.34.0",
+    "@mariozechner/pi-tui": "^0.63.0",
+    "@mariozechner/pi-coding-agent": "^0.63.0"
   }
 }

--- a/.pi/extensions/hyperpowers/routing.json
+++ b/.pi/extensions/hyperpowers/routing.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Model format: 'provider/model' (e.g., 'anthropic/claude-haiku-4-5', 'ollama/llama3.1:8b') or 'inherit' for session model",
   "subagents": {
     "review": { "model": "inherit" },
     "research": { "model": "inherit" },

--- a/.pi/extensions/hyperpowers/routing.json
+++ b/.pi/extensions/hyperpowers/routing.json
@@ -1,0 +1,9 @@
+{
+  "subagents": {
+    "review": { "model": "inherit" },
+    "research": { "model": "inherit" },
+    "validation": { "model": "inherit" },
+    "test-runner": { "model": "inherit" },
+    "default": { "model": "inherit" }
+  }
+}

--- a/.pi/extensions/hyperpowers/routing.ts
+++ b/.pi/extensions/hyperpowers/routing.ts
@@ -1,0 +1,101 @@
+export type RoutingEntry = { model?: string; effort?: string }
+export type RoutingMap = Record<string, RoutingEntry>
+export interface RoutingConfig {
+  subagents: RoutingMap
+  agents: RoutingMap
+}
+
+export const DEFAULT_ROUTING_COMMENT =
+  "Model format: 'provider/model' (e.g., 'anthropic/claude-haiku-4-5', 'ollama/llama3.1:8b') or 'inherit' for session model"
+
+const DEFAULT_SUBAGENTS: RoutingMap = {
+  review: { model: "inherit" },
+  research: { model: "inherit" },
+  validation: { model: "inherit" },
+  "test-runner": { model: "inherit" },
+  default: { model: "inherit" },
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null
+
+const normalizeEntry = (value: unknown): RoutingEntry | undefined => {
+  if (!isObject(value)) return undefined
+  const entry: RoutingEntry = {}
+  if (typeof value.model === "string") entry.model = value.model
+  if (typeof value.effort === "string") entry.effort = value.effort
+  return entry.model !== undefined || entry.effort !== undefined ? entry : undefined
+}
+
+const normalizeMap = (value: unknown): RoutingMap => {
+  if (!isObject(value)) return {}
+  const map: RoutingMap = {}
+  for (const [key, raw] of Object.entries(value)) {
+    const entry = normalizeEntry(raw)
+    if (entry) map[key] = entry
+  }
+  return map
+}
+
+export function normalizeRoutingConfig(raw: unknown): RoutingConfig {
+  const source = isObject(raw) ? raw : {}
+  const subagents = { ...DEFAULT_SUBAGENTS, ...normalizeMap(source.subagents) }
+  const agents = normalizeMap(source.agents)
+  return { subagents, agents }
+}
+
+export function serializeRoutingConfig(config: RoutingConfig): string {
+  return JSON.stringify(
+    {
+      _comment: DEFAULT_ROUTING_COMMENT,
+      subagents: config.subagents,
+      agents: config.agents,
+    },
+    null,
+    2,
+  ) + "\n"
+}
+
+export interface ResolveRoutingParams {
+  explicitModel?: string
+  agent?: string
+  type?: string
+}
+
+export interface ResolvedRoutingEntry {
+  source: "explicit" | "agent" | "type" | "default" | "inherit"
+  model: string | null
+  effort?: string
+}
+
+const materialize = (
+  source: ResolvedRoutingEntry["source"],
+  entry: RoutingEntry | undefined,
+): ResolvedRoutingEntry => ({
+  source,
+  model: entry?.model && entry.model !== "inherit" ? entry.model : null,
+  effort: entry?.effort,
+})
+
+export function resolveRoutingEntry(
+  config: RoutingConfig,
+  params: ResolveRoutingParams,
+): ResolvedRoutingEntry {
+  if (params.explicitModel) {
+    return { source: "explicit", model: params.explicitModel }
+  }
+
+  if (params.agent && config.agents[params.agent]) {
+    return materialize("agent", config.agents[params.agent])
+  }
+
+  if (params.type && config.subagents[params.type]) {
+    return materialize("type", config.subagents[params.type])
+  }
+
+  if (config.subagents.default) {
+    const resolved = materialize("default", config.subagents.default)
+    if (resolved.model !== null || resolved.effort !== undefined) return resolved
+  }
+
+  return { source: "inherit", model: null }
+}

--- a/.pi/extensions/hyperpowers/routing.ts
+++ b/.pi/extensions/hyperpowers/routing.ts
@@ -5,8 +5,23 @@ export interface RoutingConfig {
   agents: RoutingMap
 }
 
+export interface HyperpowersAgentDefinition {
+  name: string
+  type: string
+  group: "workers" | "reviewers"
+  description: string
+}
+
 export const DEFAULT_ROUTING_COMMENT =
   "Model format: 'provider/model' (e.g., 'anthropic/claude-haiku-4-5', 'ollama/llama3.1:8b') or 'inherit' for session model"
+
+export const HYPERPOWERS_AGENTS: HyperpowersAgentDefinition[] = [
+  { name: "code-reviewer", type: "review", group: "reviewers", description: "Code review, quality checks" },
+  { name: "autonomous-reviewer", type: "validation", group: "reviewers", description: "Final review and validation" },
+  { name: "codebase-investigator", type: "research", group: "workers", description: "Find existing patterns in the codebase" },
+  { name: "internet-researcher", type: "research", group: "workers", description: "Research external docs and APIs" },
+  { name: "test-runner", type: "test-runner", group: "workers", description: "Run tests in isolated subprocesses" },
+]
 
 const DEFAULT_SUBAGENTS: RoutingMap = {
   review: { model: "inherit" },
@@ -98,4 +113,40 @@ export function resolveRoutingEntry(
   }
 
   return { source: "inherit", model: null }
+}
+
+export function withSubagentModel(config: RoutingConfig, type: string, model: string): RoutingConfig {
+  return {
+    subagents: {
+      ...config.subagents,
+      [type]: { ...config.subagents[type], model },
+    },
+    agents: { ...config.agents },
+  }
+}
+
+export function withAgentModel(config: RoutingConfig, agent: string, model: string): RoutingConfig {
+  return {
+    subagents: { ...config.subagents },
+    agents: {
+      ...config.agents,
+      [agent]: { ...config.agents[agent], model },
+    },
+  }
+}
+
+export function withoutAgentOverride(config: RoutingConfig, agent: string): RoutingConfig {
+  const agents = { ...config.agents }
+  delete agents[agent]
+  return {
+    subagents: { ...config.subagents },
+    agents,
+  }
+}
+
+export function resetAllAgentOverrides(config: RoutingConfig): RoutingConfig {
+  return {
+    subagents: { ...config.subagents },
+    agents: {},
+  }
 }

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -221,6 +221,27 @@ const HOSTS: HostConfig[] = [
     },
     availableFeatures: ["memsearch"],
     postInstall: async (targetDir) => {
+      const extDir = join(targetDir, "extensions", "hyperpowers")
+
+      // Install extension dependencies (pi-tui, typebox, etc.) before mutating user files.
+      if (existsSync(join(extDir, "package.json"))) {
+        const installResult = commandExists("bun")
+          ? Bun.spawnSync(["bun", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
+          : commandExists("npm")
+            ? Bun.spawnSync(["npm", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
+            : null
+
+        if (!installResult) {
+          throw new Error("Pi install requires bun or npm to install extension dependencies")
+        }
+
+        if (installResult.exitCode !== 0) {
+          const stderr = installResult.stderr.toString().trim()
+          const stdout = installResult.stdout.toString().trim()
+          throw new Error(`Pi extension dependency install failed${stderr || stdout ? `: ${stderr || stdout}` : ""}`)
+        }
+      }
+
       // Append/replace Hyperpowers section in AGENTS.md (preserve user content before AND after)
       const agentsMdSrc = join(REPO_ROOT, ".pi", "AGENTS.md")
       const agentsMdDest = join(targetDir, "AGENTS.md")
@@ -239,29 +260,10 @@ const HOSTS: HostConfig[] = [
         await copyDir(skillsSrc, join(targetDir, "extensions", "hyperpowers", "skills"))
       }
       // Preserve user routing.json if it exists (don't overwrite custom model assignments)
-      const extDir = join(targetDir, "extensions", "hyperpowers")
       const routingDest = join(extDir, "routing.json")
       const routingSrc = join(REPO_ROOT, ".pi", "extensions", "hyperpowers", "routing.json")
       if (!existsSync(routingDest) && existsSync(routingSrc)) {
         await copyFile(routingSrc, routingDest)
-      }
-      // Install extension dependencies (pi-tui, typebox, etc.)
-      if (existsSync(join(extDir, "package.json"))) {
-        const installResult = commandExists("bun")
-          ? Bun.spawnSync(["bun", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
-          : commandExists("npm")
-            ? Bun.spawnSync(["npm", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
-            : null
-
-        if (!installResult) {
-          throw new Error("Pi install requires bun or npm to install extension dependencies")
-        }
-
-        if (installResult.exitCode !== 0) {
-          const stderr = installResult.stderr.toString().trim()
-          const stdout = installResult.stdout.toString().trim()
-          throw new Error(`Pi extension dependency install failed${stderr || stdout ? `: ${stderr || stdout}` : ""}`)
-        }
       }
     },
     postUninstall: async (targetDir) => {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import * as p from "@clack/prompts"
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { cp, mkdir, readFile, readdir, rm, writeFile, symlink, unlink, stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
@@ -221,10 +221,24 @@ const HOSTS: HostConfig[] = [
     },
     availableFeatures: ["memsearch"],
     postInstall: async (targetDir) => {
-      // Copy AGENTS.md to Pi's agent directory
+      // Append to AGENTS.md (preserve existing user instructions)
       const agentsMdSrc = join(REPO_ROOT, ".pi", "AGENTS.md")
+      const agentsMdDest = join(targetDir, "AGENTS.md")
       if (existsSync(agentsMdSrc)) {
-        await copyFile(agentsMdSrc, join(targetDir, "AGENTS.md"))
+        const newContent = readFileSync(agentsMdSrc, "utf8")
+        if (existsSync(agentsMdDest)) {
+          const existing = readFileSync(agentsMdDest, "utf8")
+          if (!existing.includes("# Hyperpowers for Pi")) {
+            // Append our section to existing AGENTS.md
+            await writeFile(agentsMdDest, existing + "\n\n" + newContent, "utf8")
+          } else {
+            // Replace our section (re-install)
+            const before = existing.split("# Hyperpowers for Pi")[0].trimEnd()
+            await writeFile(agentsMdDest, (before ? before + "\n\n" : "") + newContent, "utf8")
+          }
+        } else {
+          await copyFile(agentsMdSrc, agentsMdDest)
+        }
       }
       // Copy skills directory for runtime skill loading
       const skillsSrc = join(REPO_ROOT, "skills")

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -522,10 +522,10 @@ const installHost = async (host: HostConfig): Promise<string[]> => {
         if (existsSync(join(target, f))) installedFiles.push(f)
       }
     }
-    if (host.id === "pi") {
-      if (existsSync(join(target, "AGENTS.md"))) installedFiles.push("AGENTS.md")
-      if (existsSync(join(target, "extensions", "hyperpowers", "skills"))) installedFiles.push("extensions/hyperpowers/skills/")
-    }
+    // Pi: AGENTS.md and skills/ are NOT tracked in manifest because postUninstall
+    // handles them surgically (removes only Hyperpowers section from AGENTS.md,
+    // removes entire extensions/hyperpowers/ dir). Tracking them would cause
+    // uninstallHost to delete the whole AGENTS.md before postUninstall runs.
   }
 
   // Write version file last (after postInstall succeeds)

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -217,24 +217,33 @@ const HOSTS: HostConfig[] = [
     detect: () => commandExists("pi"),
     targetDir: () => join(homedir(), ".pi", "agent"),
     sources: {
-      "extensions/hyperpowers": { from: ".pi/extensions/hyperpowers" },
+      "extensions/hyperpowers": { from: ".pi/extensions/hyperpowers", exclude: ["routing.json"] },
     },
     availableFeatures: ["memsearch"],
     postInstall: async (targetDir) => {
-      // Append to AGENTS.md (preserve existing user instructions)
+      // Append/replace Hyperpowers section in AGENTS.md (preserve user content before AND after)
       const agentsMdSrc = join(REPO_ROOT, ".pi", "AGENTS.md")
       const agentsMdDest = join(targetDir, "AGENTS.md")
       if (existsSync(agentsMdSrc)) {
         const newContent = readFileSync(agentsMdSrc, "utf8")
         if (existsSync(agentsMdDest)) {
           const existing = readFileSync(agentsMdDest, "utf8")
-          if (!existing.includes("# Hyperpowers for Pi")) {
+          const marker = "# Hyperpowers for Pi"
+          const markerIdx = existing.indexOf(marker)
+          if (markerIdx === -1) {
             // Append our section to existing AGENTS.md
             await writeFile(agentsMdDest, existing + "\n\n" + newContent, "utf8")
           } else {
-            // Replace our section (re-install)
-            const before = existing.split("# Hyperpowers for Pi")[0].trimEnd()
-            await writeFile(agentsMdDest, (before ? before + "\n\n" : "") + newContent, "utf8")
+            // Replace our section, preserving content before AND after
+            const before = existing.slice(0, markerIdx).trimEnd()
+            // Find next top-level heading after our section to preserve trailing content
+            const afterSection = existing.slice(markerIdx + marker.length)
+            const nextHeadingMatch = afterSection.match(/\n(?=# [^#])/)
+            const after = nextHeadingMatch
+              ? afterSection.slice(nextHeadingMatch.index!).trimStart()
+              : ""
+            const parts = [before, newContent, after].filter(Boolean)
+            await writeFile(agentsMdDest, parts.join("\n\n") + "\n", "utf8")
           }
         } else {
           await copyFile(agentsMdSrc, agentsMdDest)
@@ -244,6 +253,40 @@ const HOSTS: HostConfig[] = [
       const skillsSrc = join(REPO_ROOT, "skills")
       if (existsSync(skillsSrc)) {
         await copyDir(skillsSrc, join(targetDir, "extensions", "hyperpowers", "skills"))
+      }
+      // Preserve user routing.json if it exists (don't overwrite custom model assignments)
+      const routingDest = join(targetDir, "extensions", "hyperpowers", "routing.json")
+      const routingSrc = join(REPO_ROOT, ".pi", "extensions", "hyperpowers", "routing.json")
+      if (!existsSync(routingDest) && existsSync(routingSrc)) {
+        await copyFile(routingSrc, routingDest)
+      }
+    },
+    postUninstall: async (targetDir) => {
+      // Remove Hyperpowers section from AGENTS.md (preserve user content)
+      const agentsMdPath = join(targetDir, "AGENTS.md")
+      if (existsSync(agentsMdPath)) {
+        const content = readFileSync(agentsMdPath, "utf8")
+        const marker = "# Hyperpowers for Pi"
+        const markerIdx = content.indexOf(marker)
+        if (markerIdx !== -1) {
+          const before = content.slice(0, markerIdx).trimEnd()
+          const afterSection = content.slice(markerIdx + marker.length)
+          const nextHeadingMatch = afterSection.match(/\n(?=# [^#])/)
+          const after = nextHeadingMatch
+            ? afterSection.slice(nextHeadingMatch.index!).trimStart()
+            : ""
+          const remaining = [before, after].filter(Boolean).join("\n\n").trim()
+          if (remaining) {
+            await writeFile(agentsMdPath, remaining + "\n", "utf8")
+          } else {
+            await rm(agentsMdPath, { force: true })
+          }
+        }
+      }
+      // Remove skills directory
+      const skillsDir = join(targetDir, "extensions", "hyperpowers", "skills")
+      if (existsSync(skillsDir)) {
+        await rm(skillsDir, { recursive: true, force: true })
       }
     },
   },

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -247,10 +247,20 @@ const HOSTS: HostConfig[] = [
       }
       // Install extension dependencies (pi-tui, typebox, etc.)
       if (existsSync(join(extDir, "package.json"))) {
-        if (commandExists("bun")) {
-          Bun.spawnSync(["bun", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
-        } else if (commandExists("npm")) {
-          Bun.spawnSync(["npm", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
+        const installResult = commandExists("bun")
+          ? Bun.spawnSync(["bun", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
+          : commandExists("npm")
+            ? Bun.spawnSync(["npm", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
+            : null
+
+        if (!installResult) {
+          throw new Error("Pi install requires bun or npm to install extension dependencies")
+        }
+
+        if (installResult.exitCode !== 0) {
+          const stderr = installResult.stderr.toString().trim()
+          const stdout = installResult.stdout.toString().trim()
+          throw new Error(`Pi extension dependency install failed${stderr || stdout ? `: ${stderr || stdout}` : ""}`)
         }
       }
     },

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -813,10 +813,13 @@ Options:
     features: { ...(existingManifest?.features ?? {}) },
   }
 
+  let hostInstallFailed = false
+
   for (const hostId of selectedHostIds) {
     const host = HOSTS.find((h) => h.id === hostId)
     if (!host) {
       p.log.warn(`Unknown host "${hostId}" — skipping. Supported: ${HOSTS.map((h) => h.id).join(", ")}`)
+      hostInstallFailed = true
       continue
     }
 
@@ -826,6 +829,7 @@ Options:
       manifest.hosts[hostId] = { targetDir: host.targetDir(), files }
       s.stop(`${host.name}: ${files.length} items installed`)
     } catch (err) {
+      hostInstallFailed = true
       s.stop(`${host.name}: install failed — ${err instanceof Error ? err.message : String(err)}`)
     }
   }
@@ -851,7 +855,7 @@ Options:
   if (args.json) {
     // Structured JSON output for AI agents
     console.log(JSON.stringify({
-      ok: true,
+      ok: !hostInstallFailed,
       version: VERSION,
       hosts: Object.keys(manifest.hosts),
       features: Object.fromEntries(
@@ -861,7 +865,15 @@ Options:
     }))
   } else {
     p.log.info(`Manifest written to ${manifestPath()}`)
-    p.outro(`Done! v${VERSION} installed to ${selectedHostIds.length} host(s) with ${selectedFeatureIds.length} feature(s).`)
+    if (hostInstallFailed) {
+      p.outro(`Completed with host install failures. v${VERSION} installed to ${Object.keys(manifest.hosts).length}/${selectedHostIds.length} host(s) with ${selectedFeatureIds.length} feature(s).`)
+    } else {
+      p.outro(`Done! v${VERSION} installed to ${selectedHostIds.length} host(s) with ${selectedFeatureIds.length} feature(s).`)
+    }
+  }
+
+  if (hostInstallFailed) {
+    process.exitCode = 1
   }
 }
 

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -211,6 +211,28 @@ const HOSTS: HostConfig[] = [
       }
     },
   },
+  {
+    id: "pi",
+    name: "Pi Agent",
+    detect: () => commandExists("pi"),
+    targetDir: () => join(homedir(), ".pi", "agent"),
+    sources: {
+      "extensions/hyperpowers": { from: ".pi/extensions/hyperpowers" },
+    },
+    availableFeatures: ["memsearch"],
+    postInstall: async (targetDir) => {
+      // Copy AGENTS.md to Pi's agent directory
+      const agentsMdSrc = join(REPO_ROOT, ".pi", "AGENTS.md")
+      if (existsSync(agentsMdSrc)) {
+        await copyFile(agentsMdSrc, join(targetDir, "AGENTS.md"))
+      }
+      // Copy skills directory for runtime skill loading
+      const skillsSrc = join(REPO_ROOT, "skills")
+      if (existsSync(skillsSrc)) {
+        await copyDir(skillsSrc, join(targetDir, "extensions", "hyperpowers", "skills"))
+      }
+    },
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -561,7 +583,7 @@ Options:
   --yes, -y          Auto-install all detected hosts and features
   --json, -j         Output structured JSON (implies --yes, for AI agents)
   --uninstall        Remove all installed files and features
-  --hosts <list>     Comma-separated host IDs: claude,opencode,kimi,gemini
+  --hosts <list>     Comma-separated host IDs: claude,opencode,kimi,gemini,pi
   --features <list>  Comma-separated feature IDs: memsearch,supermemory,statusline,routing-wizard,tm-cli
   --help, -h         Show this help
 `)

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -228,25 +228,9 @@ const HOSTS: HostConfig[] = [
         const newContent = readFileSync(agentsMdSrc, "utf8")
         if (existsSync(agentsMdDest)) {
           const existing = readFileSync(agentsMdDest, "utf8")
-          const marker = "# Hyperpowers for Pi"
-          const markerIdx = existing.indexOf(marker)
-          if (markerIdx === -1) {
-            // Append our section to existing AGENTS.md
-            await writeFile(agentsMdDest, existing + "\n\n" + newContent, "utf8")
-          } else {
-            // Replace our section, preserving content before AND after
-            const before = existing.slice(0, markerIdx).trimEnd()
-            // Find next top-level heading after our section to preserve trailing content
-            const afterSection = existing.slice(markerIdx + marker.length)
-            const nextHeadingMatch = afterSection.match(/\n(?=# [^#])/)
-            const after = nextHeadingMatch
-              ? afterSection.slice(nextHeadingMatch.index!).trimStart()
-              : ""
-            const parts = [before, newContent, after].filter(Boolean)
-            await writeFile(agentsMdDest, parts.join("\n\n") + "\n", "utf8")
-          }
+          await writeFile(agentsMdDest, replacePiAgentsSection(existing, newContent), "utf8")
         } else {
-          await copyFile(agentsMdSrc, agentsMdDest)
+          await writeFile(agentsMdDest, wrapPiAgentsSection(newContent) + "\n", "utf8")
         }
       }
       // Copy skills directory for runtime skill loading
@@ -275,21 +259,11 @@ const HOSTS: HostConfig[] = [
       const agentsMdPath = join(targetDir, "AGENTS.md")
       if (existsSync(agentsMdPath)) {
         const content = readFileSync(agentsMdPath, "utf8")
-        const marker = "# Hyperpowers for Pi"
-        const markerIdx = content.indexOf(marker)
-        if (markerIdx !== -1) {
-          const before = content.slice(0, markerIdx).trimEnd()
-          const afterSection = content.slice(markerIdx + marker.length)
-          const nextHeadingMatch = afterSection.match(/\n(?=# [^#])/)
-          const after = nextHeadingMatch
-            ? afterSection.slice(nextHeadingMatch.index!).trimStart()
-            : ""
-          const remaining = [before, after].filter(Boolean).join("\n\n").trim()
-          if (remaining) {
-            await writeFile(agentsMdPath, remaining + "\n", "utf8")
-          } else {
-            await rm(agentsMdPath, { force: true })
-          }
+        const remaining = removePiAgentsSection(content)
+        if (remaining) {
+          await writeFile(agentsMdPath, remaining + "\n", "utf8")
+        } else {
+          await rm(agentsMdPath, { force: true })
         }
       }
       // Remove entire hyperpowers extension directory (includes skills, routing, node_modules)
@@ -304,6 +278,53 @@ const HOSTS: HostConfig[] = [
 // ---------------------------------------------------------------------------
 // Feature Configurations
 // ---------------------------------------------------------------------------
+
+const PI_AGENTS_SECTION_BEGIN = "<!-- BEGIN HYPERPOWERS PI -->"
+const PI_AGENTS_SECTION_END = "<!-- END HYPERPOWERS PI -->"
+
+function wrapPiAgentsSection(content: string): string {
+  return `${PI_AGENTS_SECTION_BEGIN}\n${content.trim()}\n${PI_AGENTS_SECTION_END}`
+}
+
+function replacePiAgentsSection(existing: string, newContent: string): string {
+  const wrapped = wrapPiAgentsSection(newContent)
+  const beginIdx = existing.indexOf(PI_AGENTS_SECTION_BEGIN)
+  const endIdx = existing.indexOf(PI_AGENTS_SECTION_END)
+
+  if (beginIdx !== -1 && endIdx !== -1 && endIdx > beginIdx) {
+    const before = existing.slice(0, beginIdx).trimEnd()
+    const after = existing.slice(endIdx + PI_AGENTS_SECTION_END.length).trimStart()
+    return [...[before, wrapped, after].filter(Boolean)].join("\n\n") + "\n"
+  }
+
+  const legacyMarker = "# Hyperpowers for Pi"
+  const markerIdx = existing.indexOf(legacyMarker)
+  if (markerIdx !== -1) {
+    const before = existing.slice(0, markerIdx).trimEnd()
+    return [...[before, wrapped].filter(Boolean)].join("\n\n") + "\n"
+  }
+
+  return [...[existing.trimEnd(), wrapped].filter(Boolean)].join("\n\n") + "\n"
+}
+
+function removePiAgentsSection(existing: string): string {
+  const beginIdx = existing.indexOf(PI_AGENTS_SECTION_BEGIN)
+  const endIdx = existing.indexOf(PI_AGENTS_SECTION_END)
+
+  if (beginIdx !== -1 && endIdx !== -1 && endIdx > beginIdx) {
+    const before = existing.slice(0, beginIdx).trimEnd()
+    const after = existing.slice(endIdx + PI_AGENTS_SECTION_END.length).trimStart()
+    return [...[before, after].filter(Boolean)].join("\n\n").trim()
+  }
+
+  const legacyMarker = "# Hyperpowers for Pi"
+  const markerIdx = existing.indexOf(legacyMarker)
+  if (markerIdx !== -1) {
+    return existing.slice(0, markerIdx).trim()
+  }
+
+  return existing.trim()
+}
 
 const FEATURES: FeatureConfig[] = [
   {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -2,7 +2,7 @@
 
 import * as p from "@clack/prompts"
 import { existsSync, readFileSync } from "node:fs"
-import { cp, mkdir, readFile, readdir, rm, writeFile, symlink, unlink, stat } from "node:fs/promises"
+import { cp, mkdir, readFile, readdir, rm, writeFile, symlink, unlink, stat, rename } from "node:fs/promises"
 import { homedir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
 
@@ -515,57 +515,88 @@ const FEATURES: FeatureConfig[] = [
 const installHost = async (host: HostConfig): Promise<string[]> => {
   const target = host.targetDir()
   const installedFiles: string[] = []
+  const backupEntries: Array<{ originalPath: string, backupPath: string }> = []
+  const createdPaths: string[] = []
 
-  for (const [category, source] of Object.entries(host.sources)) {
-    const srcDir = join(REPO_ROOT, source.from)
-    if (!existsSync(srcDir)) continue
+  try {
+    for (const [category, source] of Object.entries(host.sources)) {
+      const srcDir = join(REPO_ROOT, source.from)
+      if (!existsSync(srcDir)) continue
 
-    const items = await listItems(srcDir, source.pattern, source.exclude)
-    const destDir = join(target, category)
-    await mkdir(destDir, { recursive: true })
+      const items = await listItems(srcDir, source.pattern, source.exclude)
+      const destDir = join(target, category)
+      await mkdir(destDir, { recursive: true })
 
-    for (const item of items) {
-      const srcPath = join(srcDir, item)
-      const destPath = join(destDir, item)
-      const s = await stat(srcPath)
-      if (s.isDirectory()) {
-        await copyDir(srcPath, destPath)
-        installedFiles.push(`${category}/${item}/`)
-      } else {
-        await copyFile(srcPath, destPath)
-        installedFiles.push(`${category}/${item}`)
+      for (const item of items) {
+        const srcPath = join(srcDir, item)
+        const destPath = join(destDir, item)
+        const backupPath = existsSync(destPath)
+          ? `${destPath}.hyperpowers-backup-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+          : null
+
+        if (backupPath) {
+          await rename(destPath, backupPath)
+          backupEntries.push({ originalPath: destPath, backupPath })
+        }
+
+        const s = await stat(srcPath)
+        if (s.isDirectory()) {
+          await copyDir(srcPath, destPath)
+          installedFiles.push(`${category}/${item}/`)
+        } else {
+          await copyFile(srcPath, destPath)
+          installedFiles.push(`${category}/${item}`)
+        }
+        createdPaths.push(destPath)
       }
     }
+
+    // Run post-install and track additional files (before writing version marker)
+    if (host.postInstall) {
+      await host.postInstall(target)
+      // Re-scan for files that postInstall may have added
+      if (host.id === "opencode") {
+        for (const f of ["package.json", "task-context.json", "cass-memory.json"]) {
+          if (existsSync(join(target, f))) installedFiles.push(f)
+        }
+      }
+      if (host.id === "claude") {
+        if (existsSync(join(target, "hyperpowers-statusline.sh"))) installedFiles.push("hyperpowers-statusline.sh")
+      }
+      if (host.id === "kimi") {
+        for (const f of ["hyperpowers.yaml", "hyperpowers-system.md", "mcp.json"]) {
+          if (existsSync(join(target, f))) installedFiles.push(f)
+        }
+      }
+      // Pi: AGENTS.md and skills/ are NOT tracked in manifest because postUninstall
+      // handles them surgically (removes only Hyperpowers section from AGENTS.md,
+      // removes entire extensions/hyperpowers/ dir). Tracking them would cause
+      // uninstallHost to delete the whole AGENTS.md before postUninstall runs.
+    }
+
+    // Write version file last (after postInstall succeeds)
+    await writeFile(join(target, ".hyperpowers-version"), VERSION + "\n", "utf8")
+    installedFiles.push(".hyperpowers-version")
+
+    for (const { backupPath } of backupEntries.reverse()) {
+      await rm(backupPath, { recursive: true, force: true }).catch(() => {})
+    }
+
+    return installedFiles
+  } catch (error) {
+    for (const createdPath of createdPaths.reverse()) {
+      await rm(createdPath, { recursive: true, force: true }).catch(() => {})
+    }
+    for (const { originalPath, backupPath } of backupEntries.reverse()) {
+      if (existsSync(backupPath)) {
+        await rename(backupPath, originalPath).catch(() => {})
+      }
+    }
+    if (host.id === "pi") {
+      await rm(join(target, "extensions", "hyperpowers"), { recursive: true, force: true }).catch(() => {})
+    }
+    throw error
   }
-
-  // Run post-install and track additional files (before writing version marker)
-  if (host.postInstall) {
-    await host.postInstall(target)
-    // Re-scan for files that postInstall may have added
-    if (host.id === "opencode") {
-      for (const f of ["package.json", "task-context.json", "cass-memory.json"]) {
-        if (existsSync(join(target, f))) installedFiles.push(f)
-      }
-    }
-    if (host.id === "claude") {
-      if (existsSync(join(target, "hyperpowers-statusline.sh"))) installedFiles.push("hyperpowers-statusline.sh")
-    }
-    if (host.id === "kimi") {
-      for (const f of ["hyperpowers.yaml", "hyperpowers-system.md", "mcp.json"]) {
-        if (existsSync(join(target, f))) installedFiles.push(f)
-      }
-    }
-    // Pi: AGENTS.md and skills/ are NOT tracked in manifest because postUninstall
-    // handles them surgically (removes only Hyperpowers section from AGENTS.md,
-    // removes entire extensions/hyperpowers/ dir). Tracking them would cause
-    // uninstallHost to delete the whole AGENTS.md before postUninstall runs.
-  }
-
-  // Write version file last (after postInstall succeeds)
-  await writeFile(join(target, ".hyperpowers-version"), VERSION + "\n", "utf8")
-  installedFiles.push(".hyperpowers-version")
-
-  return installedFiles
 }
 
 const uninstallHost = async (hostId: string, manifest: InstallManifest) => {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -517,6 +517,8 @@ const installHost = async (host: HostConfig): Promise<string[]> => {
   const installedFiles: string[] = []
   const backupEntries: Array<{ originalPath: string, backupPath: string }> = []
   const createdPaths: string[] = []
+  const piExtensionDir = join(target, "extensions", "hyperpowers")
+  const piExtensionExistedBeforeInstall = host.id === "pi" && existsSync(piExtensionDir)
 
   try {
     for (const [category, source] of Object.entries(host.sources)) {
@@ -592,8 +594,8 @@ const installHost = async (host: HostConfig): Promise<string[]> => {
         await rename(backupPath, originalPath).catch(() => {})
       }
     }
-    if (host.id === "pi") {
-      await rm(join(target, "extensions", "hyperpowers"), { recursive: true, force: true }).catch(() => {})
+    if (host.id === "pi" && !piExtensionExistedBeforeInstall) {
+      await rm(piExtensionDir, { recursive: true, force: true }).catch(() => {})
     }
     throw error
   }

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -255,10 +255,19 @@ const HOSTS: HostConfig[] = [
         await copyDir(skillsSrc, join(targetDir, "extensions", "hyperpowers", "skills"))
       }
       // Preserve user routing.json if it exists (don't overwrite custom model assignments)
-      const routingDest = join(targetDir, "extensions", "hyperpowers", "routing.json")
+      const extDir = join(targetDir, "extensions", "hyperpowers")
+      const routingDest = join(extDir, "routing.json")
       const routingSrc = join(REPO_ROOT, ".pi", "extensions", "hyperpowers", "routing.json")
       if (!existsSync(routingDest) && existsSync(routingSrc)) {
         await copyFile(routingSrc, routingDest)
+      }
+      // Install extension dependencies (pi-tui, typebox, etc.)
+      if (existsSync(join(extDir, "package.json"))) {
+        if (commandExists("bun")) {
+          Bun.spawnSync(["bun", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
+        } else if (commandExists("npm")) {
+          Bun.spawnSync(["npm", "install", "--silent"], { cwd: extDir, stdout: "pipe", stderr: "pipe" })
+        }
       }
     },
     postUninstall: async (targetDir) => {
@@ -283,10 +292,10 @@ const HOSTS: HostConfig[] = [
           }
         }
       }
-      // Remove skills directory
-      const skillsDir = join(targetDir, "extensions", "hyperpowers", "skills")
-      if (existsSync(skillsDir)) {
-        await rm(skillsDir, { recursive: true, force: true })
+      // Remove entire hyperpowers extension directory (includes skills, routing, node_modules)
+      const extDir = join(targetDir, "extensions", "hyperpowers")
+      if (existsSync(extDir)) {
+        await rm(extDir, { recursive: true, force: true })
       }
     },
   },

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -456,6 +456,10 @@ const installHost = async (host: HostConfig): Promise<string[]> => {
         if (existsSync(join(target, f))) installedFiles.push(f)
       }
     }
+    if (host.id === "pi") {
+      if (existsSync(join(target, "AGENTS.md"))) installedFiles.push("AGENTS.md")
+      if (existsSync(join(target, "extensions", "hyperpowers", "skills"))) installedFiles.push("extensions/hyperpowers/skills/")
+    }
   }
 
   // Write version file last (after postInstall succeeds)

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -255,6 +255,36 @@ test("pi installer json mode reports failure when host install fails", () => {
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("pi installer rollback preserves pre-existing extension files on failure", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-existing-ext-test-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-existing-ext-bin-"))
+  const piHome = path.join(home, ".pi", "agent")
+  const piShimPath = path.join(tmpBinDir, "pi")
+  const extDir = path.join(piHome, "extensions", "hyperpowers")
+  const routingPath = path.join(extDir, "routing.json")
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  const originalRouting = '{\n  "default": "existing-model"\n}\n'
+
+  fs.mkdirSync(extDir, { recursive: true })
+  fs.writeFileSync(routingPath, originalRouting, "utf8")
+  fs.writeFileSync(piShimPath, "#!/bin/sh\nexit 0\n", "utf8")
+  fs.chmodSync(piShimPath, 0o755)
+  fs.symlinkSync(bunPath, path.join(tmpBinDir, "bun"))
+
+  const result = spawnSync("bun", ["scripts/install.ts", "--hosts", "pi", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, NO_COLOR: "1", PATH: tmpBinDir },
+    timeout: 120000,
+  })
+
+  assert.notEqual(result.status, 0)
+  assert.equal(fs.existsSync(extDir), true)
+  assert.equal(fs.readFileSync(routingPath, "utf8"), originalRouting)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("install.sh opencode provisions tm runtime and OpenCode command surface", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-test-"))
   const opencodeHome = path.join(home, ".config", "opencode")

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -134,6 +134,69 @@ test("install.sh opencode moves pre-existing node_modules directory aside and in
   assert.equal(fs.existsSync(path.join(backupPath, "some-pkg")), true)
 })
 
+test("pi installer preserves freeform trailing AGENTS.md content across reinstall and uninstall", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-agents-test-"))
+  const piHome = path.join(home, ".pi", "agent")
+  const agentsPath = path.join(piHome, "AGENTS.md")
+  const trailingNotes = "User notes without heading\n- keep this list item\nplain trailing text"
+
+  fs.mkdirSync(piHome, { recursive: true })
+  fs.writeFileSync(
+    agentsPath,
+    [
+      "# Existing Pi Instructions",
+      "Keep the user's original preface.",
+      "",
+      "<!-- BEGIN HYPERPOWERS PI -->",
+      "# Hyperpowers for Pi",
+      "Old installed content",
+      "<!-- END HYPERPOWERS PI -->",
+      "",
+      trailingNotes,
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-bin-"))
+  const piShimPath = path.join(tmpBinDir, "pi")
+  fs.writeFileSync(piShimPath, "#!/bin/sh\nexit 0\n", "utf8")
+  fs.chmodSync(piShimPath, 0o755)
+
+  const env = { ...process.env, HOME: home, NO_COLOR: "1", PATH: `${tmpBinDir}:${process.env.PATH}` }
+
+  const installResult = spawnSync("bun", ["scripts/install.ts", "--hosts", "pi", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+    timeout: 120000,
+  })
+
+  assert.equal(installResult.status, 0)
+  const installedAgents = fs.readFileSync(agentsPath, "utf8")
+  assert.match(installedAgents, /<!-- BEGIN HYPERPOWERS PI -->/)
+  assert.match(installedAgents, /# Hyperpowers for Pi/)
+  assert.match(installedAgents, /User notes without heading/)
+  assert.match(installedAgents, /plain trailing text/)
+
+  const uninstallResult = spawnSync("bun", ["scripts/install.ts", "--hosts", "pi", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+    timeout: 120000,
+  })
+
+  assert.equal(uninstallResult.status, 0)
+  const uninstalledAgents = fs.readFileSync(agentsPath, "utf8")
+  assert.doesNotMatch(uninstalledAgents, /<!-- BEGIN HYPERPOWERS PI -->/)
+  assert.doesNotMatch(uninstalledAgents, /# Hyperpowers for Pi/)
+  assert.match(uninstalledAgents, /Keep the user's original preface\./)
+  assert.match(uninstalledAgents, /User notes without heading/)
+  assert.match(uninstalledAgents, /plain trailing text/)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("install.sh opencode provisions tm runtime and OpenCode command surface", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-test-"))
   const opencodeHome = path.join(home, ".config", "opencode")

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -202,9 +202,12 @@ test("pi installer fails when dependency install tooling is unavailable", () => 
   const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-bin-"))
   const piHome = path.join(home, ".pi", "agent")
   const piShimPath = path.join(tmpBinDir, "pi")
+  const agentsPath = path.join(piHome, "AGENTS.md")
   const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  const originalAgents = "# Existing Pi Instructions\nKeep this untouched when install fails.\n"
 
   fs.mkdirSync(piHome, { recursive: true })
+  fs.writeFileSync(agentsPath, originalAgents, "utf8")
   fs.writeFileSync(piShimPath, "#!/bin/sh\nexit 0\n", "utf8")
   fs.chmodSync(piShimPath, 0o755)
   fs.symlinkSync(bunPath, path.join(tmpBinDir, "bun"))
@@ -218,6 +221,7 @@ test("pi installer fails when dependency install tooling is unavailable", () => 
 
   assert.notEqual(result.status, 0)
   assert.match(result.stderr + result.stdout, /Pi install requires bun or npm|Pi extension dependency install failed/)
+  assert.equal(fs.readFileSync(agentsPath, "utf8"), originalAgents)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -203,6 +203,7 @@ test("pi installer fails when dependency install tooling is unavailable", () => 
   const piHome = path.join(home, ".pi", "agent")
   const piShimPath = path.join(tmpBinDir, "pi")
   const agentsPath = path.join(piHome, "AGENTS.md")
+  const extensionPath = path.join(piHome, "extensions", "hyperpowers")
   const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
   const originalAgents = "# Existing Pi Instructions\nKeep this untouched when install fails.\n"
 
@@ -222,6 +223,7 @@ test("pi installer fails when dependency install tooling is unavailable", () => 
   assert.notEqual(result.status, 0)
   assert.match(result.stderr + result.stdout, /Pi install requires bun or npm|Pi extension dependency install failed/)
   assert.equal(fs.readFileSync(agentsPath, "utf8"), originalAgents)
+  assert.equal(fs.existsSync(extensionPath), false)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -222,6 +222,33 @@ test("pi installer fails when dependency install tooling is unavailable", () => 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("pi installer json mode reports failure when host install fails", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-json-fail-test-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-json-bin-"))
+  const piHome = path.join(home, ".pi", "agent")
+  const piShimPath = path.join(tmpBinDir, "pi")
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+
+  fs.mkdirSync(piHome, { recursive: true })
+  fs.writeFileSync(piShimPath, "#!/bin/sh\nexit 0\n", "utf8")
+  fs.chmodSync(piShimPath, 0o755)
+  fs.symlinkSync(bunPath, path.join(tmpBinDir, "bun"))
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "pi", "--features", "__none__", "--yes", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, NO_COLOR: "1", PATH: tmpBinDir },
+    timeout: 120000,
+  })
+
+  assert.notEqual(result.status, 0)
+  const payload = JSON.parse(result.stdout.trim())
+  assert.equal(payload.ok, false)
+  assert.equal(Array.isArray(payload.hosts), true)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("install.sh opencode provisions tm runtime and OpenCode command surface", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-test-"))
   const opencodeHome = path.join(home, ".config", "opencode")

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -197,6 +197,31 @@ test("pi installer preserves freeform trailing AGENTS.md content across reinstal
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("pi installer fails when dependency install tooling is unavailable", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-deps-test-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-bin-"))
+  const piHome = path.join(home, ".pi", "agent")
+  const piShimPath = path.join(tmpBinDir, "pi")
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+
+  fs.mkdirSync(piHome, { recursive: true })
+  fs.writeFileSync(piShimPath, "#!/bin/sh\nexit 0\n", "utf8")
+  fs.chmodSync(piShimPath, 0o755)
+  fs.symlinkSync(bunPath, path.join(tmpBinDir, "bun"))
+
+  const result = spawnSync("bun", ["scripts/install.ts", "--hosts", "pi", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, NO_COLOR: "1", PATH: tmpBinDir },
+    timeout: 120000,
+  })
+
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr + result.stdout, /Pi install requires bun or npm|Pi extension dependency install failed/)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("install.sh opencode provisions tm runtime and OpenCode command surface", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-test-"))
   const opencodeHome = path.join(home, ".config", "opencode")

--- a/tests/pi-agent-routing.test.ts
+++ b/tests/pi-agent-routing.test.ts
@@ -2,9 +2,14 @@ import { test, expect } from "bun:test"
 
 import {
   DEFAULT_ROUTING_COMMENT,
+  HYPERPOWERS_AGENTS,
   normalizeRoutingConfig,
+  resetAllAgentOverrides,
   resolveRoutingEntry,
   serializeRoutingConfig,
+  withAgentModel,
+  withSubagentModel,
+  withoutAgentOverride,
   type RoutingConfig,
 } from "../.pi/extensions/hyperpowers/routing"
 
@@ -113,6 +118,30 @@ test("resolveRoutingEntry treats inherit as null model even when coming from age
   expect(resolved.source).toBe("agent")
   expect(resolved.model).toBeNull()
   expect(resolved.effort).toBe("medium")
+})
+
+test("agent catalog exposes worker and reviewer routing targets", () => {
+  expect(HYPERPOWERS_AGENTS.map((agent) => agent.name)).toEqual([
+    "code-reviewer",
+    "autonomous-reviewer",
+    "codebase-investigator",
+    "internet-researcher",
+    "test-runner",
+  ])
+})
+
+test("config update helpers preserve single source of truth semantics", () => {
+  const base = normalizeRoutingConfig({})
+  const withType = withSubagentModel(base, "review", "anthropic/claude-sonnet-4-5")
+  const withConcrete = withAgentModel(withType, "code-reviewer", "anthropic/claude-opus-4-5")
+  const withoutConcrete = withoutAgentOverride(withConcrete, "code-reviewer")
+  const resetConcrete = resetAllAgentOverrides(withConcrete)
+
+  expect(withType.subagents.review.model).toBe("anthropic/claude-sonnet-4-5")
+  expect(withConcrete.agents["code-reviewer"].model).toBe("anthropic/claude-opus-4-5")
+  expect(withoutConcrete.agents["code-reviewer"]).toBeUndefined()
+  expect(resetConcrete.agents).toEqual({})
+  expect(resetConcrete.subagents.review.model).toBe("anthropic/claude-sonnet-4-5")
 })
 
 test("serializeRoutingConfig writes canonical shape with comment and agents", () => {

--- a/tests/pi-agent-routing.test.ts
+++ b/tests/pi-agent-routing.test.ts
@@ -1,0 +1,135 @@
+import { test, expect } from "bun:test"
+
+import {
+  DEFAULT_ROUTING_COMMENT,
+  normalizeRoutingConfig,
+  resolveRoutingEntry,
+  serializeRoutingConfig,
+  type RoutingConfig,
+} from "../.pi/extensions/hyperpowers/routing"
+
+test("normalizeRoutingConfig preserves legacy subagent-only configs and adds defaults", () => {
+  const config = normalizeRoutingConfig({
+    subagents: {
+      review: { model: "anthropic/claude-sonnet-4-5" },
+    },
+  })
+
+  expect(config.subagents.review.model).toBe("anthropic/claude-sonnet-4-5")
+  expect(config.subagents.default.model).toBe("inherit")
+  expect(config.agents).toEqual({})
+})
+
+test("normalizeRoutingConfig falls back safely for malformed input", () => {
+  const config = normalizeRoutingConfig("not-an-object")
+
+  expect(config.subagents.default.model).toBe("inherit")
+  expect(config.agents).toEqual({})
+})
+
+test("resolveRoutingEntry prefers explicit model over all config", () => {
+  const config: RoutingConfig = normalizeRoutingConfig({
+    subagents: {
+      review: { model: "anthropic/claude-sonnet-4-5" },
+      default: { model: "inherit" },
+    },
+    agents: {
+      "code-reviewer": { model: "anthropic/claude-opus-4-5", effort: "high" },
+    },
+  })
+
+  const resolved = resolveRoutingEntry(config, {
+    explicitModel: "openai/gpt-4.1",
+    agent: "code-reviewer",
+    type: "review",
+  })
+
+  expect(resolved.source).toBe("explicit")
+  expect(resolved.model).toBe("openai/gpt-4.1")
+})
+
+test("resolveRoutingEntry prefers concrete agent override over type override", () => {
+  const config: RoutingConfig = normalizeRoutingConfig({
+    subagents: {
+      review: { model: "anthropic/claude-sonnet-4-5", effort: "medium" },
+      default: { model: "inherit" },
+    },
+    agents: {
+      "code-reviewer": { model: "anthropic/claude-opus-4-5", effort: "high" },
+    },
+  })
+
+  const resolved = resolveRoutingEntry(config, {
+    agent: "code-reviewer",
+    type: "review",
+  })
+
+  expect(resolved.source).toBe("agent")
+  expect(resolved.model).toBe("anthropic/claude-opus-4-5")
+  expect(resolved.effort).toBe("high")
+})
+
+test("resolveRoutingEntry falls back from type override to default to inherit", () => {
+  const typeConfig = normalizeRoutingConfig({
+    subagents: {
+      research: { model: "anthropic/claude-haiku-4-5" },
+      default: { model: "inherit" },
+    },
+  })
+  const defaultConfig = normalizeRoutingConfig({
+    subagents: {
+      default: { model: "anthropic/claude-sonnet-4-5", effort: "low" },
+    },
+  })
+  const inheritConfig = normalizeRoutingConfig({})
+
+  expect(resolveRoutingEntry(typeConfig, { type: "research" })).toMatchObject({
+    source: "type",
+    model: "anthropic/claude-haiku-4-5",
+  })
+  expect(resolveRoutingEntry(defaultConfig, { type: "unknown" })).toMatchObject({
+    source: "default",
+    model: "anthropic/claude-sonnet-4-5",
+    effort: "low",
+  })
+  expect(resolveRoutingEntry(inheritConfig, { type: "unknown" })).toMatchObject({
+    source: "inherit",
+    model: null,
+  })
+})
+
+test("resolveRoutingEntry treats inherit as null model even when coming from agent override", () => {
+  const config = normalizeRoutingConfig({
+    subagents: {
+      review: { model: "anthropic/claude-sonnet-4-5" },
+      default: { model: "inherit" },
+    },
+    agents: {
+      "code-reviewer": { model: "inherit", effort: "medium" },
+    },
+  })
+
+  const resolved = resolveRoutingEntry(config, { agent: "code-reviewer", type: "review" })
+  expect(resolved.source).toBe("agent")
+  expect(resolved.model).toBeNull()
+  expect(resolved.effort).toBe("medium")
+})
+
+test("serializeRoutingConfig writes canonical shape with comment and agents", () => {
+  const text = serializeRoutingConfig(
+    normalizeRoutingConfig({
+      subagents: {
+        review: { model: "anthropic/claude-sonnet-4-5" },
+      },
+      agents: {
+        "code-reviewer": { model: "anthropic/claude-opus-4-5" },
+      },
+    }),
+  )
+
+  const parsed = JSON.parse(text)
+  expect(parsed._comment).toBe(DEFAULT_ROUTING_COMMENT)
+  expect(parsed.subagents.review.model).toBe("anthropic/claude-sonnet-4-5")
+  expect(parsed.subagents.default.model).toBe("inherit")
+  expect(parsed.agents["code-reviewer"].model).toBe("anthropic/claude-opus-4-5")
+})

--- a/tests/tm-cli.test.js
+++ b/tests/tm-cli.test.js
@@ -299,39 +299,91 @@ exit 0
 })
 
 test("tm passes arguments with spaces unchanged to bd", () => {
-  // Use a temp directory with its own .beads to avoid polluting repo state
   const os = require("node:os")
   const fs = require("node:fs")
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tm-test-"))
   const tmpBeads = path.join(tmpDir, ".beads")
-  fs.mkdirSync(tmpBeads)
-  // Initialize minimal beads DB
-  spawnSync("bd", ["init"], { cwd: tmpDir, encoding: "utf8", timeout: 10000 })
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "tm-test-bin-"))
+  const bashPath = findCommandPath("bash") || "/bin/bash"
 
-  const title = "TM test issue with spaces"
-  const design = "Multi word design for testing"
-  const createResult = runTm([
-    "create", title,
-    "--type", "task",
-    "--priority", "4",
-    "--design", design,
-  ], { cwd: tmpDir })
-  assert.equal(createResult.status, 0, `tm create failed: ${createResult.stderr}`)
+  try {
+    fs.mkdirSync(tmpBeads)
 
-  // Extract issue ID from output (prefix varies by repo)
-  const idMatch = createResult.stdout.match(/(\S+-[0-9a-z]+)/)
-  assert.ok(idMatch, `Could not find issue ID in output: ${createResult.stdout}`)
-  const issueId = idMatch[1]
+    for (const commandName of ["awk", "bash", "cat", "dirname", "grep"]) {
+      const commandPath = findCommandPath(commandName)
+      assert.ok(commandPath, `Could not find ${commandName} on PATH`)
+      fs.symlinkSync(commandPath, path.join(tmpBinDir, commandName))
+    }
 
-  // Verify the title and design were preserved
-  const showResult = runTm(["show", issueId], { cwd: tmpDir })
-  assert.equal(showResult.status, 0)
-  assert.ok(showResult.stdout.includes(title), `Title not found in show output`)
-  assert.ok(showResult.stdout.includes(design), `Design not found in show output`)
+    const fakeBdPath = path.join(tmpBinDir, "bd")
+    fs.writeFileSync(
+      fakeBdPath,
+      `#!${bashPath}
+set -euo pipefail
+store="${tmpDir}/issues.txt"
+command="$1"
+shift || true
 
-  // Clean up
-  runTm(["close", issueId, "--reason", "test cleanup"], { cwd: tmpDir })
-  fs.rmSync(tmpDir, { recursive: true, force: true })
+case "$command" in
+  create)
+    title="$1"
+    shift
+    design=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --design)
+          design="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    printf '%s\n%s\n' "$title" "$design" > "$store"
+    printf '✓ Created issue: tmtest-1 — %s\n' "$title"
+    ;;
+  show)
+    issue_id="$1"
+    [[ "$issue_id" == "tmtest-1" ]] || exit 0
+    cat "$store"
+    ;;
+  close)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+    )
+    fs.chmodSync(fakeBdPath, 0o755)
+
+    const env = { ...process.env, TM_BACKEND: "bd", PATH: tmpBinDir }
+    const title = "TM test issue with spaces"
+    const design = "Multi word design for testing"
+    const createResult = runTm([
+      "create", title,
+      "--type", "task",
+      "--priority", "4",
+      "--design", design,
+    ], { cwd: tmpDir, env })
+    assert.equal(createResult.status, 0, `tm create failed: ${createResult.stderr}`)
+
+    const idMatch = createResult.stdout.match(/(\S+-[0-9a-z]+)/)
+    assert.ok(idMatch, `Could not find issue ID in output: ${createResult.stdout}`)
+    const issueId = idMatch[1]
+
+    const showResult = runTm(["show", issueId], { cwd: tmpDir, env })
+    assert.equal(showResult.status, 0)
+    assert.ok(showResult.stdout.includes(title), `Title not found in show output`)
+    assert.ok(showResult.stdout.includes(design), `Design not found in show output`)
+
+    runTm(["close", issueId, "--reason", "test cleanup"], { cwd: tmpDir, env })
+  } finally {
+    fs.rmSync(tmpBinDir, { recursive: true, force: true })
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
 })
 
 test("tm when bd not in PATH gives helpful error message", () => {


### PR DESCRIPTION
## Summary
Add full Pi coding agent (pi.dev) support as a new host in Hyperpowers, bringing the total to 6 supported AI tools.

## What's included

### Pi Extension (`.pi/extensions/hyperpowers/`)
- TypeScript extension using Pi's `ExtensionAPI`
- 13 skills registered as slash commands (`/brainstorm`, `/recall`, `/tdd`, etc.)
- `session_start` hook for memsearch long-term memory recall
- Skills loaded at runtime from SKILL.md files (not duplicated)

### AGENTS.md
- Auto-loaded by Pi from `~/.pi/agent/`
- Command reference table + core principles

### Installer
- Pi added as a host in `install.ts` with `pi` CLI detection
- Copies extension + skills to `~/.pi/agent/extensions/hyperpowers/`

## Supported Hosts (now 6)
| Host | Status |
|------|--------|
| Claude Code | Full support |
| OpenCode | Full support |
| Kimi CLI | Full support |
| Gemini CLI | Extension support |
| **Pi Agent** | **New — full support** |
| Codex CLI | Via sync scripts |

## Test plan
- [x] Install script tests pass (5/5)
- [x] Orchestrator tests pass (27/27)
- [x] Extension compiles without errors
- [x] Installer detects Pi and shows in host list

🤖 Generated with [Claude Code](https://claude.com/claude-code)