### PR TITLE
fix: rollback Pi AGENTS changes on install failure

### DIFF
--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -519,6 +519,11 @@ const installHost = async (host: HostConfig): Promise<string[]> => {
   const createdPaths: string[] = []
   const piExtensionDir = join(target, "extensions", "hyperpowers")
   const piExtensionExistedBeforeInstall = host.id === "pi" && existsSync(piExtensionDir)
+  const piAgentsPath = host.id === "pi" ? join(target, "AGENTS.md") : null
+  const piAgentsExistedBeforeInstall = piAgentsPath ? existsSync(piAgentsPath) : false
+  const piAgentsOriginalContent = piAgentsExistedBeforeInstall && piAgentsPath
+    ? readFileSync(piAgentsPath, "utf8")
+    : null
 
   try {
     for (const [category, source] of Object.entries(host.sources)) {
@@ -592,6 +597,13 @@ const installHost = async (host: HostConfig): Promise<string[]> => {
     for (const { originalPath, backupPath } of backupEntries.reverse()) {
       if (existsSync(backupPath)) {
         await rename(backupPath, originalPath).catch(() => {})
+      }
+    }
+    if (host.id === "pi" && piAgentsPath) {
+      if (piAgentsExistedBeforeInstall) {
+        await writeFile(piAgentsPath, piAgentsOriginalContent ?? "", "utf8").catch(() => {})
+      } else {
+        await rm(piAgentsPath, { force: true }).catch(() => {})
       }
     }
     if (host.id === "pi" && !piExtensionExistedBeforeInstall) {

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -285,6 +285,39 @@ test("pi installer rollback preserves pre-existing extension files on failure", 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("pi installer rolls back AGENTS.md if a later Pi postInstall step fails", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-agents-rollback-test-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-pi-agents-rollback-bin-"))
+  const piHome = path.join(home, ".pi", "agent")
+  const piShimPath = path.join(tmpBinDir, "pi")
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  const agentsPath = path.join(piHome, "AGENTS.md")
+  const extDir = path.join(piHome, "extensions", "hyperpowers")
+  const skillsPath = path.join(extDir, "skills")
+  const originalAgents = "# Existing Pi Instructions\nKeep this untouched if install fails after AGENTS update.\n"
+
+  fs.mkdirSync(extDir, { recursive: true })
+  fs.writeFileSync(agentsPath, originalAgents, "utf8")
+  fs.symlinkSync("/dev/full", skillsPath)
+  fs.writeFileSync(piShimPath, "#!/bin/sh\nexit 0\n", "utf8")
+  fs.chmodSync(piShimPath, 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "bun"), "#!/bin/sh\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "bun"), 0o755)
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "pi", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, NO_COLOR: "1", PATH: `${tmpBinDir}:${process.env.PATH}` },
+    timeout: 120000,
+  })
+
+  assert.notEqual(result.status, 0)
+  assert.equal(fs.readFileSync(agentsPath, "utf8"), originalAgents)
+  assert.equal(fs.lstatSync(skillsPath).isSymbolicLink(), true)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("install.sh opencode provisions tm runtime and OpenCode command surface", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-test-"))
   const opencodeHome = path.join(home, ".config", "opencode")


### PR DESCRIPTION
## Summary
- restore the original Pi `AGENTS.md` content when a later Pi `postInstall` step fails
- add a regression test that simulates a post-AGENTS failure during Pi install
- preserve existing Pi extension state during the rollback scenario

## Testing
- node --test tests/install-script.test.js --test-name-pattern \"pi installer\"
- node --test tests/opencode-linear-support.test.js tests/install-script.test.js --test-name-pattern \"pi|routing|subagent\"