### PR TITLE
fix(pi): explicitly send user message in command handlers

### DIFF
--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -987,9 +987,19 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
       return await ctx.ui.custom<string>(
         (_tui: any, _theme: any, _keybindings: any, done: (v: string) => void) => {
           dashboard.tui = _tui
+
+          // Enable SGR mouse tracking for scrolling
+          _tui.terminal.write("\x1b[?1000h\x1b[?1006h")
+
           dashboard.onCancel = () => {
+            _tui.terminal.write("\x1b[?1000l\x1b[?1006l")
             done("Task Management dashboard closed.")
           }
+
+          dashboard.dispose = () => {
+            _tui.terminal.write("\x1b[?1000l\x1b[?1006l")
+          }
+
           return dashboard
         },
         { overlay: true, overlayOptions: { width: "90%", maxHeight: "90%" } }

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -986,12 +986,14 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
 
       return await ctx.ui.custom<string>(
         (_tui: any, _theme: any, _keybindings: any, done: (v: string) => void) => {
+          dashboard.tui = _tui
+          dashboard.theme = _theme
           dashboard.onCancel = () => {
             done("Task Management dashboard closed.")
           }
           return dashboard
         },
-        { overlay: true }
+        { overlay: true, overlayOptions: { width: "90%", maxHeight: "90%" } }
       )
     },
   })

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -987,7 +987,6 @@ Write your config to \`~/.pi/agent/models.json\` and restart Pi to apply.`
       return await ctx.ui.custom<string>(
         (_tui: any, _theme: any, _keybindings: any, done: (v: string) => void) => {
           dashboard.tui = _tui
-          dashboard.theme = _theme
           dashboard.onCancel = () => {
             done("Task Management dashboard closed.")
           }

--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -739,7 +739,14 @@ export default function (pi: any) {
     pi.registerCommand(command, {
       description,
       handler: async (args: unknown, ctx: any) => {
-        return await executePiCommand(command, skill, args, ctx)
+        const result = await executePiCommand(command, skill, args, ctx)
+        if (result) {
+          if (typeof ctx.sendUserMessage === "function") {
+            await ctx.sendUserMessage(result)
+          } else {
+            console.log(result)
+          }
+        }
       },
     })
   }

--- a/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
+++ b/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
@@ -130,21 +130,44 @@ export class TmDashboard extends Container implements Focusable {
   }
 
   render(width: number): string[] {
-    const leftWidth = Math.floor(width * 0.4)
-    const rightWidth = width - leftWidth - 1 // 1 for divider
+    const leftWidth = Math.floor(width * 0.4) - 1 // 1 for left border
+    const rightWidth = width - leftWidth - 3 // 3 total border lines
 
     const leftLines = this.renderLeftPane(leftWidth)
     const rightLines = this.renderRightPane(rightWidth)
 
-    const maxLines = Math.max(leftLines.length, rightLines.length)
+    const footerLines = this.state.error ? 4 : 2
+    // 4 static lines for borders: top, header, divider, bottom
+    const targetPaneLines = Math.max(1, this.getOverlayHeight() - footerLines - 4)
+    const maxLines = Math.max(leftLines.length, rightLines.length, targetPaneLines)
+
     const out: string[] = []
+
+    // Top border
+    out.push(`╭${"─".repeat(leftWidth)}┬${"─".repeat(rightWidth)}╮`)
+
+    // Headers
+    const lTitle = " 📋 Tasks "
+    const rTitle = " 📄 Details "
+    const lTitlePad = " ".repeat(Math.max(0, leftWidth - visibleWidth(lTitle)))
+    const rTitlePad = " ".repeat(Math.max(0, rightWidth - visibleWidth(rTitle)))
+    out.push(`│${lTitle}${lTitlePad}│${rTitle}${rTitlePad}│`)
+
+    // Divider
+    out.push(`├${"─".repeat(leftWidth)}┼${"─".repeat(rightWidth)}┤`)
+
     for (let i = 0; i < maxLines; i++) {
       const l = leftLines[i] || ""
       const r = rightLines[i] || ""
       const lLen = visibleWidth(l)
       const lPad = " ".repeat(Math.max(0, leftWidth - lLen))
-      out.push(`${l}${lPad}│ ${r}`)
+      const rLen = visibleWidth(r)
+      const rPad = " ".repeat(Math.max(0, rightWidth - rLen))
+      out.push(`│${l}${lPad}│${r}${rPad}│`)
     }
+
+    // Bottom border
+    out.push(`╰${"─".repeat(leftWidth)}┴${"─".repeat(rightWidth)}╯`)
 
     // Error / Help bar at bottom
     if (this.state.error) {
@@ -162,17 +185,15 @@ export class TmDashboard extends Container implements Focusable {
 
   private renderLeftPane(width: number): string[] {
     const lines: string[] = []
-    lines.push(truncateToWidth(" 📋 Tasks ", width))
-    lines.push("─".repeat(Math.min(width, visibleWidth(" 📋 Tasks "))))
 
     if (this.state.tasks.length === 0) {
-      lines.push("No tasks found.")
+      lines.push(" No tasks found.")
       return lines
     }
 
     const overlayHeight = this.getOverlayHeight()
     const footerLines = this.state.error ? 4 : 2 // global bottom bars
-    const staticLines = 2 // "Tasks" header + divider
+    const staticLines = 4 // top, header, divider, bottom
     const indicatorReserve = this.state.tasks.length > 1 ? 2 : 0
     const maxListLines = Math.max(1, overlayHeight - footerLines - staticLines - indicatorReserve)
 
@@ -190,19 +211,19 @@ export class TmDashboard extends Container implements Focusable {
     }
 
     if (startIdx > 0) {
-      lines.push(truncateToWidth("↑ ...", width))
+      lines.push(truncateToWidth(" ↑ ...", width))
     }
 
     for (let i = startIdx; i < endIdx; i++) {
       const task = this.state.tasks[i]!
       const icon = this.statusIcon(task.status)
-      const prefix = i === this.selectedIndex ? "❯ " : "  "
+      const prefix = i === this.selectedIndex ? " ❯ " : "   "
       const title = truncateToWidth(task.title, width - 4 - visibleWidth(icon))
       lines.push(truncateToWidth(`${prefix}${icon} ${title}`, width))
     }
 
     if (endIdx < this.state.tasks.length) {
-      lines.push(truncateToWidth("↓ ...", width))
+      lines.push(truncateToWidth(" ↓ ...", width))
     }
 
     return lines
@@ -210,35 +231,33 @@ export class TmDashboard extends Container implements Focusable {
 
   private renderRightPane(width: number): string[] {
     const lines: string[] = []
-    lines.push(truncateToWidth(" 📄 Details ", width))
-    lines.push("─".repeat(Math.min(width, visibleWidth(" 📄 Details "))))
 
     if (this.state.tasks.length === 0) {
-      lines.push("Select a task to view details.")
+      lines.push(" Select a task to view details.")
       return lines
     }
 
     const task = this.state.tasks[this.selectedIndex]
     if (!task) {
-      lines.push("Select a task to view details.")
+      lines.push(" Select a task to view details.")
       return lines
     }
 
-    lines.push(truncateToWidth(`ID:    ${task.id}`, width))
-    lines.push(truncateToWidth(`Title: ${task.title}`, width))
-    lines.push(truncateToWidth(`Type:  ${task.issue_type}`, width))
-    lines.push(truncateToWidth(`Status: ${task.status} ${this.statusIcon(task.status)}`, width))
-    lines.push(truncateToWidth(`Priority: P${task.priority}`, width))
+    lines.push(truncateToWidth(` ID:    ${task.id}`, width))
+    lines.push(truncateToWidth(` Title: ${task.title}`, width))
+    lines.push(truncateToWidth(` Type:  ${task.issue_type}`, width))
+    lines.push(truncateToWidth(` Status: ${task.status} ${this.statusIcon(task.status)}`, width))
+    lines.push(truncateToWidth(` Priority: P${task.priority}`, width))
     if (task.owner) {
-      lines.push(truncateToWidth(`Owner: ${task.owner}`, width))
+      lines.push(truncateToWidth(` Owner: ${task.owner}`, width))
     }
 
     lines.push("")
     if (this.showingActions) {
-      lines.push("─── Actions ───")
-      lines.push("[c] Claim task (set in_progress)")
-      lines.push("[x] Close task")
-      lines.push("[Esc] Back to list")
+      lines.push(" ─── Actions ───")
+      lines.push(" [c] Claim task (set in_progress)")
+      lines.push(" [x] Close task")
+      lines.push(" [Esc] Back to list")
     } else if (task.design) {
       const overlayHeight = this.getOverlayHeight()
       const footerLines = this.state.error ? 4 : 2
@@ -253,12 +272,12 @@ export class TmDashboard extends Container implements Focusable {
         designLines = this.mdCache.lines
       } else {
         const mdTheme = getMarkdownTheme()
-        const md = new Markdown(task.design, 0, 0, mdTheme)
+        const md = new Markdown(task.design, 1, 0, mdTheme)
         designLines = md.render(width)
         this.mdCache = { taskId: task.id, design: task.design, width, lines: designLines }
       }
 
-      const staticLines = lines.length + 1 // existing right-pane lines + "Design preview" line
+      const staticLines = 4 /* window borders */ + lines.length + 1 /* "Design preview" */
       const indicatorReserve = designLines.length > 0 ? 2 : 0
       const maxDesignLines = Math.max(1, overlayHeight - footerLines - staticLines - indicatorReserve)
 
@@ -269,13 +288,13 @@ export class TmDashboard extends Container implements Focusable {
 
       const preview = designLines.slice(offset, offset + maxDesignLines)
       
-      lines.push(truncateToWidth(`Design preview: (lines ${offset + 1}-${Math.min(designLines.length, offset + maxDesignLines)} of ${designLines.length})`, width))
-      if (offset > 0) lines.push(truncateToWidth("↑ ...", width))
+      lines.push(truncateToWidth(` Design preview: (lines ${offset + 1}-${Math.min(designLines.length, offset + maxDesignLines)} of ${designLines.length})`, width))
+      if (offset > 0) lines.push(truncateToWidth(" ↑ ...", width))
       for (const line of preview) {
         lines.push(truncateToWidth(line, width))
       }
       if (offset + maxDesignLines < designLines.length) {
-        lines.push(truncateToWidth("↓ ...", width))
+        lines.push(truncateToWidth(" ↓ ...", width))
       }
     }
 

--- a/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
+++ b/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
@@ -31,6 +31,11 @@ export class TmDashboard extends Container implements Focusable {
 
   private mdCache: { taskId: string; design: string; width: number; lines: string[] } | null = null
 
+  private viewMode: "list" | "kanban" = "list"
+  private kanbanActiveColumn: 0 | 1 | 2 = 0
+  private kanbanSelectedIndex: [number, number, number] = [0, 0, 0]
+  private kanbanTasks: [TmTask[], TmTask[], TmTask[]] = [[], [], []]
+
   // Used for disposing mouse tracking
   dispose?(): void
 
@@ -49,6 +54,27 @@ export class TmDashboard extends Container implements Focusable {
   constructor(initialState: TmDashboardState) {
     super()
     this.state = initialState
+    this.updateKanbanTasks()
+  }
+
+  private updateKanbanTasks() {
+    this.kanbanTasks = [[], [], []]
+    for (const task of this.state.tasks) {
+      if (task.status === "in_progress") {
+        this.kanbanTasks[1].push(task)
+      } else if (task.status === "done" || task.status === "closed") {
+        this.kanbanTasks[2].push(task)
+      } else {
+        this.kanbanTasks[0].push(task)
+      }
+    }
+    
+    // clamp selection
+    for (let i = 0; i < 3; i++) {
+      if (this.kanbanSelectedIndex[i] >= this.kanbanTasks[i]!.length) {
+        this.kanbanSelectedIndex[i] = Math.max(0, this.kanbanTasks[i]!.length - 1)
+      }
+    }
   }
 
   public updateState(newState: Partial<TmDashboardState>) {
@@ -58,18 +84,48 @@ export class TmDashboard extends Container implements Focusable {
     if (!hadTasks || this.state.tasks.length === 0) {
       this.selectedIndex = 0
       this.designScrollOffset = 0
+      this.kanbanSelectedIndex = [0, 0, 0]
     }
     // Clamp selection
     if (this.selectedIndex >= this.state.tasks.length) {
       this.selectedIndex = Math.max(0, this.state.tasks.length - 1)
       this.designScrollOffset = 0
     }
+    this.updateKanbanTasks()
     this.showingActions = false
     this.invalidate()
   }
 
   handleInput(data: string): boolean {
     const taskCount = this.state.tasks.length
+
+    if (data === "m") {
+      this.viewMode = this.viewMode === "list" ? "kanban" : "list"
+      if (this.viewMode === "kanban") {
+         const selectedTask = this.state.tasks[this.selectedIndex]
+         if (selectedTask) {
+           for (let i = 0; i < 3; i++) {
+             const idx = this.kanbanTasks[i]!.findIndex(t => t.id === selectedTask.id)
+             if (idx !== -1) {
+               this.kanbanActiveColumn = i as 0 | 1 | 2
+               this.kanbanSelectedIndex[i] = idx
+               break
+             }
+           }
+         }
+      } else {
+         const activeTask = this.kanbanTasks[this.kanbanActiveColumn]?.[this.kanbanSelectedIndex[this.kanbanActiveColumn]]
+         if (activeTask) {
+           const idx = this.state.tasks.findIndex(t => t.id === activeTask.id)
+           if (idx !== -1) {
+             this.selectedIndex = idx
+             this.designScrollOffset = 0
+           }
+         }
+      }
+      this.invalidate()
+      return true
+    }
 
     if (matchesKey(data, Key.escape) || data === "\x1b") {
       if (this.showingActions) {
@@ -130,11 +186,11 @@ export class TmDashboard extends Container implements Focusable {
 
     if (this.showingActions) {
       if (data === "c") {
-        const task = this.state.tasks[this.selectedIndex]
+        const task = this.viewMode === "list" ? this.state.tasks[this.selectedIndex] : this.kanbanTasks[this.kanbanActiveColumn]?.[this.kanbanSelectedIndex[this.kanbanActiveColumn]]
         if (task) this.onClaim?.(task.id)
         this.showingActions = false
       } else if (data === "x") {
-        const task = this.state.tasks[this.selectedIndex]
+        const task = this.viewMode === "list" ? this.state.tasks[this.selectedIndex] : this.kanbanTasks[this.kanbanActiveColumn]?.[this.kanbanSelectedIndex[this.kanbanActiveColumn]]
         if (task) this.onClose?.(task.id)
         this.showingActions = false
       }
@@ -142,35 +198,73 @@ export class TmDashboard extends Container implements Focusable {
       return true
     }
 
-    if (matchesKey(data, Key.up) && this.selectedIndex > 0) {
-      this.selectedIndex--
-      this.designScrollOffset = 0
-      this.invalidate()
-    } else if (matchesKey(data, Key.down) && this.selectedIndex < taskCount - 1) {
-      this.selectedIndex++
-      this.designScrollOffset = 0
-      this.invalidate()
-    } else if (matchesKey(data, Key.pageUp) || data === "k") {
-      this.designScrollOffset = Math.max(0, this.designScrollOffset - 1)
-      this.invalidate()
-    } else if (matchesKey(data, Key.pageDown) || data === "j") {
-      this.designScrollOffset += 1
-      this.invalidate()
-    } else if (matchesKey(data, Key.enter)) {
-      this.showingActions = true
-      this.invalidate()
-    } else if (matchesKey(data, Key.space)) {
-      const task = this.state.tasks[this.selectedIndex]
-      if (task) this.onClaim?.(task.id)
-    } else if (data === "r") {
-      this.onRefresh?.()
-    } else if (data === "q") {
-      this.onCancel?.()
+    if (this.viewMode === "list") {
+      if (matchesKey(data, Key.up) && this.selectedIndex > 0) {
+        this.selectedIndex--
+        this.designScrollOffset = 0
+        this.invalidate()
+      } else if (matchesKey(data, Key.down) && this.selectedIndex < taskCount - 1) {
+        this.selectedIndex++
+        this.designScrollOffset = 0
+        this.invalidate()
+      } else if (matchesKey(data, Key.pageUp) || data === "k") {
+        this.designScrollOffset = Math.max(0, this.designScrollOffset - 1)
+        this.invalidate()
+      } else if (matchesKey(data, Key.pageDown) || data === "j") {
+        this.designScrollOffset += 1
+        this.invalidate()
+      } else if (matchesKey(data, Key.enter)) {
+        this.showingActions = true
+        this.invalidate()
+      } else if (matchesKey(data, Key.space)) {
+        const task = this.state.tasks[this.selectedIndex]
+        if (task) this.onClaim?.(task.id)
+      } else if (data === "r") {
+        this.onRefresh?.()
+      } else if (data === "q") {
+        this.onCancel?.()
+      }
+    } else { // kanban mode
+      if (matchesKey(data, Key.left) && this.kanbanActiveColumn > 0) {
+        this.kanbanActiveColumn--
+        this.invalidate()
+      } else if (matchesKey(data, Key.right) && this.kanbanActiveColumn < 2) {
+        this.kanbanActiveColumn++
+        this.invalidate()
+      } else if (matchesKey(data, Key.up) && this.kanbanSelectedIndex[this.kanbanActiveColumn] > 0) {
+        this.kanbanSelectedIndex[this.kanbanActiveColumn]--
+        this.invalidate()
+      } else if (matchesKey(data, Key.down) && this.kanbanSelectedIndex[this.kanbanActiveColumn] < (this.kanbanTasks[this.kanbanActiveColumn]?.length || 0) - 1) {
+        this.kanbanSelectedIndex[this.kanbanActiveColumn]++
+        this.invalidate()
+      } else if (matchesKey(data, Key.enter)) {
+        const activeTask = this.kanbanTasks[this.kanbanActiveColumn]?.[this.kanbanSelectedIndex[this.kanbanActiveColumn]]
+        if (activeTask) {
+          const idx = this.state.tasks.findIndex(t => t.id === activeTask.id)
+          if (idx !== -1) {
+            this.selectedIndex = idx
+            this.viewMode = "list"
+            this.designScrollOffset = 0
+            this.invalidate()
+          }
+        }
+      } else if (matchesKey(data, Key.space)) {
+        const task = this.kanbanTasks[this.kanbanActiveColumn]?.[this.kanbanSelectedIndex[this.kanbanActiveColumn]]
+        if (task) this.onClaim?.(task.id)
+      } else if (data === "r") {
+        this.onRefresh?.()
+      } else if (data === "q") {
+        this.onCancel?.()
+      }
     }
     return true
   }
 
   render(width: number): string[] {
+    if (this.viewMode === "kanban") {
+      return this.renderKanbanView(width)
+    }
+
     const leftWidth = Math.floor(width * 0.4) - 1 // 1 for left border
     const rightWidth = width - leftWidth - 3 // 3 total border lines
 
@@ -218,7 +312,7 @@ export class TmDashboard extends Container implements Focusable {
     out.push("")
     const help = this.showingActions
       ? "[c] Claim  [x] Close  [Esc] Back"
-      : "[↑↓] Nav  [j/k] Scroll  [Enter] Actions  [Space] Claim  [r] Refresh  [q/Esc] Exit"
+      : "[m] Kanban  [↑↓] Nav  [j/k] Scroll  [Enter] Actions  [Space] Claim  [r] Refresh  [q/Esc] Exit"
     out.push(truncateToWidth(help, width))
 
     return out
@@ -337,6 +431,118 @@ export class TmDashboard extends Container implements Focusable {
       if (offset + maxDesignLines < designLines.length) {
         lines.push(truncateToWidth(" ↓ ...", width))
       }
+    }
+
+    return lines
+  }
+
+  private renderKanbanView(width: number): string[] {
+    const colWidth = Math.max(1, Math.floor(width / 3)) - 1 // 1 for border
+    const extraWidth = width - (colWidth + 1) * 3
+    const c1Width = colWidth + (extraWidth > 0 ? 1 : 0)
+    const c2Width = colWidth + (extraWidth > 1 ? 1 : 0)
+    const c3Width = Math.max(1, width - c1Width - c2Width - 4) // 4 borders: ╭ ┬ ┬ ╮
+
+    const footerLines = this.state.error ? 4 : 2
+    // 4 static lines for borders: top, header, divider, bottom
+    const targetPaneLines = Math.max(1, this.getOverlayHeight() - footerLines - 4)
+
+    const cols = [
+      this.renderKanbanColumn(0, c1Width, targetPaneLines),
+      this.renderKanbanColumn(1, c2Width, targetPaneLines),
+      this.renderKanbanColumn(2, c3Width, targetPaneLines),
+    ]
+
+    const maxLines = Math.max(cols[0]!.length, cols[1]!.length, cols[2]!.length, targetPaneLines)
+
+    const out: string[] = []
+
+    // Top border
+    out.push(`╭${"─".repeat(c1Width)}┬${"─".repeat(c2Width)}┬${"─".repeat(c3Width)}╮`)
+
+    // Headers
+    const t1 = truncateToWidth(" ⏳ Todo ", c1Width)
+    const t2 = truncateToWidth(" 🔄 In Progress ", c2Width)
+    const t3 = truncateToWidth(" ✅ Done ", c3Width)
+    const p1 = " ".repeat(Math.max(0, c1Width - visibleWidth(t1)))
+    const p2 = " ".repeat(Math.max(0, c2Width - visibleWidth(t2)))
+    const p3 = " ".repeat(Math.max(0, c3Width - visibleWidth(t3)))
+    
+    // Highlight active column header
+    const h1 = this.kanbanActiveColumn === 0 ? `\x1b[7m${t1}${p1}\x1b[27m` : `${t1}${p1}`
+    const h2 = this.kanbanActiveColumn === 1 ? `\x1b[7m${t2}${p2}\x1b[27m` : `${t2}${p2}`
+    const h3 = this.kanbanActiveColumn === 2 ? `\x1b[7m${t3}${p3}\x1b[27m` : `${t3}${p3}`
+    out.push(`│${h1}│${h2}│${h3}│`)
+
+    // Divider
+    out.push(`├${"─".repeat(c1Width)}┼${"─".repeat(c2Width)}┼${"─".repeat(c3Width)}┤`)
+
+    for (let i = 0; i < maxLines; i++) {
+      const l1 = cols[0]![i] || ""
+      const l2 = cols[1]![i] || ""
+      const l3 = cols[2]![i] || ""
+      const pad1 = " ".repeat(Math.max(0, c1Width - visibleWidth(l1)))
+      const pad2 = " ".repeat(Math.max(0, c2Width - visibleWidth(l2)))
+      const pad3 = " ".repeat(Math.max(0, c3Width - visibleWidth(l3)))
+      out.push(`│${l1}${pad1}│${l2}${pad2}│${l3}${pad3}│`)
+    }
+
+    // Bottom border
+    out.push(`╰${"─".repeat(c1Width)}┴${"─".repeat(c2Width)}┴${"─".repeat(c3Width)}╯`)
+
+    // Error / Help bar at bottom
+    if (this.state.error) {
+      out.push("")
+      out.push(truncateToWidth(`⚠️  ${this.state.error}`, width))
+    }
+    out.push("")
+    const help = this.showingActions
+      ? "[c] Claim  [x] Close  [Esc] Back"
+      : "[m] List View  [←→] Cols  [↑↓] Tasks  [Enter] Details  [Space] Claim  [r] Refresh  [q/Esc] Exit"
+    out.push(truncateToWidth(help, width))
+
+    return out
+  }
+
+  private renderKanbanColumn(colIdx: 0 | 1 | 2, width: number, targetLines: number): string[] {
+    const lines: string[] = []
+    const tasks = this.kanbanTasks[colIdx]!
+
+    if (tasks.length === 0) {
+      lines.push(" No tasks.")
+      return lines
+    }
+
+    const indicatorReserve = tasks.length > 1 ? 2 : 0
+    const maxListLines = Math.max(1, targetLines - indicatorReserve)
+
+    let startIdx = 0
+    let endIdx = tasks.length
+    const activeIdx = this.kanbanSelectedIndex[colIdx]
+
+    if (tasks.length > maxListLines) {
+      startIdx = Math.max(0, activeIdx - Math.floor(maxListLines / 2))
+      endIdx = Math.min(tasks.length, startIdx + maxListLines)
+
+      if (endIdx - startIdx < maxListLines) {
+        startIdx = Math.max(0, endIdx - maxListLines)
+      }
+    }
+
+    if (startIdx > 0) {
+      lines.push(truncateToWidth(" ↑ ...", width))
+    }
+
+    for (let i = startIdx; i < endIdx; i++) {
+      const task = tasks[i]!
+      const isActive = this.kanbanActiveColumn === colIdx && i === activeIdx
+      const prefix = isActive ? " ❯ " : "   "
+      const taskStr = truncateToWidth(`${prefix}${task.id} ${task.title}`, width)
+      lines.push(taskStr)
+    }
+
+    if (endIdx < tasks.length) {
+      lines.push(truncateToWidth(" ↓ ...", width))
     }
 
     return lines

--- a/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
+++ b/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
@@ -28,9 +28,8 @@ export class TmDashboard extends Container implements Focusable {
   public onCancel?: () => void
 
   public tui?: any
-  public theme?: any
 
-  private mdCache: { taskId: string; width: number; lines: string[] } | null = null
+  private mdCache: { taskId: string; design: string; width: number; lines: string[] } | null = null
 
   get focused(): boolean {
     return this._focused
@@ -167,7 +166,7 @@ export class TmDashboard extends Container implements Focusable {
     }
 
     const termHeight = this.tui?.terminal?.rows || 24
-    const maxListLines = Math.max(1, termHeight - 6) // Account for headers and footers
+    const maxListLines = Math.max(1, Math.floor(termHeight * 0.9) - 6) // Account for headers and footers
 
     let startIdx = 0
     let endIdx = this.state.tasks.length
@@ -175,7 +174,7 @@ export class TmDashboard extends Container implements Focusable {
     if (this.state.tasks.length > maxListLines) {
       startIdx = Math.max(0, this.selectedIndex - Math.floor(maxListLines / 2))
       endIdx = Math.min(this.state.tasks.length, startIdx + maxListLines)
-      
+
       // Adjust start if end hit the boundary
       if (endIdx - startIdx < maxListLines) {
         startIdx = Math.max(0, endIdx - maxListLines)
@@ -234,17 +233,22 @@ export class TmDashboard extends Container implements Focusable {
       lines.push("[Esc] Back to list")
     } else if (task.design) {
       const termHeight = this.tui?.terminal?.rows || 24
-      // Calculate available height for design: terminal height * 0.9 (overlay height) - approx 10 lines for header/footer and padding
+      // Calculate available height for design: terminal height * 0.9 (overlay height) - approx 14 lines for header/footer and padding
       const maxDesignLines = Math.max(1, Math.floor(termHeight * 0.9) - 14)
       
       let designLines: string[]
-      if (this.mdCache && this.mdCache.taskId === task.id && this.mdCache.width === width) {
+      if (
+        this.mdCache &&
+        this.mdCache.taskId === task.id &&
+        this.mdCache.width === width &&
+        this.mdCache.design === task.design
+      ) {
         designLines = this.mdCache.lines
       } else {
         const mdTheme = getMarkdownTheme()
         const md = new Markdown(task.design, 0, 0, mdTheme)
         designLines = md.render(width)
-        this.mdCache = { taskId: task.id, width, lines: designLines }
+        this.mdCache = { taskId: task.id, design: task.design, width, lines: designLines }
       }
 
       // Clamp scroll offset to not scroll completely past the content

--- a/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
+++ b/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
@@ -31,6 +31,9 @@ export class TmDashboard extends Container implements Focusable {
 
   private mdCache: { taskId: string; design: string; width: number; lines: string[] } | null = null
 
+  // Used for disposing mouse tracking
+  dispose?(): void
+
   private getOverlayHeight(): number {
     const rows = this.tui?.terminal?.rows ?? 24
     return Math.max(1, Math.floor(rows * 0.9))
@@ -75,6 +78,44 @@ export class TmDashboard extends Container implements Focusable {
         return true
       }
       this.onCancel?.()
+      return true
+    }
+
+    const mouseMatch = data.match(/^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/)
+    if (mouseMatch) {
+      const button = parseInt(mouseMatch[1]!, 10)
+      const x = parseInt(mouseMatch[2]!, 10)
+      const isRelease = mouseMatch[4] === "m"
+
+      if (!isRelease) {
+        // Scroll Up = 64, Scroll Down = 65
+        const isScrollUp = button === 64 || button === 64 + 32 // Some terminals add 32 for motion
+        const isScrollDown = button === 65 || button === 65 + 32
+        
+        if (button === 64 || button === 65) {
+          const termWidth = this.tui?.terminal?.columns || 80
+          // Overlay is 90% wide, centered. Left pane is 40% of overlay.
+          // That means left pane is roughly from 5% to 41% of the terminal width.
+          const isLeftPane = x <= Math.floor(termWidth * 0.45)
+          
+          if (isLeftPane) {
+            if (button === 64 && this.selectedIndex > 0) {
+              this.selectedIndex--
+              this.designScrollOffset = 0
+            } else if (button === 65 && this.selectedIndex < taskCount - 1) {
+              this.selectedIndex++
+              this.designScrollOffset = 0
+            }
+          } else {
+            if (button === 64) {
+              this.designScrollOffset = Math.max(0, this.designScrollOffset - 1)
+            } else if (button === 65) {
+              this.designScrollOffset += 1
+            }
+          }
+          this.invalidate()
+        }
+      }
       return true
     }
 

--- a/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
+++ b/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
@@ -5,7 +5,9 @@ import {
   type Focusable,
   truncateToWidth,
   visibleWidth,
+  Markdown,
 } from "@mariozechner/pi-tui"
+import { getMarkdownTheme } from "@mariozechner/pi-coding-agent"
 import type { TmTask } from "./tm-cli-wrapper"
 
 export interface TmDashboardState {
@@ -24,6 +26,11 @@ export class TmDashboard extends Container implements Focusable {
   public onClose?: (taskId: string) => void
   public onRefresh?: () => void
   public onCancel?: () => void
+
+  public tui?: any
+  public theme?: any
+
+  private mdCache: { taskId: string; width: number; lines: string[] } | null = null
 
   get focused(): boolean {
     return this._focused
@@ -70,6 +77,8 @@ export class TmDashboard extends Container implements Focusable {
     if (taskCount === 0) {
       if (data === "r") {
         this.onRefresh?.()
+      } else if (data === "q") {
+        this.onCancel?.()
       }
       return true
     }
@@ -97,10 +106,10 @@ export class TmDashboard extends Container implements Focusable {
       this.designScrollOffset = 0
       this.invalidate()
     } else if (matchesKey(data, Key.pageUp) || data === "k") {
-      this.designScrollOffset = Math.max(0, this.designScrollOffset - 5)
+      this.designScrollOffset = Math.max(0, this.designScrollOffset - 1)
       this.invalidate()
     } else if (matchesKey(data, Key.pageDown) || data === "j") {
-      this.designScrollOffset += 5
+      this.designScrollOffset += 1
       this.invalidate()
     } else if (matchesKey(data, Key.enter)) {
       this.showingActions = true
@@ -110,6 +119,8 @@ export class TmDashboard extends Container implements Focusable {
       if (task) this.onClaim?.(task.id)
     } else if (data === "r") {
       this.onRefresh?.()
+    } else if (data === "q") {
+      this.onCancel?.()
     }
     return true
   }
@@ -139,7 +150,7 @@ export class TmDashboard extends Container implements Focusable {
     out.push("")
     const help = this.showingActions
       ? "[c] Claim  [x] Close  [Esc] Back"
-      : "[↑↓] Nav  [j/k] Scroll  [Enter] Actions  [Space] Claim  [r] Refresh  [Esc] Exit"
+      : "[↑↓] Nav  [j/k] Scroll  [Enter] Actions  [Space] Claim  [r] Refresh  [q/Esc] Exit"
     out.push(truncateToWidth(help, width))
 
     return out
@@ -155,12 +166,36 @@ export class TmDashboard extends Container implements Focusable {
       return lines
     }
 
-    for (let i = 0; i < this.state.tasks.length; i++) {
+    const termHeight = this.tui?.terminal?.rows || 24
+    const maxListLines = Math.max(1, termHeight - 6) // Account for headers and footers
+
+    let startIdx = 0
+    let endIdx = this.state.tasks.length
+
+    if (this.state.tasks.length > maxListLines) {
+      startIdx = Math.max(0, this.selectedIndex - Math.floor(maxListLines / 2))
+      endIdx = Math.min(this.state.tasks.length, startIdx + maxListLines)
+      
+      // Adjust start if end hit the boundary
+      if (endIdx - startIdx < maxListLines) {
+        startIdx = Math.max(0, endIdx - maxListLines)
+      }
+    }
+
+    if (startIdx > 0) {
+      lines.push(truncateToWidth("↑ ...", width))
+    }
+
+    for (let i = startIdx; i < endIdx; i++) {
       const task = this.state.tasks[i]!
       const icon = this.statusIcon(task.status)
       const prefix = i === this.selectedIndex ? "❯ " : "  "
       const title = truncateToWidth(task.title, width - 4 - visibleWidth(icon))
       lines.push(truncateToWidth(`${prefix}${icon} ${title}`, width))
+    }
+
+    if (endIdx < this.state.tasks.length) {
+      lines.push(truncateToWidth("↓ ...", width))
     }
 
     return lines
@@ -198,8 +233,20 @@ export class TmDashboard extends Container implements Focusable {
       lines.push("[x] Close task")
       lines.push("[Esc] Back to list")
     } else if (task.design) {
-      const maxDesignLines = 25
-      const designLines = task.design.split("\n")
+      const termHeight = this.tui?.terminal?.rows || 24
+      // Calculate available height for design: terminal height * 0.9 (overlay height) - approx 10 lines for header/footer and padding
+      const maxDesignLines = Math.max(1, Math.floor(termHeight * 0.9) - 14)
+      
+      let designLines: string[]
+      if (this.mdCache && this.mdCache.taskId === task.id && this.mdCache.width === width) {
+        designLines = this.mdCache.lines
+      } else {
+        const mdTheme = getMarkdownTheme()
+        const md = new Markdown(task.design, 0, 0, mdTheme)
+        designLines = md.render(width)
+        this.mdCache = { taskId: task.id, width, lines: designLines }
+      }
+
       // Clamp scroll offset to not scroll completely past the content
       const maxScroll = Math.max(0, designLines.length - maxDesignLines)
       const offset = Math.min(this.designScrollOffset, maxScroll)

--- a/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
+++ b/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
@@ -31,6 +31,11 @@ export class TmDashboard extends Container implements Focusable {
 
   private mdCache: { taskId: string; design: string; width: number; lines: string[] } | null = null
 
+  private getOverlayHeight(): number {
+    const rows = this.tui?.terminal?.rows ?? 24
+    return Math.max(1, Math.floor(rows * 0.9))
+  }
+
   get focused(): boolean {
     return this._focused
   }
@@ -165,8 +170,11 @@ export class TmDashboard extends Container implements Focusable {
       return lines
     }
 
-    const termHeight = this.tui?.terminal?.rows || 24
-    const maxListLines = Math.max(1, Math.floor(termHeight * 0.9) - 6) // Account for headers and footers
+    const overlayHeight = this.getOverlayHeight()
+    const footerLines = this.state.error ? 4 : 2 // global bottom bars
+    const staticLines = 2 // "Tasks" header + divider
+    const indicatorReserve = this.state.tasks.length > 1 ? 2 : 0
+    const maxListLines = Math.max(1, overlayHeight - footerLines - staticLines - indicatorReserve)
 
     let startIdx = 0
     let endIdx = this.state.tasks.length
@@ -232,10 +240,9 @@ export class TmDashboard extends Container implements Focusable {
       lines.push("[x] Close task")
       lines.push("[Esc] Back to list")
     } else if (task.design) {
-      const termHeight = this.tui?.terminal?.rows || 24
-      // Calculate available height for design: terminal height * 0.9 (overlay height) - approx 14 lines for header/footer and padding
-      const maxDesignLines = Math.max(1, Math.floor(termHeight * 0.9) - 14)
-      
+      const overlayHeight = this.getOverlayHeight()
+      const footerLines = this.state.error ? 4 : 2
+
       let designLines: string[]
       if (
         this.mdCache &&
@@ -250,6 +257,10 @@ export class TmDashboard extends Container implements Focusable {
         designLines = md.render(width)
         this.mdCache = { taskId: task.id, design: task.design, width, lines: designLines }
       }
+
+      const staticLines = lines.length + 1 // existing right-pane lines + "Design preview" line
+      const indicatorReserve = designLines.length > 0 ? 2 : 0
+      const maxDesignLines = Math.max(1, overlayHeight - footerLines - staticLines - indicatorReserve)
 
       // Clamp scroll offset to not scroll completely past the content
       const maxScroll = Math.max(0, designLines.length - maxDesignLines)

--- a/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
+++ b/.pi/extensions/hyperpowers/tm-dashboard-tui.ts
@@ -147,8 +147,8 @@ export class TmDashboard extends Container implements Focusable {
     out.push(`╭${"─".repeat(leftWidth)}┬${"─".repeat(rightWidth)}╮`)
 
     // Headers
-    const lTitle = " 📋 Tasks "
-    const rTitle = " 📄 Details "
+    const lTitle = truncateToWidth(" 📋 Tasks ", leftWidth)
+    const rTitle = truncateToWidth(" 📄 Details ", rightWidth)
     const lTitlePad = " ".repeat(Math.max(0, leftWidth - visibleWidth(lTitle)))
     const rTitlePad = " ".repeat(Math.max(0, rightWidth - visibleWidth(rTitle)))
     out.push(`│${lTitle}${lTitlePad}│${rTitle}${rTitlePad}│`)

--- a/hooks/block-beads-direct-read.py
+++ b/hooks/block-beads-direct-read.py
@@ -19,6 +19,10 @@ TRUNCATION_MARKERS = (
 
 def has_truncation_marker(value):
     """Return True when hook input appears truncated."""
+    if isinstance(value, dict):
+        value = str(value)
+    elif not isinstance(value, str):
+        return False
     return any(marker in value.lower() for marker in TRUNCATION_MARKERS)
 
 

--- a/hooks/post-tool-use/02-block-bd-truncation.py
+++ b/hooks/post-tool-use/02-block-bd-truncation.py
@@ -15,6 +15,10 @@ TRUNCATION_MARKERS = (
 
 def has_truncation_marker(value):
     """Return True when hook input appears truncated."""
+    if isinstance(value, dict):
+        value = str(value)
+    elif not isinstance(value, str):
+        return False
     return any(marker in value.lower() for marker in TRUNCATION_MARKERS)
 
 

--- a/hooks/post-tool-use/03-block-pre-commit-bash.py
+++ b/hooks/post-tool-use/03-block-pre-commit-bash.py
@@ -99,6 +99,10 @@ TRUNCATION_MARKERS = (
 
 def has_truncation_marker(value):
     """Return True when hook input appears truncated."""
+    if isinstance(value, dict):
+        value = str(value)
+    elif not isinstance(value, str):
+        return False
     return any(marker in value.lower() for marker in TRUNCATION_MARKERS)
 
 

--- a/hooks/post-tool-use/04-block-pre-existing-checks.py
+++ b/hooks/post-tool-use/04-block-pre-existing-checks.py
@@ -37,6 +37,10 @@ TRUNCATION_MARKERS = (
 
 def has_truncation_marker(value):
     """Return True when hook input appears truncated."""
+    if isinstance(value, dict):
+        value = str(value)
+    elif not isinstance(value, str):
+        return False
     return any(marker in value.lower() for marker in TRUNCATION_MARKERS)
 
 

--- a/hooks/pre-tool-use/01-block-pre-commit-edits.py
+++ b/hooks/pre-tool-use/01-block-pre-commit-edits.py
@@ -16,6 +16,10 @@ TRUNCATION_MARKERS = (
 
 def has_truncation_marker(value):
     """Return True when hook input appears truncated."""
+    if isinstance(value, dict):
+        value = str(value)
+    elif not isinstance(value, str):
+        return False
     return any(marker in value.lower() for marker in TRUNCATION_MARKERS)
 
 

--- a/hooks/pre-tool-use/block-dangerous-bash.py
+++ b/hooks/pre-tool-use/block-dangerous-bash.py
@@ -38,6 +38,10 @@ TRUNCATION_MARKERS = (
 
 def has_truncation_marker(value):
     """Return True when hook input appears truncated."""
+    if isinstance(value, dict):
+        value = str(value)
+    elif not isinstance(value, str):
+        return False
     return any(marker in value.lower() for marker in TRUNCATION_MARKERS)
 
 

--- a/hooks/pre-tool-use/block-env-writes.py
+++ b/hooks/pre-tool-use/block-env-writes.py
@@ -19,6 +19,10 @@ TRUNCATION_MARKERS = (
 
 def has_truncation_marker(value):
     """Return True when hook input appears truncated."""
+    if isinstance(value, dict):
+        value = str(value)
+    elif not isinstance(value, str):
+        return False
     return any(marker in value.lower() for marker in TRUNCATION_MARKERS)
 
 

--- a/tests/tm-dashboard-tui.test.ts
+++ b/tests/tm-dashboard-tui.test.ts
@@ -34,7 +34,7 @@ test("first task is selected by default", () => {
   ]))
   const lines = dashboard.render(80)
   // First task should have ❯ prefix, second should have spaces
-  const leftPane = lines.map(l => l.split("│")[0] || "")
+  const leftPane = lines.map(l => l.split("│")[1] || "")
   expect(leftPane.some(l => l.includes("❯") && l.includes("Fix auth"))).toBe(true)
   expect(leftPane.some(l => l.includes("  ") && l.includes("Add tests"))).toBe(true)
 })
@@ -49,7 +49,7 @@ test("arrow down moves selection", () => {
   dashboard.handleInput("\x1b[B")
 
   const lines = dashboard.render(80)
-  const leftPane = lines.map(l => l.split("│")[0] || "")
+  const leftPane = lines.map(l => l.split("│")[1] || "")
   expect(leftPane.some(l => l.includes("  ") && l.includes("Fix auth"))).toBe(true)
   expect(leftPane.some(l => l.includes("❯") && l.includes("Add tests"))).toBe(true)
 })
@@ -64,7 +64,7 @@ test("arrow up moves selection back", () => {
   dashboard.handleInput("\x1b[A") // up
 
   const lines = dashboard.render(80)
-  const leftPane = lines.map(l => l.split("│")[0] || "")
+  const leftPane = lines.map(l => l.split("│")[1] || "")
   expect(leftPane.some(l => l.includes("❯") && l.includes("Fix auth"))).toBe(true)
 })
 
@@ -143,7 +143,7 @@ test("updateState resets selection when tasks change", () => {
   dashboard.updateState({ tasks: [{ id: "bd-3", title: "New task", status: "open", priority: 2, issue_type: "feature" }] })
 
   const lines = dashboard.render(80)
-  const leftPane = lines.map(l => l.split("│")[0] || "")
+  const leftPane = lines.map(l => l.split("│")[1] || "")
   expect(leftPane.some(l => l.includes("❯") && l.includes("New task"))).toBe(true)
 })
 
@@ -211,14 +211,14 @@ test("j/k and PageDown/PageUp scroll design preview", () => {
 
   let lines = dashboard.render(80).join("\n")
   expect(lines).toContain("Line 1")
-  expect(lines).toContain("Line 8")
-  expect(lines).not.toContain("Line 9")
+  expect(lines).toContain("Line 6")
+  expect(lines).not.toContain("Line 7")
 
   dashboard.handleInput("j")
   lines = dashboard.render(80).join("\n")
   expect(lines).not.toContain("Line 1 ")
   expect(lines).toContain("Line 2 ")
-  expect(lines).toContain("Line 9 ")
+  expect(lines).toContain("Line 7 ")
 
   dashboard.handleInput("k")
   lines = dashboard.render(80).join("\n")
@@ -228,7 +228,7 @@ test("j/k and PageDown/PageUp scroll design preview", () => {
   lines = dashboard.render(80).join("\n")
   expect(lines).not.toContain("Line 1 ")
   expect(lines).toContain("Line 2 ")
-  expect(lines).toContain("Line 9 ")
+  expect(lines).toContain("Line 7 ")
 
   dashboard.handleInput("\x1b[5~") // PageUp
   lines = dashboard.render(80).join("\n")

--- a/tests/tm-dashboard-tui.test.ts
+++ b/tests/tm-dashboard-tui.test.ts
@@ -211,14 +211,14 @@ test("j/k and PageDown/PageUp scroll design preview", () => {
 
   let lines = dashboard.render(80).join("\n")
   expect(lines).toContain("Line 1")
-  expect(lines).toContain("Line 7")
-  expect(lines).not.toContain("Line 8")
+  expect(lines).toContain("Line 8")
+  expect(lines).not.toContain("Line 9")
 
   dashboard.handleInput("j")
   lines = dashboard.render(80).join("\n")
   expect(lines).not.toContain("Line 1 ")
   expect(lines).toContain("Line 2 ")
-  expect(lines).toContain("Line 8 ")
+  expect(lines).toContain("Line 9 ")
 
   dashboard.handleInput("k")
   lines = dashboard.render(80).join("\n")
@@ -228,7 +228,7 @@ test("j/k and PageDown/PageUp scroll design preview", () => {
   lines = dashboard.render(80).join("\n")
   expect(lines).not.toContain("Line 1 ")
   expect(lines).toContain("Line 2 ")
-  expect(lines).toContain("Line 8 ")
+  expect(lines).toContain("Line 9 ")
 
   dashboard.handleInput("\x1b[5~") // PageUp
   lines = dashboard.render(80).join("\n")

--- a/tests/tm-dashboard-tui.test.ts
+++ b/tests/tm-dashboard-tui.test.ts
@@ -234,3 +234,52 @@ test("j/k and PageDown/PageUp scroll design preview", () => {
   lines = dashboard.render(80).join("\n")
   expect(lines).toContain("Line 1 ")
 })
+
+test("mouse wheel scrolls left pane", () => {
+  const dashboard = new TmDashboard(makeState(
+    Array.from({ length: 50 }, (_, i) => ({
+      id: `bd-${i}`,
+      title: `Task ${i}`,
+      status: "open",
+      priority: 1,
+      issue_type: "task"
+    }))
+  ))
+  
+  // Set terminal columns explicitly so pane boundary is predictable
+  dashboard.tui = { terminal: { columns: 80, rows: 24 } }
+  
+  // Mouse scroll down (65) in left pane (x=10)
+  dashboard.handleInput("\x1b[<65;10;10M")
+  
+  const lines = dashboard.render(80)
+  const leftPane = lines.map(l => l.split("│")[1] || "")
+  // First task should not be selected anymore, it should be the second
+  expect(leftPane.some(l => l.includes("❯") && l.includes("Task 1"))).toBe(true)
+  
+  // Mouse scroll up (64) in left pane (x=10)
+  dashboard.handleInput("\x1b[<64;10;10M")
+  const linesUp = dashboard.render(80)
+  const leftPaneUp = linesUp.map(l => l.split("│")[1] || "")
+  expect(leftPaneUp.some(l => l.includes("❯") && l.includes("Task 0"))).toBe(true)
+})
+
+test("mouse wheel scrolls right pane details", () => {
+  const longDesign = Array.from({ length: 50 }, (_, i) => `Line ${i + 1}`).join("\n")
+  const dashboard = new TmDashboard(makeState([
+    { id: "bd-1", title: "Fix auth", status: "open", priority: 0, issue_type: "bug", design: longDesign },
+  ]))
+  
+  dashboard.tui = { terminal: { columns: 80, rows: 24 } }
+  
+  // Mouse scroll down (65) in right pane (x=50)
+  dashboard.handleInput("\x1b[<65;50;10M")
+  
+  let lines = dashboard.render(80).join("\n")
+  expect(lines).toContain("Line 2 ")
+  
+  // Mouse scroll up (64) in right pane (x=50)
+  dashboard.handleInput("\x1b[<64;50;10M")
+  lines = dashboard.render(80).join("\n")
+  expect(lines).toContain("Line 1 ")
+})

--- a/tests/tm-dashboard-tui.test.ts
+++ b/tests/tm-dashboard-tui.test.ts
@@ -264,22 +264,52 @@ test("mouse wheel scrolls left pane", () => {
   expect(leftPaneUp.some(l => l.includes("❯") && l.includes("Task 0"))).toBe(true)
 })
 
-test("mouse wheel scrolls right pane details", () => {
-  const longDesign = Array.from({ length: 50 }, (_, i) => `Line ${i + 1}`).join("\n")
+test("kanban mode toggles on m key and renders 3 columns", () => {
   const dashboard = new TmDashboard(makeState([
-    { id: "bd-1", title: "Fix auth", status: "open", priority: 0, issue_type: "bug", design: longDesign },
+    { id: "bd-1", title: "Task 1", status: "todo", priority: 1, issue_type: "task" },
+    { id: "bd-2", title: "Task 2", status: "in_progress", priority: 1, issue_type: "task" },
+    { id: "bd-3", title: "Task 3", status: "done", priority: 1, issue_type: "task" },
   ]))
   
-  dashboard.tui = { terminal: { columns: 80, rows: 24 } }
+  // Toggle to kanban
+  dashboard.handleInput("m")
+  const lines = dashboard.render(80).join("\n")
   
-  // Mouse scroll down (65) in right pane (x=50)
-  dashboard.handleInput("\x1b[<65;50;10M")
+  // Should have 3 columns
+  expect(lines).toContain("⏳ Todo")
+  expect(lines).toContain("🔄 In Progress")
+  expect(lines).toContain("✅ Done")
   
+  // Tasks should be sorted into the columns (all 3 should be visible on screen)
+  expect(lines).toContain("Task 1")
+  expect(lines).toContain("Task 2")
+  expect(lines).toContain("Task 3")
+})
+
+test("kanban mode navigation", () => {
+  const dashboard = new TmDashboard(makeState([
+    { id: "bd-1", title: "Task 1", status: "todo", priority: 1, issue_type: "task" },
+    { id: "bd-2", title: "Task 2", status: "todo", priority: 1, issue_type: "task" },
+    { id: "bd-3", title: "Task 3", status: "in_progress", priority: 1, issue_type: "task" },
+  ]))
+  
+  dashboard.handleInput("m")
+  
+  // By default, active column is 0, task 0 selected. Press down to select task 1 in column 0
+  dashboard.handleInput("\x1b[B") // down
   let lines = dashboard.render(80).join("\n")
-  expect(lines).toContain("Line 2 ")
+  expect(lines).toContain("❯ bd-2 Task 2")
   
-  // Mouse scroll up (64) in right pane (x=50)
-  dashboard.handleInput("\x1b[<64;50;10M")
+  // Right to move to column 1
+  dashboard.handleInput("\x1b[C") // right
   lines = dashboard.render(80).join("\n")
-  expect(lines).toContain("Line 1 ")
+  // Now column 1 header should be highlighted (inverse) and its task selected
+  expect(lines).toContain("\x1b[7m 🔄 In Progress")
+  expect(lines).toContain("❯ bd-3 Task 3")
+  
+  // Enter should switch back to list mode with the selected task
+  dashboard.handleInput("\r")
+  lines = dashboard.render(80).join("\n")
+  expect(lines).toContain(" 📄 Details ")
+  expect(lines).toContain("ID:    bd-3")
 })

--- a/tests/tm-dashboard-tui.test.ts
+++ b/tests/tm-dashboard-tui.test.ts
@@ -116,6 +116,16 @@ test("escape triggers onCancel callback", () => {
   expect(cancelled).toBe(true)
 })
 
+test("q key triggers onCancel callback", () => {
+  let cancelled = false
+  const dashboard = new TmDashboard(makeState([]))
+  dashboard.onCancel = () => { cancelled = true }
+
+  dashboard.handleInput("q")
+
+  expect(cancelled).toBe(true)
+})
+
 test("displays error bar when error is set", () => {
   const dashboard = new TmDashboard(makeState([], "tm binary not found"))
   const lines = dashboard.render(80)
@@ -201,17 +211,16 @@ test("j/k and PageDown/PageUp scroll design preview", () => {
 
   let lines = dashboard.render(80).join("\n")
   expect(lines).toContain("Line 1")
-  expect(lines).toContain("Line 25")
-  expect(lines).not.toContain("Line 26")
+  expect(lines).toContain("Line 7")
+  expect(lines).not.toContain("Line 8")
 
   dashboard.handleInput("j")
   lines = dashboard.render(80).join("\n")
-  expect(lines).not.toContain("│ Line 1\n")
-  expect(lines).toContain("Line 6")
-  expect(lines).toContain("Line 30")
+  expect(lines).not.toContain("Line 1 ")
+  expect(lines).toContain("Line 2 ")
+  expect(lines).toContain("Line 8 ")
 
-  // Using PageDown key sequence (mocked if needed, but j/k is what we mostly use, let's just use j/k here since handleInput handles matchesKey or string)
   dashboard.handleInput("k")
   lines = dashboard.render(80).join("\n")
-  expect(lines).toContain("│ Line 1\n")
+  expect(lines).toContain("Line 1 ")
 })

--- a/tests/tm-dashboard-tui.test.ts
+++ b/tests/tm-dashboard-tui.test.ts
@@ -223,4 +223,14 @@ test("j/k and PageDown/PageUp scroll design preview", () => {
   dashboard.handleInput("k")
   lines = dashboard.render(80).join("\n")
   expect(lines).toContain("Line 1 ")
+
+  dashboard.handleInput("\x1b[6~") // PageDown
+  lines = dashboard.render(80).join("\n")
+  expect(lines).not.toContain("Line 1 ")
+  expect(lines).toContain("Line 2 ")
+  expect(lines).toContain("Line 8 ")
+
+  dashboard.handleInput("\x1b[5~") // PageUp
+  lines = dashboard.render(80).join("\n")
+  expect(lines).toContain("Line 1 ")
 })


### PR DESCRIPTION
Pi's extension API recently tightened to ignore return values from command handlers (they now expect Promise<void>). This meant that commands like /execute-ralph or /execute-plan, which previously returned the generated prompt string, were doing absolutely nothing.

This commit explicitly captures the generated prompt string and calls ctx.sendUserMessage(result) so it is injected into the session to trigger the LLM as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kanban view mode to the task dashboard—organize tasks by status in three columns with arrow-key navigation.
  * Added mouse wheel scrolling support for task lists and preview content.
  * Slash-command results now deliver directly to users via messages.

* **Bug Fixes**
  * Improved robustness of truncation detection handling across components.

* **Tests**
  * Expanded test coverage for Kanban mode, mouse interactions, and scrolling features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->