### PR TITLE
fix: ensure Ralph session deletes state and triggers abort properly without overlay handle

### DIFF
--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -782,9 +782,16 @@ export default function (pi: any) {
           ...stateUpdate
         }, () => {
           const currSession = ralphSessions.get(sessionKey)
-          if (currSession && currSession.handle) {
-            currSession.handle.close?.()
+          if (currSession) {
+            currSession.handle?.close?.()
             ralphSessions.delete(sessionKey)
+            
+            // Abort the pi host execution so the LLM workflow halts
+            if (typeof ctx?.abort === "function") {
+              ctx.abort()
+            } else if (typeof ctx?.ui?.cancel === "function") {
+              ctx.ui.cancel()
+            }
           }
         })
         dashboard.tui = ctx.ui.tui // try to grab tui reference if available
@@ -808,8 +815,8 @@ export default function (pi: any) {
         session.closeTimer = setTimeout(() => {
           const currSession = ralphSessions.get(sessionKey)
           // only close if the timer hasn't been replaced or cleared
-          if (currSession === session && currSession.handle) {
-            currSession.handle.close?.()
+          if (currSession === session) {
+            currSession.handle?.close?.()
             ralphSessions.delete(sessionKey)
           }
         }, 2000)


### PR DESCRIPTION
## Summary
Fixes two unresolved comments from PR #40:
1. Delete Ralph session state even without an overlay handle (fixes the timeout state deletion condition).
2. Abort Ralph run when dashboard cancel is triggered (triggers `ctx.abort()` or `ctx.ui.cancel()`).

These changes were originally pushed locally but omitted from the squash-merge of the previous PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Ralph dashboard session cleanup to properly terminate active processes and TUI handles when sessions complete, with improved error handling for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->