### PR TITLE
fix: ensure Ralph session closeTimer is explicitly cleared before abort

### DIFF
--- a/.pi/extensions/hyperpowers/index.ts
+++ b/.pi/extensions/hyperpowers/index.ts
@@ -783,9 +783,13 @@ export default function (pi: any) {
         }, () => {
           const currSession = ralphSessions.get(sessionKey)
           if (currSession) {
+            if (currSession.closeTimer) {
+              clearTimeout(currSession.closeTimer)
+              currSession.closeTimer = undefined
+            }
             currSession.handle?.close?.()
             ralphSessions.delete(sessionKey)
-            
+
             // Abort the pi host execution so the LLM workflow halts
             if (typeof ctx?.abort === "function") {
               ctx.abort()


### PR DESCRIPTION
## Summary
Fixes unresolved comments from PR #41:
1. The cancel callback deletes the session but doesn't clear any pending `closeTimer` on that session. Consider clearing `currSession.closeTimer`.
2. Removed trailing whitespace.