### PR TITLE
fix: text fallback parser enhancements

### DIFF
--- a/.pi/extensions/hyperpowers/tm-cli-wrapper.ts
+++ b/.pi/extensions/hyperpowers/tm-cli-wrapper.ts
@@ -96,12 +96,14 @@ function runTmJson<T>(
           // Clean typical tm output decorators
           const cleanLine = line.replace(/^[○◐●✓❄]\s+/, "")
           
-          // Match standard ID (e.g. bd-42, ENG-123) and title
-          const match = cleanLine.match(/^([a-zA-Z0-9-]+)\s+(.+)$/)
-          if (!match) return null
+          // Reject matches that are obviously not IDs (like summary or decorative lines)
+          if (cleanLine.startsWith("Total:") || cleanLine.startsWith("Status:") || cleanLine.startsWith("-")) {
+            return null
+          }
 
-          // Reject matches that are obviously not IDs (like "Total:")
-          if (match[1] === "Total:" || match[1] === "Status:") return null
+          // Match standard ID (e.g. bd-42, ENG_CORE-123) and title
+          const match = cleanLine.match(/^([a-zA-Z0-9-_]+)\s+(.+)$/)
+          if (!match) return null
 
           return {
             id: match[1]!,

--- a/tests/tm-cli-wrapper.test.ts
+++ b/tests/tm-cli-wrapper.test.ts
@@ -152,17 +152,23 @@ test("getReadyTasks returns empty array for empty text fallback output", () => {
 test("getReadyTasks returns text fallback on invalid JSON", () => {
   mockSpawnSync.mockImplementation(() => ({
     status: 0,
-    stdout: "ENG-123 Some Task",
+    stdout: `○ ENG_CORE-123 Some Task
+--------------------------------------------------------------------------------
+Total: 4 issues (4 open, 0 in progress)
+
+Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred`,
     stderr: "",
     error: undefined,
     signal: null,
   }))
 
   const result = getReadyTasks("/tmp/project")
+  if (!result.ok) console.error(result.error)
   expect(result.ok).toBe(true)
-  expect((result.data as any)[0].id).toBe("ENG-123")
+  expect((result.data as any)[0].id).toBe("ENG_CORE-123")
   expect((result.data as any)[0].title).toBe("Some Task")
   expect((result.data as any)[0].status).toBe("ready")
+  expect((result.data as any).length).toBe(1)
 })
 
 test("getAssignedTasks returns text fallback on invalid JSON using status from arguments", () => {


### PR DESCRIPTION
Fixes PR 38 unresolved comments: Allow underscores in text-fallback task IDs, remove trailing whitespace, and explicitly filter out diagnostic/summary rows instead of relying on regex mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated task list parsing tests with more realistic multi-line output scenarios.

* **Refactor**
  * Improved task ID parsing logic to handle more ID format variations and filter irrelevant output lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->