### PR TITLE
fix: correct regex for Linear IDs with underscores in text fallback

### DIFF
--- a/.pi/extensions/hyperpowers/tm-cli-wrapper.ts
+++ b/.pi/extensions/hyperpowers/tm-cli-wrapper.ts
@@ -102,7 +102,7 @@ function runTmJson<T>(
           }
 
           // Match standard ID (e.g. bd-42, ENG_CORE-123) and title
-          const match = cleanLine.match(/^([a-zA-Z0-9-_]+)\s+(.+)$/)
+          const match = cleanLine.match(/^([a-zA-Z0-9_-]+)\s+(.+)$/)
           if (!match) return null
 
           return {


### PR DESCRIPTION
Fixes the regex pattern to correctly allow underscores in Linear ticket IDs (e.g. ENG_CORE-123) during text fallback parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task ID parsing to properly recognize underscores in task identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->