### PR TITLE
fix: convert agent tools/disallowedTools from arrays to objects

### DIFF
--- a/.gemini-extension/agents/code-reviewer.md
+++ b/.gemini-extension/agents/code-reviewer.md
@@ -1,6 +1,8 @@
 ---
+
 name: code-reviewer
-description: Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
+description: >
+  Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-5)
@@ -8,7 +10,9 @@ description: Human-facing code reviewer for major milestones. Provides detailed 
 # Recommended: Capable model (sonnet, glm-4.7) for complex reasoning and analysis
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/codebase-investigator.md
+++ b/.gemini-extension/agents/codebase-investigator.md
@@ -1,8 +1,12 @@
 ---
+
 name: codebase-investigator
-description: Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/devops.md
+++ b/.gemini-extension/agents/devops.md
@@ -1,16 +1,19 @@
 ---
+
 name: devops
 description: DevOps reviewer - analyzes CI/CD pipelines, pre-commit hooks, build configurations, and diagnoses pipeline failures. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/internet-researcher.md
+++ b/.gemini-extension/agents/internet-researcher.md
@@ -1,8 +1,12 @@
 ---
+
 name: internet-researcher
-description: Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/knowledge-aggregator.md
+++ b/.gemini-extension/agents/knowledge-aggregator.md
@@ -1,6 +1,8 @@
 ---
+
 name: knowledge-aggregator
-description: Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
+description: >
+  Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-6)
@@ -9,14 +11,16 @@ description: Use this agent when you need to aggregate context from project docu
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/planner.md
+++ b/.gemini-extension/agents/planner.md
@@ -1,6 +1,8 @@
 ---
+
 name: planner
-description: Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-opus-4-6)
@@ -9,15 +11,17 @@ description: Use this agent when planning or designing features and you need to 
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/ralph.md
+++ b/.gemini-extension/agents/ralph.md
@@ -1,11 +1,15 @@
 ---
+
 name: ralph
-description: YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
+description: >
+  YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # Ralph should inherit the parent model since it orchestrates other agents
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/review-documentation.md
+++ b/.gemini-extension/agents/review-documentation.md
@@ -1,16 +1,19 @@
 ---
+
 name: review-documentation
 description: Documentation reviewer - checks if docs need updates for API changes, new features, config changes. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/review-implementation.md
+++ b/.gemini-extension/agents/review-implementation.md
@@ -1,16 +1,20 @@
 ---
+
 name: review-implementation
-description: Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
+description: >
+  Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/review-quality.md
+++ b/.gemini-extension/agents/review-quality.md
@@ -1,16 +1,19 @@
 ---
+
 name: review-quality
 description: Quality reviewer - finds bugs, race conditions, error handling gaps, resource leaks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/review-simplification.md
+++ b/.gemini-extension/agents/review-simplification.md
@@ -1,16 +1,19 @@
 ---
+
 name: review-simplification
 description: Simplification reviewer - detects over-engineering, unnecessary complexity, premature abstractions. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/review-testing.md
+++ b/.gemini-extension/agents/review-testing.md
@@ -1,16 +1,19 @@
 ---
+
 name: review-testing
 description: Testing reviewer - evaluates test coverage, test quality, and testing gaps. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/security-scanner.md
+++ b/.gemini-extension/agents/security-scanner.md
@@ -1,16 +1,19 @@
 ---
+
 name: security-scanner
 description: Security scanner - performs OWASP Top 10 scanning, secrets detection, and dependency vulnerability checks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/test-effectiveness-analyst.md
+++ b/.gemini-extension/agents/test-effectiveness-analyst.md
@@ -1,7 +1,11 @@
 ---
+
 name: test-effectiveness-analyst
-description: Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+description: >
+  Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/agents/test-runner.md
+++ b/.gemini-extension/agents/test-runner.md
@@ -1,6 +1,8 @@
 ---
+
 name: test-runner
-description: Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
+description: >
+  Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-haiku-4-5)
@@ -8,7 +10,9 @@ description: Use this agent to run tests, pre-commit hooks, or commits without p
 # Recommended: Fast model (haiku, glm-4.5) for high-volume, low-complexity tasks
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.gemini-extension/mcp/agents-server.js
+++ b/.gemini-extension/mcp/agents-server.js
@@ -61,19 +61,14 @@ function parseFrontmatter(content) {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return null;
   
-  const frontmatter = {};
-  const lines = match[1].split('\n');
-  
-  for (const line of lines) {
-    const colonIndex = line.indexOf(':');
-    if (colonIndex > 0) {
-      const key = line.slice(0, colonIndex).trim();
-      const value = line.slice(colonIndex + 1).trim();
-      frontmatter[key] = value;
-    }
+  // Use js-yaml to handle folded block scalars and full YAML objects
+  const jsYaml = require("js-yaml");
+  try {
+    return jsYaml.load(match[1]) || {};
+  } catch (e) {
+    console.error("Warning: invalid frontmatter YAML", e.message);
+    return {};
   }
-  
-  return frontmatter;
 }
 
 /**

--- a/.kimi/agents/code-reviewer-system.md
+++ b/.kimi/agents/code-reviewer-system.md
@@ -1,6 +1,8 @@
 ---
+
 name: code-reviewer
-description: Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
+description: >
+  Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-5)
@@ -8,7 +10,9 @@ description: Human-facing code reviewer for major milestones. Provides detailed 
 # Recommended: Capable model (sonnet, glm-4.7) for complex reasoning and analysis
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/codebase-investigator-system.md
+++ b/.kimi/agents/codebase-investigator-system.md
@@ -1,8 +1,12 @@
 ---
+
 name: codebase-investigator
-description: Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/devops-system.md
+++ b/.kimi/agents/devops-system.md
@@ -1,16 +1,19 @@
 ---
+
 name: devops
 description: DevOps reviewer - analyzes CI/CD pipelines, pre-commit hooks, build configurations, and diagnoses pipeline failures. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/internet-researcher-system.md
+++ b/.kimi/agents/internet-researcher-system.md
@@ -1,8 +1,12 @@
 ---
+
 name: internet-researcher
-description: Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/knowledge-aggregator-system.md
+++ b/.kimi/agents/knowledge-aggregator-system.md
@@ -1,6 +1,8 @@
 ---
+
 name: knowledge-aggregator
-description: Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
+description: >
+  Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-6)
@@ -9,14 +11,16 @@ description: Use this agent when you need to aggregate context from project docu
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/planner-system.md
+++ b/.kimi/agents/planner-system.md
@@ -1,6 +1,8 @@
 ---
+
 name: planner
-description: Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-opus-4-6)
@@ -9,15 +11,17 @@ description: Use this agent when planning or designing features and you need to 
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/ralph-system.md
+++ b/.kimi/agents/ralph-system.md
@@ -1,11 +1,15 @@
 ---
+
 name: ralph
-description: YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
+description: >
+  YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # Ralph should inherit the parent model since it orchestrates other agents
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/review-documentation-system.md
+++ b/.kimi/agents/review-documentation-system.md
@@ -1,16 +1,19 @@
 ---
+
 name: review-documentation
 description: Documentation reviewer - checks if docs need updates for API changes, new features, config changes. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/review-implementation-system.md
+++ b/.kimi/agents/review-implementation-system.md
@@ -1,16 +1,20 @@
 ---
+
 name: review-implementation
-description: Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
+description: >
+  Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/review-quality-system.md
+++ b/.kimi/agents/review-quality-system.md
@@ -1,16 +1,19 @@
 ---
+
 name: review-quality
 description: Quality reviewer - finds bugs, race conditions, error handling gaps, resource leaks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/review-simplification-system.md
+++ b/.kimi/agents/review-simplification-system.md
@@ -1,16 +1,19 @@
 ---
+
 name: review-simplification
 description: Simplification reviewer - detects over-engineering, unnecessary complexity, premature abstractions. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/review-testing-system.md
+++ b/.kimi/agents/review-testing-system.md
@@ -1,16 +1,19 @@
 ---
+
 name: review-testing
 description: Testing reviewer - evaluates test coverage, test quality, and testing gaps. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/security-scanner-system.md
+++ b/.kimi/agents/security-scanner-system.md
@@ -1,16 +1,19 @@
 ---
+
 name: security-scanner
 description: Security scanner - performs OWASP Top 10 scanning, secrets detection, and dependency vulnerability checks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/test-effectiveness-analyst-system.md
+++ b/.kimi/agents/test-effectiveness-analyst-system.md
@@ -1,7 +1,11 @@
 ---
+
 name: test-effectiveness-analyst
-description: Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+description: >
+  Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/agents/test-runner-system.md
+++ b/.kimi/agents/test-runner-system.md
@@ -1,6 +1,8 @@
 ---
+
 name: test-runner
-description: Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
+description: >
+  Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-haiku-4-5)
@@ -8,7 +10,9 @@ description: Use this agent to run tests, pre-commit hooks, or commits without p
 # Recommended: Fast model (haiku, glm-4.5) for high-volume, low-complexity tasks
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/skills/codex-agent-code-reviewer/SKILL.md
+++ b/.kimi/skills/codex-agent-code-reviewer/SKILL.md
@@ -17,8 +17,10 @@ This skill wraps the source file `agents/code-reviewer.md` for Codex Skills comp
 
 ```markdown
 ---
+
 name: code-reviewer
-description: Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
+description: >
+  Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-5)
@@ -26,7 +28,9 @@ description: Human-facing code reviewer for major milestones. Provides detailed 
 # Recommended: Capable model (sonnet, glm-4.7) for complex reasoning and analysis
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/skills/codex-agent-codebase-investigator/SKILL.md
+++ b/.kimi/skills/codex-agent-codebase-investigator/SKILL.md
@@ -17,10 +17,14 @@ This skill wraps the source file `agents/codebase-investigator.md` for Codex Ski
 
 ```markdown
 ---
+
 name: codebase-investigator
-description: Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/skills/codex-agent-devops/SKILL.md
+++ b/.kimi/skills/codex-agent-devops/SKILL.md
@@ -20,16 +20,15 @@ This skill wraps the source file `agents/devops.md` for Codex Skills compatibili
 name: devops
 description: DevOps reviewer - analyzes CI/CD pipelines, pre-commit hooks, build configurations, and diagnoses pipeline failures. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # DevOps Agent

--- a/.kimi/skills/codex-agent-internet-researcher/SKILL.md
+++ b/.kimi/skills/codex-agent-internet-researcher/SKILL.md
@@ -17,10 +17,14 @@ This skill wraps the source file `agents/internet-researcher.md` for Codex Skill
 
 ```markdown
 ---
+
 name: internet-researcher
-description: Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/skills/codex-agent-knowledge-aggregator/SKILL.md
+++ b/.kimi/skills/codex-agent-knowledge-aggregator/SKILL.md
@@ -17,8 +17,10 @@ This skill wraps the source file `agents/knowledge-aggregator.md` for Codex Skil
 
 ```markdown
 ---
+
 name: knowledge-aggregator
-description: Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
+description: >
+  Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-6)
@@ -27,13 +29,14 @@ description: Use this agent when you need to aggregate context from project docu
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)

--- a/.kimi/skills/codex-agent-planner/SKILL.md
+++ b/.kimi/skills/codex-agent-planner/SKILL.md
@@ -17,8 +17,10 @@ This skill wraps the source file `agents/planner.md` for Codex Skills compatibil
 
 ```markdown
 ---
+
 name: planner
-description: Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-opus-4-6)
@@ -27,14 +29,15 @@ description: Use this agent when planning or designing features and you need to 
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)

--- a/.kimi/skills/codex-agent-ralph/SKILL.md
+++ b/.kimi/skills/codex-agent-ralph/SKILL.md
@@ -17,13 +17,17 @@ This skill wraps the source file `agents/ralph.md` for Codex Skills compatibilit
 
 ```markdown
 ---
+
 name: ralph
-description: YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
+description: >
+  YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # Ralph should inherit the parent model since it orchestrates other agents
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/skills/codex-agent-review-documentation/SKILL.md
+++ b/.kimi/skills/codex-agent-review-documentation/SKILL.md
@@ -20,16 +20,15 @@ This skill wraps the source file `agents/review-documentation.md` for Codex Skil
 name: review-documentation
 description: Documentation reviewer - checks if docs need updates for API changes, new features, config changes. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Documentation Review Agent

--- a/.kimi/skills/codex-agent-review-implementation/SKILL.md
+++ b/.kimi/skills/codex-agent-review-implementation/SKILL.md
@@ -20,16 +20,15 @@ This skill wraps the source file `agents/review-implementation.md` for Codex Ski
 name: review-implementation
 description: Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Implementation Review Agent

--- a/.kimi/skills/codex-agent-review-quality/SKILL.md
+++ b/.kimi/skills/codex-agent-review-quality/SKILL.md
@@ -20,16 +20,15 @@ This skill wraps the source file `agents/review-quality.md` for Codex Skills com
 name: review-quality
 description: Quality reviewer - finds bugs, race conditions, error handling gaps, resource leaks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Quality Review Agent

--- a/.kimi/skills/codex-agent-review-simplification/SKILL.md
+++ b/.kimi/skills/codex-agent-review-simplification/SKILL.md
@@ -20,16 +20,15 @@ This skill wraps the source file `agents/review-simplification.md` for Codex Ski
 name: review-simplification
 description: Simplification reviewer - detects over-engineering, unnecessary complexity, premature abstractions. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Simplification Review Agent

--- a/.kimi/skills/codex-agent-review-testing/SKILL.md
+++ b/.kimi/skills/codex-agent-review-testing/SKILL.md
@@ -20,16 +20,15 @@ This skill wraps the source file `agents/review-testing.md` for Codex Skills com
 name: review-testing
 description: Testing reviewer - evaluates test coverage, test quality, and testing gaps. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Testing Review Agent

--- a/.kimi/skills/codex-agent-security-scanner/SKILL.md
+++ b/.kimi/skills/codex-agent-security-scanner/SKILL.md
@@ -20,16 +20,15 @@ This skill wraps the source file `agents/security-scanner.md` for Codex Skills c
 name: security-scanner
 description: Security scanner - performs OWASP Top 10 scanning, secrets detection, and dependency vulnerability checks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Security Scanner Agent

--- a/.kimi/skills/codex-agent-test-effectiveness-analyst/SKILL.md
+++ b/.kimi/skills/codex-agent-test-effectiveness-analyst/SKILL.md
@@ -17,9 +17,13 @@ This skill wraps the source file `agents/test-effectiveness-analyst.md` for Code
 
 ```markdown
 ---
+
 name: test-effectiveness-analyst
-description: Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+description: >
+  Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.kimi/skills/codex-agent-test-runner/SKILL.md
+++ b/.kimi/skills/codex-agent-test-runner/SKILL.md
@@ -17,8 +17,10 @@ This skill wraps the source file `agents/test-runner.md` for Codex Skills compat
 
 ```markdown
 ---
+
 name: test-runner
-description: Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
+description: >
+  Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-haiku-4-5)
@@ -26,7 +28,9 @@ description: Use this agent to run tests, pre-commit hooks, or commits without p
 # Recommended: Fast model (haiku, glm-4.5) for high-volume, low-complexity tasks
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -1,6 +1,8 @@
 ---
+
 name: code-reviewer
-description: Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
+description: >
+  Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-5)
@@ -8,7 +10,9 @@ description: Human-facing code reviewer for major milestones. Provides detailed 
 # Recommended: Capable model (sonnet, glm-4.7) for complex reasoning and analysis
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/codebase-investigator.md
+++ b/.opencode/agents/codebase-investigator.md
@@ -1,8 +1,12 @@
 ---
+
 name: codebase-investigator
-description: Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/devops.md
+++ b/.opencode/agents/devops.md
@@ -1,17 +1,20 @@
 ---
+
 name: devops
 model: inherit
 description: DevOps reviewer - analyzes CI/CD pipelines, pre-commit hooks, build configurations, and diagnoses pipeline failures. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/internet-researcher.md
+++ b/.opencode/agents/internet-researcher.md
@@ -1,8 +1,12 @@
 ---
+
 name: internet-researcher
-description: Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/knowledge-aggregator.md
+++ b/.opencode/agents/knowledge-aggregator.md
@@ -1,6 +1,8 @@
 ---
+
 name: knowledge-aggregator
-description: Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
+description: >
+  Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-6)
@@ -9,14 +11,16 @@ description: Use this agent when you need to aggregate context from project docu
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/planner.md
+++ b/.opencode/agents/planner.md
@@ -1,6 +1,8 @@
 ---
+
 name: planner
-description: Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-opus-4-6)
@@ -9,15 +11,17 @@ description: Use this agent when planning or designing features and you need to 
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/ralph.md
+++ b/.opencode/agents/ralph.md
@@ -1,11 +1,15 @@
 ---
+
 name: ralph
-description: YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
+description: >
+  YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # Ralph should inherit the parent model since it orchestrates other agents
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/review-documentation.md
+++ b/.opencode/agents/review-documentation.md
@@ -1,17 +1,20 @@
 ---
+
 name: review-documentation
 model: inherit
 description: Documentation reviewer - checks if docs need updates for API changes, new features, config changes. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/review-implementation.md
+++ b/.opencode/agents/review-implementation.md
@@ -1,17 +1,21 @@
 ---
+
 name: review-implementation
 model: inherit
-description: Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
+description: >
+  Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/review-quality.md
+++ b/.opencode/agents/review-quality.md
@@ -1,17 +1,20 @@
 ---
+
 name: review-quality
 model: inherit
 description: Quality reviewer - finds bugs, race conditions, error handling gaps, resource leaks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/review-simplification.md
+++ b/.opencode/agents/review-simplification.md
@@ -1,17 +1,20 @@
 ---
+
 name: review-simplification
 model: inherit
 description: Simplification reviewer - detects over-engineering, unnecessary complexity, premature abstractions. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/review-testing.md
+++ b/.opencode/agents/review-testing.md
@@ -1,17 +1,20 @@
 ---
+
 name: review-testing
 model: inherit
 description: Testing reviewer - evaluates test coverage, test quality, and testing gaps. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/security-scanner.md
+++ b/.opencode/agents/security-scanner.md
@@ -1,17 +1,20 @@
 ---
+
 name: security-scanner
 model: inherit
 description: Security scanner - performs OWASP Top 10 scanning, secrets detection, and dependency vulnerability checks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/test-effectiveness-analyst.md
+++ b/.opencode/agents/test-effectiveness-analyst.md
@@ -1,8 +1,12 @@
 ---
+
 name: test-effectiveness-analyst
 model: inherit
-description: Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+description: >
+  Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/.opencode/agents/test-runner.md
+++ b/.opencode/agents/test-runner.md
@@ -1,6 +1,8 @@
 ---
+
 name: test-runner
-description: Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
+description: >
+  Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-haiku-4-5)
@@ -8,7 +10,9 @@ description: Use this agent to run tests, pre-commit hooks, or commits without p
 # Recommended: Fast model (haiku, glm-4.5) for high-volume, low-complexity tasks
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,6 +1,8 @@
 ---
+
 name: code-reviewer
-description: Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
+description: >
+  Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the hyperpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the hyperpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the hyperpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the hyperpowers:code-reviewer agent should review the work.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-5)
@@ -8,7 +10,9 @@ description: Human-facing code reviewer for major milestones. Provides detailed 
 # Recommended: Capable model (sonnet, glm-4.7) for complex reasoning and analysis
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/agents/codebase-investigator.md
+++ b/agents/codebase-investigator.md
@@ -1,8 +1,12 @@
 ---
+
 name: codebase-investigator
-description: Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the hyperpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the hyperpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/agents/devops.md
+++ b/agents/devops.md
@@ -2,16 +2,15 @@
 name: devops
 description: DevOps reviewer - analyzes CI/CD pipelines, pre-commit hooks, build configurations, and diagnoses pipeline failures. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # DevOps Agent

--- a/agents/internet-researcher.md
+++ b/agents/internet-researcher.md
@@ -1,8 +1,12 @@
 ---
+
 name: internet-researcher
-description: Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the hyperpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the hyperpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/agents/knowledge-aggregator.md
+++ b/agents/knowledge-aggregator.md
@@ -1,6 +1,8 @@
 ---
+
 name: knowledge-aggregator
-description: Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
+description: >
+  Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-6)
@@ -9,13 +11,14 @@ description: Use this agent when you need to aggregate context from project docu
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
+
 ---
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,6 +1,8 @@
 ---
+
 name: planner
-description: Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
+description: >
+  Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-opus-4-6)
@@ -9,14 +11,15 @@ description: Use this agent when planning or designing features and you need to 
 # See docs/model-configuration.md for details
 model: inherit
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
+
 ---
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)

--- a/agents/ralph.md
+++ b/agents/ralph.md
@@ -1,11 +1,15 @@
 ---
+
 name: ralph
-description: YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
+description: >
+  YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # Ralph should inherit the parent model since it orchestrates other agents
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/agents/review-documentation.md
+++ b/agents/review-documentation.md
@@ -2,16 +2,15 @@
 name: review-documentation
 description: Documentation reviewer - checks if docs need updates for API changes, new features, config changes. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Documentation Review Agent

--- a/agents/review-implementation.md
+++ b/agents/review-implementation.md
@@ -2,16 +2,15 @@
 name: review-implementation
 description: Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Implementation Review Agent

--- a/agents/review-quality.md
+++ b/agents/review-quality.md
@@ -2,16 +2,15 @@
 name: review-quality
 description: Quality reviewer - finds bugs, race conditions, error handling gaps, resource leaks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Quality Review Agent

--- a/agents/review-simplification.md
+++ b/agents/review-simplification.md
@@ -2,16 +2,15 @@
 name: review-simplification
 description: Simplification reviewer - detects over-engineering, unnecessary complexity, premature abstractions. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
+  Read: true
+  Grep: true
+  Glob: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
-  - WebFetch
+  Edit: false
+  Write: false
+  Bash: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Simplification Review Agent

--- a/agents/review-testing.md
+++ b/agents/review-testing.md
@@ -2,16 +2,15 @@
 name: review-testing
 description: Testing reviewer - evaluates test coverage, test quality, and testing gaps. Returns PASS or ISSUES_FOUND.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+  Read: true
+  Grep: true
+  Glob: true
+  Bash: true
 disallowedTools:
-  - Edit
-  - Write
-  - WebFetch
+  Edit: false
+  Write: false
+  WebFetch: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Testing Review Agent

--- a/agents/security-scanner.md
+++ b/agents/security-scanner.md
@@ -2,16 +2,15 @@
 name: security-scanner
 description: Security scanner - performs OWASP Top 10 scanning, secrets detection, and dependency vulnerability checks. Returns PASS or ISSUES_FOUND with severity.
 tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
+  Read: true
+  Grep: true
+  Glob: true
+  WebFetch: true
 disallowedTools:
-  - Edit
-  - Write
-  - Bash
+  Edit: false
+  Write: false
+  Bash: false
 ---
-
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 
 # Security Scanner Agent

--- a/agents/test-effectiveness-analyst.md
+++ b/agents/test-effectiveness-analyst.md
@@ -1,7 +1,11 @@
 ---
+
 name: test-effectiveness-analyst
-description: Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+description: >
+  Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -1,6 +1,8 @@
 ---
+
 name: test-runner
-description: Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
+description: >
+  Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
 # Model Configuration:
 # - inherit: Use the parent's/current model (default)
 # - providerID/modelID: Explicit model selection (e.g., anthropic/claude-haiku-4-5)
@@ -8,7 +10,9 @@ description: Use this agent to run tests, pre-commit hooks, or commits without p
 # Recommended: Fast model (haiku, glm-4.5) for high-volume, low-complexity tasks
 # See docs/model-configuration.md for details
 model: inherit
+
 ---
+
 
 > 📚 See the main hyperpowers documentation: [Global README](../README.md)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
-        "@linear/sdk": "^76.0.0"
+        "@linear/sdk": "^76.0.0",
+        "js-yaml": "^4.1.1"
       },
       "bin": {
         "tm": "scripts/tm"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/js-yaml": "^4.0.9",
         "eslint": "^10.2.1"
       }
     },
@@ -268,6 +270,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -315,6 +324,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -689,6 +704,18 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
   "homepage": "https://github.com/dpolishuk/myhyperpowers#readme",
   "dependencies": {
     "@clack/prompts": "^1.1.0",
-    "@linear/sdk": "^76.0.0"
+    "@linear/sdk": "^76.0.0",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/js-yaml": "^4.0.9",
     "eslint": "^10.2.1"
   }
 }

--- a/scripts/sync-codex-skills.js
+++ b/scripts/sync-codex-skills.js
@@ -59,7 +59,7 @@ const parseFrontmatter = (rawContent, filePath, options = {}) => {
 
   // We need to parse block scalars like description: > and object maps like tools:
   const jsYaml = require("js-yaml")
-  let frontmatter = {}
+  let frontmatter
   try {
     frontmatter = jsYaml.load(match[1]) || {}
   } catch (err) {

--- a/scripts/sync-codex-skills.js
+++ b/scripts/sync-codex-skills.js
@@ -57,22 +57,15 @@ const parseFrontmatter = (rawContent, filePath, options = {}) => {
     throw new Error(`missing frontmatter: ${filePath} (add YAML frontmatter with 'name' and 'description')`)
   }
 
-  const frontmatter = {}
-  for (const line of match[1].split("\n")) {
-    const trimmed = line.trim()
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue
-    }
-
-    const separatorIndex = trimmed.indexOf(":")
-    if (separatorIndex === -1) {
-      continue
-    }
-
-    const key = trimmed.slice(0, separatorIndex).trim()
-    let value = trimmed.slice(separatorIndex + 1).trim()
-    value = value.replace(/^['"]/, "").replace(/['"]$/, "")
-    frontmatter[key] = value
+  // We need to parse block scalars like description: > and object maps like tools:
+  const jsYaml = require("js-yaml")
+  let frontmatter = {}
+  try {
+    frontmatter = jsYaml.load(match[1]) || {}
+  } catch (err) {
+    // If YAML fails (e.g. because of "!!!" which fails as a tag), fallback or report
+    // For this sync script we want to be permissive with raw values if strict YAML fails
+    throw new Error(`invalid YAML frontmatter: ${err.message}`)
   }
 
   if (requireName && !frontmatter.name) {

--- a/tests/codex-metadata-validation.test.js
+++ b/tests/codex-metadata-validation.test.js
@@ -121,7 +121,7 @@ test("syncCodexSkills fails on invalid canonical skill names", () => {
   try {
     write(
       path.join(root, "skills", "invalid", "SKILL.md"),
-      "---\nname: !!!\ndescription: Invalid slug target.\n---\n\nbody\n",
+      "---\nname: '!!!'\ndescription: Invalid slug target.\n---\n\nbody\n",
     )
 
     const result = syncCodexSkills({ projectRoot: root, mode: "write" })

--- a/tests/codex-sync-hardening.test.js
+++ b/tests/codex-sync-hardening.test.js
@@ -43,7 +43,7 @@ test("syncCodexSkills emits YAML-safe quoted descriptions in generated frontmatt
   try {
     write(
       path.join(root, "skills", "alpha", "SKILL.md"),
-      "---\nname: alpha\ndescription: Has YAML-risk chars: [x] # comment {obj} \"quote\" \\slash\n---\n\nbody\n",
+      "---\nname: alpha\ndescription: \"Has YAML-risk chars: [x] # comment {obj} \\\"quote\\\" \\\\slash\"\n---\n\nbody\n",
     )
 
     const result = syncCodexSkills({ projectRoot: root, mode: "write" })


### PR DESCRIPTION
## Problem

OpenCode (and likely other platforms) expect `tools` and `disallowedTools` to be objects (or undefined), not YAML arrays. This was causing a config validation error:

```
ConfigInvalidError: Expected object | undefined, got ["Read","Grep","Glob","Bash"]
```

## Fix

Convert all agent configs across all platforms to use object format:
- `tools`: `{ ToolName: true }` instead of `[ToolName, ...]`
- `disallowedTools`: `{ ToolName: false }` instead of `[ToolName, ...]`

## Affected platforms

- `agents/` (canonical definitions)
- `.opencode/agents/`
- `.gemini-extension/agents/`
- `.kimi/agents/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized agent/frontmatter formatting (description fields converted to folded multi-line YAML; tool permissions normalized from lists to explicit boolean maps).
  * Improved metadata parsing to reliably handle YAML features (block scalars and mappings).
  * Added YAML parsing support dependency to enable the above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->