### PR TITLE
Fix Pi dashboards for mobile terminals

### DIFF
--- a/.pi/extensions/xpowers/brainstorm-tui.ts
+++ b/.pi/extensions/xpowers/brainstorm-tui.ts
@@ -12,6 +12,11 @@ import {
 } from "@mariozechner/pi-tui"
 import { getMarkdownTheme } from "@mariozechner/pi-coding-agent"
 
+interface DashboardTui {
+  terminal?: { columns?: number; rows?: number }
+  requestRender?: () => void
+}
+
 export interface BrainstormState {
   requirements: string[]
   antiPatterns: { pattern: string; reason: string }[]
@@ -34,6 +39,7 @@ export class BrainstormDashboard extends Container implements Focusable {
 
   public onOptionSelect?: (index: number) => void
   public onCancel?: () => void
+  public tui?: DashboardTui
 
   get focused(): boolean {
     return this._focused
@@ -64,6 +70,7 @@ export class BrainstormDashboard extends Container implements Focusable {
     if (!this.state.currentQuestion) {
       if (matchesKey(data, Key.escape) || data === "\x1b") {
         this.onCancel?.()
+        this.tui?.requestRender?.()
       }
       return true
     }
@@ -72,23 +79,60 @@ export class BrainstormDashboard extends Container implements Focusable {
     if (matchesKey(data, Key.up) && this.selectedOption > 0) {
       this.selectedOption--
       this.invalidate()
+      this.tui?.requestRender?.()
     } else if (matchesKey(data, Key.down) && this.selectedOption < optionsCount - 1) {
       this.selectedOption++
       this.invalidate()
+      this.tui?.requestRender?.()
     } else if (matchesKey(data, Key.enter)) {
       this.onOptionSelect?.(this.selectedOption)
+      this.tui?.requestRender?.()
     } else if (matchesKey(data, Key.escape) || data === "\x1b") {
       this.onCancel?.()
+      this.tui?.requestRender?.()
     }
     return true
   }
 
   render(width: number): string[] {
-    // Determine split width
-    const leftWidth = Math.floor(width * 0.5)
-    const rightWidth = width - leftWidth - 1 // 1 for divider
+    const terminalColumns = this.tui?.terminal?.columns ?? width
+    const renderWidth = Math.max(1, Math.min(width, terminalColumns))
+    const termRows = Math.max(1, this.tui?.terminal?.rows || 24)
+    const narrow = renderWidth < 80
 
-    // Build Epic Preview Markdown
+    const rightLines = this.renderQuestionPane(narrow ? renderWidth : Math.max(1, renderWidth - Math.floor(renderWidth * 0.5) - 1))
+
+    if (narrow) {
+      const out = [...rightLines]
+      out.push("")
+      out.push(...this.renderPlainEpic(renderWidth))
+      return out.map(line => truncateToWidth(line, renderWidth)).slice(0, termRows)
+    }
+
+    const leftWidth = Math.floor(renderWidth * 0.5)
+    const rightWidth = renderWidth - leftWidth - 1
+    const leftLines = this.renderEpicMarkdown(leftWidth)
+
+    const maxLines = Math.max(leftLines.length, rightLines.length)
+    const out: string[] = []
+    for (let i = 0; i < maxLines; i++) {
+      const l = truncateToWidth(leftLines[i] || "", leftWidth)
+      const r = truncateToWidth(rightLines[i] || "", Math.max(1, rightWidth - 2))
+      const lLen = visibleWidth(l)
+      const lPad = " ".repeat(Math.max(0, leftWidth - lLen))
+      out.push(truncateToWidth(`${l}${lPad}│ ${r}`, renderWidth))
+    }
+
+    return out.slice(0, termRows)
+  }
+
+  private renderEpicMarkdown(width: number): string[] {
+    const mdTheme = getMarkdownTheme()
+    const md = new Markdown(this.buildEpicMarkdown(), 0, 0, mdTheme)
+    return md.render(Math.max(1, width - 2))
+  }
+
+  private buildEpicMarkdown(): string {
     let epicMd = "# Epic Preview\n\n"
     if (this.state.requirements.length > 0) {
       epicMd += "## Requirements (IMMUTABLE)\n"
@@ -110,55 +154,47 @@ export class BrainstormDashboard extends Container implements Focusable {
       this.state.openQuestions.forEach((oq) => (epicMd += `- ${oq}\n`))
       epicMd += "\n"
     }
+    return epicMd
+  }
 
-    // Render Left Pane
-    // We use a mock theme for Markdown here, but ideally we'd pass it in from render context
-    const mdTheme = getMarkdownTheme()
-    const md = new Markdown(epicMd || "Waiting for requirements...", 0, 0, mdTheme)
-    const leftLines = md.render(leftWidth - 2) // padding
+  private renderPlainEpic(width: number): string[] {
+    const lines: string[] = ["# Epic Preview"]
+    const addSection = (title: string, items: string[]) => {
+      if (items.length === 0) return
+      lines.push(`## ${title}`)
+      for (const item of items) lines.push(truncateToWidth(`- ${item}`, width))
+    }
+    addSection("Requirements", this.state.requirements)
+    addSection("Anti-Patterns", this.state.antiPatterns.map(ap => `❌ ${ap.pattern} (${ap.reason})`))
+    addSection("Research", this.state.researchFindings)
+    addSection("Open Questions", this.state.openQuestions)
+    return lines.map(line => truncateToWidth(line, width))
+  }
 
-    // Render Right Pane (History & Current Question)
+  private renderQuestionPane(width: number): string[] {
     const rightLines: string[] = []
-    
-    // History
     rightLines.push("--- Q&A History ---")
-    const maxHistory = 10
-    const historySlice = this.state.history.slice(-maxHistory)
+    const historySlice = this.state.history.slice(-10)
     for (const msg of historySlice) {
       const prefix = msg.role === "agent" ? "🤖 " : "👤 "
-      rightLines.push(truncateToWidth(prefix + msg.content, rightWidth - 2))
+      rightLines.push(truncateToWidth(prefix + msg.content, width))
     }
     rightLines.push("")
 
-    // Current Question
     if (this.state.currentQuestion) {
-      rightLines.push(`Q: ${this.state.currentQuestion.question}`)
-      rightLines.push(`Priority: ${this.state.currentQuestion.priority}`)
+      rightLines.push("--- Current Question ---")
+      rightLines.push(truncateToWidth(`Q: ${this.state.currentQuestion.question}`, width))
+      rightLines.push(truncateToWidth(`Priority: ${this.state.currentQuestion.priority}`, width))
       rightLines.push("")
       this.state.currentQuestion.options.forEach((opt, i) => {
-        const isSelected = i === this.selectedOption
-        const prefix = isSelected ? "❯ " : "  "
-        // TODO: ANSI styles for selected
+        const prefix = i === this.selectedOption ? "❯ " : "  "
         let text = prefix + opt.label
         if (opt.description) text += ` - ${opt.description}`
-        rightLines.push(truncateToWidth(text, rightWidth - 2))
+        rightLines.push(truncateToWidth(text, width))
       })
     } else {
       rightLines.push("Waiting for next question...")
     }
-
-    // Combine them side by side
-    const maxLines = Math.max(leftLines.length, rightLines.length)
-    const out: string[] = []
-    for (let i = 0; i < maxLines; i++) {
-      const l = leftLines[i] || ""
-      const r = rightLines[i] || ""
-      // Pad left
-      const lLen = visibleWidth(l)
-      const lPad = " ".repeat(Math.max(0, leftWidth - lLen))
-      out.push(`${l}${lPad}│ ${r}`)
-    }
-
-    return out
+    return rightLines.map(line => truncateToWidth(line, width))
   }
 }

--- a/.pi/extensions/xpowers/execution-dashboard-tui.ts
+++ b/.pi/extensions/xpowers/execution-dashboard-tui.ts
@@ -1,13 +1,15 @@
 import {
   Container,
-  Box,
-  Text,
   matchesKey,
   Key,
   truncateToWidth,
-  visibleWidth,
 } from "@mariozechner/pi-tui"
 import type { StructuredTaskStatus } from "./task-runner"
+
+interface DashboardTui {
+  terminal?: { columns?: number; rows?: number }
+  requestRender?: () => void
+}
 
 export interface LiveTaskState {
   id: string
@@ -26,6 +28,7 @@ export interface LiveExecutionState {
 export class LiveExecutionDashboard extends Container {
   private state: LiveExecutionState
   private onCancel?: () => void
+  public tui?: DashboardTui
 
   constructor(initialState: LiveExecutionState, onCancel?: () => void) {
     super()
@@ -41,60 +44,79 @@ export class LiveExecutionDashboard extends Container {
     }
   }
 
-  handleInput(data: string): void {
+  handleInput(data: string): boolean {
     if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
       this.onCancel?.()
+      this.tui?.requestRender?.()
+      return true
     }
+    return true
   }
 
   render(width: number): string[] {
+    const terminalColumns = this.tui?.terminal?.columns ?? width
+    const renderWidth = Math.max(1, Math.min(width, terminalColumns))
+    const termRows = Math.max(1, this.tui?.terminal?.rows || 24)
+    const narrow = renderWidth < 80
     const lines: string[] = []
-    
-    // Header
+    const push = (line = "") => lines.push(truncateToWidth(line, renderWidth))
+
     const titleText = ` 🚀 ${this.state.title} `
-    lines.push(truncateToWidth(titleText, width))
-    lines.push("─".repeat(Math.min(width, titleText.length)))
-    
-    // Progress
+    push(titleText)
+    push("─".repeat(renderWidth))
+
     const total = this.state.tasks.length
     const completed = this.state.tasks.filter(t => t.status !== "pending" && t.status !== "running").length
     const percent = total > 0 ? Math.floor((completed / total) * 100) : 0
-    
-    const barWidth = 20
+    const barWidth = Math.max(1, Math.min(20, renderWidth - (narrow ? 19 : 28)))
     const filled = Math.floor((percent / 100) * barWidth)
     const bar = "█".repeat(filled) + "░".repeat(barWidth - filled)
-    lines.push(`[${bar}] ${percent}% Complete - ${completed}/${total} Tasks`)
-    lines.push("")
-    
-    // Tasks list
-    lines.push("Active Subagents:")
-    
+    push(narrow ? `[${bar}] ${completed}/${total} Tasks` : `[${bar}] ${percent}% Complete - ${completed}/${total} Tasks`)
+    push("")
+    push(narrow ? "Tasks:" : "Active Subagents:")
+
+    const reservedRows = lines.length + 3
+    const maxTaskRows = Math.max(0, termRows - reservedRows)
+    let usedTaskRows = 0
+    let renderedTasks = 0
+
     for (const task of this.state.tasks) {
+      const rowCost = narrow ? 1 : (task.output || task.summary ? 2 : 1)
+      if (usedTaskRows + rowCost > maxTaskRows) break
+
       let icon = "⏳"
       if (task.status === "running") icon = "🔄"
       else if (task.status === "PASS") icon = "✅"
       else if (task.status === "ISSUES_FOUND") icon = "⚠️ "
       else if (task.status === "FAIL") icon = "❌"
 
-      let taskLine = `${icon} Task ${task.id}: ${task.title}`
+      let taskLine = narrow ? `${icon} ${task.id}: ${task.title}` : `${icon} Task ${task.id}: ${task.title}`
       if (task.status === "running" && task.effort) {
         taskLine += ` [thinking: ${task.effort}]`
       } else if (task.status !== "pending" && task.status !== "running") {
         taskLine += ` [${task.status}]`
       }
-      
-      lines.push(truncateToWidth(taskLine, width))
-      
-      if (task.output) {
-        lines.push(truncateToWidth(`   └─ ${task.output}`, width))
-      } else if (task.summary) {
-        lines.push(truncateToWidth(`   └─ ${task.summary}`, width))
+      push(taskLine)
+      usedTaskRows++
+      renderedTasks++
+
+      if (!narrow && task.output && usedTaskRows < maxTaskRows) {
+        push(`   └─ ${task.output}`)
+        usedTaskRows++
+      } else if (!narrow && task.summary && usedTaskRows < maxTaskRows) {
+        push(`   └─ ${task.summary}`)
+        usedTaskRows++
       }
     }
-    
-    lines.push("")
-    lines.push("[Ctrl+C / Esc] Cancel")
-    
-    return lines
+
+    const hiddenTasks = total - renderedTasks
+    if (hiddenTasks > 0 && lines.length < termRows - 2) {
+      push(`... ${hiddenTasks} more tasks`)
+    }
+
+    push("")
+    push("[Ctrl+C / Esc] Cancel")
+
+    return lines.slice(0, termRows).map(line => truncateToWidth(line, renderWidth))
   }
 }

--- a/.pi/extensions/xpowers/index.ts
+++ b/.pi/extensions/xpowers/index.ts
@@ -708,8 +708,9 @@ export default function (pi: any) {
       }
 
       const result = await ctx.ui.custom<string>(
-        (_tui: any, _theme: any, _keybindings: any, done: (v: string) => void) => {
+        (tui: any, _theme: any, _keybindings: any, done: (v: string) => void) => {
           const dashboard = new BrainstormDashboard(state);
+          dashboard.tui = tui;
           
           dashboard.onOptionSelect = (index: number) => {
             const selected = params.options?.[index]?.label
@@ -724,7 +725,7 @@ export default function (pi: any) {
           
           return dashboard;
         },
-        { overlay: true }
+        { overlay: true, overlayOptions: { width: "96%", maxHeight: "90%", margin: 1 } }
       );
 
       return { content: [{ type: "text", text: result }] };
@@ -813,9 +814,17 @@ export default function (pi: any) {
         session.handle = ctx.ui.custom(
           (tui: any, _theme: any, _keybindings: any, _done: (v: unknown) => void) => {
             session!.dashboard.tui = tui
-            return session!.dashboard
+            return {
+              render: (width: number) => session!.dashboard.render(width),
+              invalidate: () => session!.dashboard.invalidate(),
+              handleInput: (data: string) => {
+                session!.dashboard.handleInput(data)
+                tui.requestRender?.()
+                return true
+              },
+            }
           },
-          { overlay: true }
+          { overlay: true, overlayOptions: { width: "96%", maxHeight: "90%", margin: 1 } }
         )
       } else {
         session.handle.requestRender?.()

--- a/.pi/extensions/xpowers/ralph-dashboard-tui.ts
+++ b/.pi/extensions/xpowers/ralph-dashboard-tui.ts
@@ -15,6 +15,11 @@ export type RalphPhase =
   | "completion"
   | "done"
 
+interface DashboardTui {
+  terminal?: { columns?: number; rows?: number }
+  requestRender?: () => void
+}
+
 export interface RalphState {
   phase: RalphPhase
   epicId?: string
@@ -35,7 +40,7 @@ export class RalphDashboard extends Container implements Focusable {
   private onCancel?: () => void
   private _focused = true
 
-  public tui?: any
+  public tui?: DashboardTui
 
   get focused(): boolean {
     return this._focused
@@ -79,134 +84,132 @@ export class RalphDashboard extends Container implements Focusable {
   handleInput(data: string): boolean {
     if (matchesKey(data, Key.escape) || data === "\x1b" || matchesKey(data, Key.ctrl("c")) || data === "\x03" || data === "q" || data === "Q") {
       this.onCancel?.()
+      this.tui?.requestRender?.()
       return true
     }
     return true
   }
 
   render(width: number): string[] {
+    const terminalColumns = this.tui?.terminal?.columns ?? width
+    const renderWidth = Math.max(1, Math.min(width, terminalColumns))
+    const termRows = Math.max(1, this.tui?.terminal?.rows || 24)
+    const narrow = renderWidth < 80
     const lines: string[] = []
+    const push = (line = "") => lines.push(truncateToWidth(line, renderWidth))
 
-    // 1. Header
     const epicStr = this.state.epicId ? `[${this.state.epicId}] ${this.state.epicTitle || ""}` : "Loading Epic..."
-    const header = ` 🤖 Ralph Autonomous Execution ── ${epicStr} `
-    lines.push(truncateToWidth(header, width))
-    lines.push("─".repeat(Math.min(width, visibleWidth(header))))
-    lines.push("")
-    
-    // 2. Phase Tracker
+    const title = narrow ? ` 🤖 Ralph ── ${epicStr} ` : ` 🤖 Ralph Autonomous Execution ── ${epicStr} `
+    push(title)
+    push("─".repeat(renderWidth))
+    push()
+
     const phases = [
-      { id: "setup", label: "Setup" },
-      { id: "get_task", label: "Get Task" },
-      { id: "subagent", label: "Subagent" },
-      { id: "review", label: "Review" },
-      { id: "completion", label: "Completion" },
-      { id: "done", label: "Done" },
+      { id: "setup", label: narrow ? "Setup" : "Setup" },
+      { id: "get_task", label: narrow ? "Task" : "Get Task" },
+      { id: "subagent", label: narrow ? "Agent" : "Subagent" },
+      { id: "review", label: narrow ? "Review" : "Review" },
+      { id: "completion", label: narrow ? "Finish" : "Completion" },
+      { id: "done", label: narrow ? "Done" : "Done" },
     ]
 
-    const phaseLabels = phases.map(p => {
-      if (this.state.phase === p.id) return `\x1b[7m ${p.label} \x1b[27m`
-      return ` ${p.label} `
-    })
-    lines.push(` 📍 Phase:  ${phaseLabels.join(" ➞ ")}`)
-    lines.push("")
+    const currentPhase = phases.find(p => p.id === this.state.phase)?.label || this.state.phase
+    if (narrow) {
+      push(` 📍 Phase: ${currentPhase}`)
+    } else {
+      const phaseLabels = phases.map(p => {
+        if (this.state.phase === p.id) return `\x1b[7m ${p.label} \x1b[27m`
+        return ` ${p.label} `
+      })
+      push(` 📍 Phase:  ${phaseLabels.join(" ➞ ")}`)
+    }
+    push()
 
-    // 3. Two-column Layout: Current Target vs Epic Status
-    const leftWidth = Math.floor(width * 0.55)
-    const rightWidth = Math.max(1, width - leftWidth - 1)
+    const statusIcon = this.statusIcon()
+    const focusLines = this.buildFocusLines(statusIcon, narrow)
+    const progressLines = this.buildProgressLines(narrow ? renderWidth : Math.max(1, Math.floor(renderWidth * 0.45)))
 
-    const leftLines: string[] = []
-    const rightLines: string[] = []
+    if (narrow) {
+      for (const line of focusLines.slice(0, 5)) push(line)
+      push()
+      for (const line of progressLines) push(line)
+    } else {
+      const leftWidth = Math.floor(renderWidth * 0.55)
+      const rightWidth = Math.max(1, renderWidth - leftWidth - 1)
+      const fit = (text: string, w: number) => {
+        const t = truncateToWidth(text, Math.max(1, w))
+        return `${t}${" ".repeat(Math.max(0, w - visibleWidth(t)))}`
+      }
+      const maxCols = Math.max(focusLines.length, progressLines.length)
+      for (let i = 0; i < maxCols; i++) {
+        const l = fit(focusLines[i] || "│", leftWidth)
+        const r = truncateToWidth(progressLines[i] || "│", Math.max(1, rightWidth))
+        push(`${l} ${r}`)
+      }
+    }
+    push()
 
-    // Left: Current Action / Subagent
-    leftLines.push("╭── Current Focus ──────────────────────")
+    push("── Execution Logs ──")
+
+    const helpLine = "[q / Esc / Ctrl+C] Cancel Execution"
+    const reservedForHelp = 2
+    const remainingRows = Math.max(0, termRows - lines.length - reservedForHelp)
+    const maxLogLines = narrow ? Math.min(remainingRows, 3) : remainingRows
+    const displayLogs = maxLogLines > 0 ? this.state.logs.slice(-maxLogLines) : []
+
+    if (displayLogs.length === 0 && maxLogLines > 0) {
+      push(" Waiting for logs...")
+    } else {
+      for (const log of displayLogs) push(` > ${log}`)
+    }
+
+    push()
+    push(helpLine)
+
+    return lines.slice(0, termRows).map(line => truncateToWidth(line, renderWidth))
+  }
+
+  private statusIcon(): string {
+    if (this.state.subagentStatus === "running") return "🔄"
+    if (this.state.subagentStatus === "pass") return "✅"
+    if (this.state.subagentStatus === "fail") return "❌"
+    if (this.state.subagentStatus === "issues_found") return "⚠️ "
+    return "⏳"
+  }
+
+  private buildFocusLines(statusIcon: string, compact: boolean): string[] {
+    const lines: string[] = [compact ? "╭─ Current Focus" : "╭── Current Focus ──────────────────────"]
     if (this.state.currentTaskId) {
-      leftLines.push(`│ Task: ${this.state.currentTaskId} - ${this.state.currentTaskTitle || ""}`)
-      
-      let statusIcon = "⏳"
-      if (this.state.subagentStatus === "running") statusIcon = "🔄"
-      else if (this.state.subagentStatus === "pass") statusIcon = "✅"
-      else if (this.state.subagentStatus === "fail") statusIcon = "❌"
-      else if (this.state.subagentStatus === "issues_found") statusIcon = "⚠️ "
-
-      leftLines.push(`│ Subagent: ${statusIcon} ${this.state.subagentStatus || "pending"}`)
-      if (this.state.subagentOutput) {
-        leftLines.push(`│ Output: ${this.state.subagentOutput}`)
+      lines.push(`│ Task: ${this.state.currentTaskId} - ${this.state.currentTaskTitle || ""}`)
+      lines.push(`│ Agent: ${statusIcon} ${this.state.subagentStatus || "pending"}`)
+      if (this.state.subagentOutput && !compact) {
+        lines.push(`│ Output: ${this.state.subagentOutput}`)
       }
     } else {
-      leftLines.push("│ Task: Identifying next work item...")
+      lines.push("│ Task: Identifying next work item...")
     }
 
-    leftLines.push("│")
-    if (this.state.branchName) {
-      leftLines.push(`│ Branch: 🌿 ${this.state.branchName}`)
-      if (this.state.gitProgress) {
-        leftLines.push(`│ Commits: ${this.state.gitProgress}`)
-      }
-    } else {
-      leftLines.push(`│ Branch: pending...`)
-    }
+    const branch = this.state.branchName ? `🌿 ${this.state.branchName}` : "pending..."
+    lines.push(`│ Branch: ${branch}`)
+    if (this.state.gitProgress && !compact) lines.push(`│ Commits: ${this.state.gitProgress}`)
+    return lines
+  }
 
-    // Right: Epic Progress
-    rightLines.push("╭── Epic Progress ──────────────────────")
+  private buildProgressLines(width: number): string[] {
+    const lines: string[] = [width < 40 ? "╭─ Epic Progress" : "╭── Epic Progress ──────────────────────"]
     if (this.state.totalCriteria > 0) {
       const total = Math.max(0, this.state.totalCriteria)
       const unmet = Math.min(Math.max(0, this.state.unmetCriteria), total)
       const met = total - unmet
       const percent = total === 0 ? 0 : Math.floor((met / total) * 100)
-      const barWidth = 20
+      const barWidth = Math.max(1, Math.min(20, width - 22))
       const filled = Math.max(0, Math.min(barWidth, Math.floor((percent / 100) * barWidth)))
       const bar = "█".repeat(filled) + "░".repeat(barWidth - filled)
-      rightLines.push(`│ Criteria: [${bar}] ${percent}%`)
-      rightLines.push(`│ Completed: ${met}/${total}`)
+      lines.push(`│ Criteria: [${bar}] ${percent}%`)
+      lines.push(`│ Completed: ${met}/${total}`)
     } else {
-      rightLines.push("│ Criteria: Parsing...")
+      lines.push("│ Criteria: Parsing...")
     }
-
-    const fit = (text: string, w: number) => {
-      const t = truncateToWidth(text, Math.max(1, w))
-      return `${t}${" ".repeat(Math.max(0, w - visibleWidth(t)))}`
-    }
-
-    // Merge columns
-    const maxCols = Math.max(leftLines.length, rightLines.length)
-    for (let i = 0; i < maxCols; i++) {
-      const l = fit(leftLines[i] || "│", leftWidth)
-      const r = truncateToWidth(rightLines[i] || "│", Math.max(1, rightWidth))
-      lines.push(truncateToWidth(`${l} ${r}`, width))
-    }
-    lines.push("")
-
-    // 4. Logs
-    lines.push("── Execution Logs ──")
-    
-    // We want to leave space for the bottom help text (2 lines) and account for lines already used.
-    // If terminal object exists, we can dynamically size the log area.
-    const termRows = this.tui?.terminal?.rows || 24
-    const bottomReserved = 2
-    const currentLinesCount = lines.length
-    
-    // Calculate how many logs we can fit, minimum 5
-    const maxLogLines = Math.max(5, termRows - currentLinesCount - bottomReserved)
-    const displayLogs = this.state.logs.slice(-maxLogLines)
-    
-    if (displayLogs.length === 0) {
-      lines.push(" Waiting for logs...")
-      // pad out remaining lines to prevent flickering height
-      const toPad = maxLogLines - 1
-      for(let i=0; i < toPad; i++) lines.push("")
-    } else {
-      for (const log of displayLogs) {
-        lines.push(truncateToWidth(` > ${log}`, width))
-      }
-      // pad out remaining lines if fewer than maxLogLines
-      const toPad = maxLogLines - displayLogs.length
-      for(let i=0; i < toPad; i++) lines.push("")
-    }
-
-    lines.push("")
-    lines.push("[q / Esc / Ctrl+C] Cancel Execution")
-
     return lines
   }
 }

--- a/.pi/extensions/xpowers/review-parallel.ts
+++ b/.pi/extensions/xpowers/review-parallel.ts
@@ -108,8 +108,19 @@ export async function runParallelReview(
     })
     // Launch dashboard and save handle
     handle = ctx.uiCtx.ui.custom(
-      (_tui: any, _theme: any, _keybindings: any, _done: (v: unknown) => void) => dashboard,
-      { overlay: true }
+      (tui: any, _theme: any, _keybindings: any, _done: (v: unknown) => void) => {
+        dashboard.tui = tui
+        return {
+          render: (width: number) => dashboard.render(width),
+          invalidate: () => dashboard.invalidate(),
+          handleInput: (data: string) => {
+            dashboard.handleInput(data)
+            tui.requestRender?.()
+            return true
+          },
+        }
+      },
+      { overlay: true, overlayOptions: { width: "96%", maxHeight: "90%", margin: 1 } }
     )
   }
 

--- a/tests/pi-brainstorm-tool.test.ts
+++ b/tests/pi-brainstorm-tool.test.ts
@@ -91,8 +91,8 @@ test("update_ralph_state opens dashboard with Pi custom factory", async () => {
       custom: (factory: any, options: any) => {
         customCalled = true
         expect(typeof factory).toBe("function")
-        expect(options).toEqual({ overlay: true })
-        dashboard = factory({ terminal: { rows: 30 } }, {}, {}, () => {})
+        expect(options).toEqual({ overlay: true, overlayOptions: { width: "96%", maxHeight: "90%", margin: 1 } })
+        dashboard = factory({ terminal: { rows: 30, columns: 100 }, requestRender: () => {} }, {}, {}, () => {})
         return { close: () => {}, requestRender: () => {} }
       }
     }
@@ -102,7 +102,7 @@ test("update_ralph_state opens dashboard with Pi custom factory", async () => {
 
   expect(customCalled).toBe(true)
   expect(typeof dashboard.render).toBe("function")
-  expect(dashboard.focused).toBe(true)
+  expect(dashboard.handleInput("q")).toBe(true)
   expect(result.content).toEqual([])
 })
 

--- a/tests/pi-dashboard-responsive.test.ts
+++ b/tests/pi-dashboard-responsive.test.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "bun:test"
+import { visibleWidth } from "../.pi/extensions/xpowers/node_modules/@mariozechner/pi-tui"
+import { BrainstormDashboard, type BrainstormState } from "../.pi/extensions/xpowers/brainstorm-tui"
+import { LiveExecutionDashboard, type LiveExecutionState } from "../.pi/extensions/xpowers/execution-dashboard-tui"
+
+function expectAllLinesFit(lines: string[], width: number) {
+  for (const line of lines) expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+}
+
+test("Brainstorm dashboard collapses to readable single-column layout on narrow terminals", () => {
+  const state: BrainstormState = {
+    requirements: ["Support responsive dashboards on iPhone Termius terminals"],
+    antiPatterns: [{ pattern: "Fixed desktop-only panes", reason: "mobile terminals become unreadable" }],
+    researchFindings: ["Pi TUI render(width) requires every line to fit"],
+    openQuestions: ["How narrow is narrow enough?"],
+    history: [{ role: "agent", content: "Asked about responsive behavior" }],
+    currentQuestion: {
+      question: "How should narrow terminals render?",
+      priority: "CRITICAL",
+      options: [
+        { label: "Adaptive single-column", description: "recommended for mobile" },
+        { label: "Keep desktop panes" },
+      ],
+    },
+  }
+  const dashboard = new BrainstormDashboard(state)
+  const lines = dashboard.render(38)
+  const text = lines.join("\n")
+
+  expect(text).toContain("Epic Preview")
+  expect(text).toContain("Current Question")
+  expect(text).not.toContain("│ Q:")
+  expectAllLinesFit(lines, 38)
+})
+
+test("Live execution dashboard uses compact progress and height cap on mobile terminals", () => {
+  const state: LiveExecutionState = {
+    title: "Parallel review with a very long title that should fit",
+    tasks: Array.from({ length: 8 }, (_, index) => ({
+      id: `task-${index + 1}`,
+      title: "Review lane with a verbose description that should not overflow",
+      status: index === 0 ? "running" : "pending",
+      summary: "Summary that should be shortened on small screens",
+    })),
+  }
+  const dashboard = new LiveExecutionDashboard(state)
+  dashboard.tui = { terminal: { columns: 36, rows: 12 } }
+  const lines = dashboard.render(36)
+  const text = lines.join("\n")
+
+  expect(text).toContain("Tasks")
+  expect(text).toContain("more tasks")
+  expect(lines.length).toBeLessThanOrEqual(12)
+  expectAllLinesFit(lines, 36)
+})
+
+test("Brainstorm narrow layout keeps current question visible when epic preview is long", () => {
+  const dashboard = new BrainstormDashboard({
+    requirements: Array.from({ length: 20 }, (_, i) => `Requirement ${i + 1} with enough text to consume rows`),
+    antiPatterns: [{ pattern: "Hide the prompt", reason: "user cannot answer" }],
+    researchFindings: [],
+    openQuestions: [],
+    history: [],
+    currentQuestion: {
+      question: "Which mobile layout should we use?",
+      priority: "CRITICAL",
+      options: [{ label: "Adaptive" }, { label: "Always compact" }],
+    },
+  })
+  dashboard.tui = { terminal: { columns: 36, rows: 10 } }
+
+  const text = dashboard.render(36).join("\n")
+
+  expect(text).toContain("Current Question")
+  expect(text).toContain("Which mobile layout")
+  expect(text).toContain("Adaptive")
+})
+
+test("Pi dashboards respect terminal widths below twenty columns", () => {
+  const brainstorm = new BrainstormDashboard({
+    requirements: ["Very long requirement that must fit"],
+    antiPatterns: [],
+    researchFindings: [],
+    openQuestions: [],
+    history: [],
+  })
+  brainstorm.tui = { terminal: { columns: 12, rows: 8 } }
+  expectAllLinesFit(brainstorm.render(12), 12)
+
+  const execution = new LiveExecutionDashboard({
+    title: "Very long live execution title",
+    tasks: [{ id: "lane", title: "Very long task title", status: "running" }],
+  })
+  execution.tui = { terminal: { columns: 12, rows: 8 } }
+  const executionLines = execution.render(12)
+  expectAllLinesFit(executionLines, 12)
+  expect(executionLines.length).toBeLessThanOrEqual(8)
+})

--- a/tests/pi-review-parallel.test.ts
+++ b/tests/pi-review-parallel.test.ts
@@ -110,10 +110,11 @@ test("runParallelReview uses TUI dashboard when UI context is available", async 
     ui: {
       custom: (factory: any, options: any) => {
         customCalled = true
-        expect(options).toEqual({ overlay: true })
+        expect(options).toEqual({ overlay: true, overlayOptions: { width: "96%", maxHeight: "90%", margin: 1 } })
         expect(typeof factory).toBe("function")
-        const component = factory({}, {}, {}, () => {})
-        expect(typeof component.updateTask).toBe("function")
+        const component = factory({ terminal: { columns: 100, rows: 30 }, requestRender: () => {} }, {}, {}, () => {})
+        expect(typeof component.render).toBe("function")
+        expect(component.handleInput("x")).toBe(true)
         return { 
           close: () => { handleClosed = true },
           requestRender: () => {}

--- a/tests/ralph-dashboard-tui.test.ts
+++ b/tests/ralph-dashboard-tui.test.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "bun:test"
+import { visibleWidth } from "../.pi/extensions/xpowers/node_modules/@mariozechner/pi-tui"
+import { RalphDashboard, type RalphState } from "../.pi/extensions/xpowers/ralph-dashboard-tui"
+
+function makeState(overrides: Partial<RalphState> = {}): RalphState {
+  return {
+    phase: "subagent",
+    epicId: "bd-1",
+    epicTitle: "Responsive dashboard work",
+    currentTaskId: "bd-2",
+    currentTaskTitle: "Fix Ralph hotkeys and mobile layout",
+    subagentStatus: "running",
+    subagentOutput: "Subagent is producing a very long status line that must not overflow narrow terminals",
+    branchName: "feature/mobile-friendly-ralph-dashboard",
+    gitProgress: "3 commits ahead with a very long message",
+    unmetCriteria: 2,
+    totalCriteria: 5,
+    logs: [
+      "Started Ralph execution with a log entry that is intentionally long enough to require truncation",
+      "Dispatched implementation subagent",
+    ],
+    ...overrides,
+  }
+}
+
+function expectAllLinesFit(lines: string[], width: number) {
+  for (const line of lines) {
+    // Strip ANSI escape sequences for a stable visible-length approximation in tests.
+    expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+  }
+}
+
+test("q, escape, and ctrl-c hotkeys cancel Ralph dashboard", () => {
+  for (const key of ["q", "\x1b", "\x03"]) {
+    let cancelled = false
+    const dashboard = new RalphDashboard(makeState(), () => { cancelled = true })
+
+    const handled = dashboard.handleInput(key)
+
+    expect(handled).toBe(true)
+    expect(cancelled).toBe(true)
+  }
+})
+
+test("Ralph dashboard renders as stacked single-column layout on narrow terminals", () => {
+  const dashboard = new RalphDashboard(makeState())
+  dashboard.tui = { terminal: { columns: 38, rows: 16 } }
+
+  const lines = dashboard.render(38)
+  const text = lines.join("\n")
+
+  expect(text).toContain("Current Focus")
+  expect(text).toContain("Epic Progress")
+  expect(text).not.toContain("╭── Current Focus ────────────────────── ╭── Epic Progress")
+  expectAllLinesFit(lines, 38)
+  expect(lines.length).toBeLessThanOrEqual(16)
+})
+
+test("Ralph dashboard respects widths smaller than twenty columns", () => {
+  const dashboard = new RalphDashboard(makeState())
+  dashboard.tui = { terminal: { columns: 12, rows: 10 } }
+
+  const lines = dashboard.render(12)
+
+  expectAllLinesFit(lines, 12)
+  expect(lines.length).toBeLessThanOrEqual(10)
+})
+
+test("Ralph dashboard keeps two-column layout on wide terminals", () => {
+  const dashboard = new RalphDashboard(makeState())
+  dashboard.tui = { terminal: { columns: 100, rows: 30 } }
+
+  const lines = dashboard.render(100)
+  const text = lines.join("\n")
+
+  expect(text).toContain("╭── Current Focus")
+  expect(text).toContain("╭── Epic Progress")
+  expect(text).toContain("╭── Current Focus ──────────────────────")
+  expectAllLinesFit(lines, 100)
+})


### PR DESCRIPTION
## Summary
- Fix Ralph dashboard cancel hotkeys and render refresh handling
- Add responsive single-column layouts for narrow/mobile Pi dashboards
- Add regression coverage for Ralph, Brainstorm, and live execution dashboards

## Test Plan
- bun test tests/pi-brainstorm-tool.test.ts tests/pi-review-parallel.test.ts tests/pi-dashboard-responsive.test.ts tests/ralph-dashboard-tui.test.ts
- node --test tests/*.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI dashboards now render responsively based on terminal width, automatically switching between compact and expanded layouts.
  * Added immediate visual feedback when users interact with inputs (cancel, navigate, select).
  * Improved overflow handling with "... N more" indicators when content exceeds available space.
  * Enhanced terminal size awareness for better use of available display area.

* **Tests**
  * Added comprehensive tests validating responsive rendering under constrained terminal dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->