### PR TITLE
fix: enforce tm-first task management

### DIFF
--- a/.gemini-extension/README.md
+++ b/.gemini-extension/README.md
@@ -168,7 +168,7 @@ tm close <id>                 # Complete work
 tm sync                       # Push local work to Linear (when configured)
 ```
 
-Legacy `bd_*` Gemini tools may remain for compatibility, but the branch direction is `tm` first.
+Legacy `bd_*` Gemini tools are not registered by default. Use the `tm_*` tools for normal task-management workflows.
 
 ## Extension Structure
 
@@ -179,7 +179,7 @@ Legacy `bd_*` Gemini tools may remain for compatibility, but the branch directio
 ├── mcp/
 │   ├── skills-server.js # MCP server for skills
 │   ├── agents-server.js # MCP server for agents
-│   ├── bd-server.js     # Legacy MCP server for bd integration
+│   ├── bd-server.js     # Legacy unregistered MCP server for bd compatibility testing
 │   └── tm-server.js     # MCP server for tm task management + sync
 ├── agents/              # Sub-agent definitions
 ├── commands/            # Slash command definitions
@@ -196,8 +196,9 @@ The extension uses Model Context Protocol (MCP) to expose capabilities:
 
 1. **skills-server**: Scans skills/ directory and exposes tools
 2. **agents-server**: Provides agent invocation
-3. **bd-server**: Wraps bd CLI commands (legacy compatibility)
-4. **tm-server**: Exposes shared tm task-management + sync commands
+3. **tm-server**: Exposes shared tm task-management + sync commands
+
+`bd-server.js` remains in the tree only for legacy compatibility tests and is not registered in the default manifest.
 
 ### Adding New Skills
 

--- a/.gemini-extension/agents/ralph.md
+++ b/.gemini-extension/agents/ralph.md
@@ -59,21 +59,21 @@ From `triage.project_health.graph`:
 bv --robot-next 2>/dev/null
 ```
 
-This returns the optimal next task with:
+This returns the optimal next task. Treat any backend command strings in the output as advisory only:
 ```json
 {
   "id": "bd-xxx",
   "title": "...",
   "score": 0.xx,
-  "claim_command": "bd update bd-xxx --status=in_progress",
-  "show_command": "bd show bd-xxx"
+  "claim_command": "<backend-specific command; do not run verbatim>",
+  "show_command": "<backend-specific command; do not run verbatim>"
 }
 ```
 
 ### Step 4: Claim and Execute
 
-1. Run the `claim_command` to mark in_progress
-2. Run the `show_command` to get full details
+1. Extract the issue `id` from the triage output and run `tm update <id> --status in_progress` to mark in_progress
+2. Run `tm show <id>` to get full details
 3. Check issue type:
    - **epic** → Use `execute-ralph` skill for full epic execution.
    - **task/bug/feature/chore** → Use **Stateless Dispatch** for SCIU implementation:
@@ -131,9 +131,9 @@ This returns tracks that can be executed in parallel. Consider spawning parallel
 | Smart next pick | `bv --robot-next` |
 | Full triage | `bv --robot-triage` |
 | Execution plan | `bv --robot-plan` |
-| Ready items | `bd ready --json` |
-| Blocked items | `bd blocked --json` |
-| Claim task | `bd update <id> --status in_progress` |
+| Ready items | `tm ready` |
+| Blocked items | `tm list --status blocked` |
+| Claim task | `tm update <id> --status in_progress` |
 | Verify task closure | `tm show <id> --json` |
 
 ## Integration

--- a/.gemini-extension/gemini-extension.json
+++ b/.gemini-extension/gemini-extension.json
@@ -14,11 +14,6 @@
       "args": ["${extensionPath}${/}mcp${/}agents-server.js"],
       "cwd": "${extensionPath}"
     },
-    "bd": {
-      "command": "node",
-      "args": ["${extensionPath}${/}mcp${/}bd-server.js"],
-      "cwd": "${extensionPath}"
-    },
     "tm": {
       "command": "node",
       "args": ["${extensionPath}${/}mcp${/}tm-server.js"],

--- a/.gemini-extension/tests/manifest-command-validation.test.js
+++ b/.gemini-extension/tests/manifest-command-validation.test.js
@@ -20,7 +20,7 @@ test('gemini extension manifest is parseable and canonical', async () => {
   assert.equal(typeof manifest.mcpServers, 'object');
   assert.ok(manifest.mcpServers.skills, 'manifest should include skills server');
   assert.ok(manifest.mcpServers.agents, 'manifest should include agents server');
-  assert.ok(manifest.mcpServers.bd, 'manifest should include bd server');
+  assert.equal(Object.prototype.hasOwnProperty.call(manifest.mcpServers, 'bd'), false, 'manifest should not expose legacy bd server by default');
   assert.ok(manifest.mcpServers.tm, 'manifest should include tm server');
   assert.equal(manifest.mcpServers.tm.command, 'node');
   assert.deepEqual(manifest.mcpServers.tm.args, ['${extensionPath}${/}mcp${/}tm-server.js']);

--- a/.kimi/agents/ralph-system.md
+++ b/.kimi/agents/ralph-system.md
@@ -59,21 +59,21 @@ From `triage.project_health.graph`:
 bv --robot-next 2>/dev/null
 ```
 
-This returns the optimal next task with:
+This returns the optimal next task. Treat any backend command strings in the output as advisory only:
 ```json
 {
   "id": "bd-xxx",
   "title": "...",
   "score": 0.xx,
-  "claim_command": "bd update bd-xxx --status=in_progress",
-  "show_command": "bd show bd-xxx"
+  "claim_command": "<backend-specific command; do not run verbatim>",
+  "show_command": "<backend-specific command; do not run verbatim>"
 }
 ```
 
 ### Step 4: Claim and Execute
 
-1. Run the `claim_command` to mark in_progress
-2. Run the `show_command` to get full details
+1. Extract the issue `id` from the triage output and run `tm update <id> --status in_progress` to mark in_progress
+2. Run `tm show <id>` to get full details
 3. Check issue type:
    - **epic** → Use `execute-ralph` skill for full epic execution.
    - **task/bug/feature/chore** → Use **Stateless Dispatch** for SCIU implementation:
@@ -131,9 +131,9 @@ This returns tracks that can be executed in parallel. Consider spawning parallel
 | Smart next pick | `bv --robot-next` |
 | Full triage | `bv --robot-triage` |
 | Execution plan | `bv --robot-plan` |
-| Ready items | `bd ready --json` |
-| Blocked items | `bd blocked --json` |
-| Claim task | `bd update <id> --status in_progress` |
+| Ready items | `tm ready` |
+| Blocked items | `tm list --status blocked` |
+| Claim task | `tm update <id> --status in_progress` |
 | Verify task closure | `tm show <id> --json` |
 
 ## Integration

--- a/.kimi/skills/codex-agent-ralph/SKILL.md
+++ b/.kimi/skills/codex-agent-ralph/SKILL.md
@@ -77,21 +77,21 @@ From `triage.project_health.graph`:
 bv --robot-next 2>/dev/null
 ```
 
-This returns the optimal next task with:
+This returns the optimal next task. Treat any backend command strings in the output as advisory only:
 ```json
 {
   "id": "bd-xxx",
   "title": "...",
   "score": 0.xx,
-  "claim_command": "bd update bd-xxx --status=in_progress",
-  "show_command": "bd show bd-xxx"
+  "claim_command": "<backend-specific command; do not run verbatim>",
+  "show_command": "<backend-specific command; do not run verbatim>"
 }
 ```
 
 ### Step 4: Claim and Execute
 
-1. Run the `claim_command` to mark in_progress
-2. Run the `show_command` to get full details
+1. Extract the issue `id` from the triage output and run `tm update <id> --status in_progress` to mark in_progress
+2. Run `tm show <id>` to get full details
 3. Check issue type:
    - **epic** → Use `execute-ralph` skill for full epic execution.
    - **task/bug/feature/chore** → Use **Stateless Dispatch** for SCIU implementation:
@@ -149,9 +149,9 @@ This returns tracks that can be executed in parallel. Consider spawning parallel
 | Smart next pick | `bv --robot-next` |
 | Full triage | `bv --robot-triage` |
 | Execution plan | `bv --robot-plan` |
-| Ready items | `bd ready --json` |
-| Blocked items | `bd blocked --json` |
-| Claim task | `bd update <id> --status in_progress` |
+| Ready items | `tm ready` |
+| Blocked items | `tm list --status blocked` |
+| Claim task | `tm update <id> --status in_progress` |
 | Verify task closure | `tm show <id> --json` |
 
 ## Integration

--- a/.kimi/skills/codex-skill-fixing-bugs/SKILL.md
+++ b/.kimi/skills/codex-skill-fixing-bugs/SKILL.md
@@ -74,7 +74,7 @@ tm create "Bug: [Clear description]" --type bug --priority P1
 
 **Document:**
 ```bash
-tm edit bd-123 --design "
+tm update bd-123 --design "
 ## Bug Description
 [What's wrong]
 
@@ -108,7 +108,7 @@ Use Skill tool: xpowers:debugging-with-tools
 
 **Update bd issue with findings:**
 ```bash
-tm edit bd-123 --design "[previous content]
+tm update bd-123 --design "[previous content]
 
 ## Investigation
 [Root cause found via debugging]
@@ -186,7 +186,7 @@ pytest tests/test_user.py::test_rejects_empty_email
 **REQUIRED: Classify fix status before closing:**
 
 ```bash
-tm edit bd-123 --design "[previous content]
+tm update bd-123 --design "[previous content]
 
 ## Fix Status: FIXED
 **Evidence:**

--- a/.kimi/skills/codex-skill-managing-bd-tasks/SKILL.md
+++ b/.kimi/skills/codex-skill-managing-bd-tasks/SKILL.md
@@ -104,7 +104,7 @@ tm dep tree bd-5
 ### Step 3: Update original task and close
 
 ```bash
-tm edit bd-5 --design "
+tm update bd-5 --design "
 Implement user authentication.
 
 ## Status
@@ -163,7 +163,7 @@ tm show bd-7
 tm show bd-9
 
 # Combine into bd-7
-tm edit bd-7 --design "
+tm update bd-7 --design "
 Add email validation to user creation and update.
 
 ## Background
@@ -195,7 +195,7 @@ tm dep add bd-10 bd-7
 ### Step 4: Close duplicate with reference
 
 ```bash
-tm edit bd-9 --design "DUPLICATE: Merged into bd-7
+tm update bd-9 --design "DUPLICATE: Merged into bd-7
 
 This task was duplicate of bd-7. All work tracked there."
 
@@ -388,7 +388,7 @@ tm dep add bd-10 bd-9     # Add correct
 git log -p -- .beads/issues.jsonl | grep -A 50 "bd-10"
 # Find previous version, copy
 
-tm edit bd-10 --design "[paste previous]"
+tm update bd-10 --design "[paste previous]"
 ```
 
 ### Epic structure wrong
@@ -435,7 +435,7 @@ tm show bd-7  # Only mentions validation on creation
 tm show bd-9  # Mentions validation on update too
 
 # Merge information
-tm edit bd-7 --design "
+tm update bd-7 --design "
 Email validation for user creation and update.
 
 ## Background
@@ -448,7 +448,7 @@ Merged from bd-9.
 "
 
 # Then close duplicate with reference
-tm edit bd-9 --design "DUPLICATE: Merged into bd-7"
+tm update bd-9 --design "DUPLICATE: Merged into bd-7"
 tm close bd-9
 ```
 
@@ -496,7 +496,7 @@ bd-15: "Implement payment processing" (started)
 ```bash
 # 3 hours in, stop and split
 
-tm edit bd-15 --design "
+tm update bd-15 --design "
 Implement payment processing.
 
 ## Status
@@ -587,7 +587,7 @@ tm create "Analytics API endpoints" ...  # bd-20
 tm dep add bd-15 bd-20
 
 # UPDATE bd-15 to document new requirement
-tm edit bd-15 --design "
+tm update bd-15 --design "
 Add analytics to dashboard.
 
 ## Dependencies

--- a/.kimi/skills/codex-skill-refactoring-safely/SKILL.md
+++ b/.kimi/skills/codex-skill-refactoring-safely/SKILL.md
@@ -75,7 +75,7 @@ tm create "Refactor: Extract user validation logic" \
   --type task \
   --priority P2
 
-tm edit bd-456 --design "
+tm update bd-456 --design "
 ## Goal
 Extract user validation logic from UserService into separate Validator class.
 
@@ -248,7 +248,7 @@ git diff main...HEAD
 **Close bd task:**
 
 ```bash
-tm edit bd-456 --design "
+tm update bd-456 --design "
 ... (append to existing design)
 
 ## Completed

--- a/.kimi/skills/fixing-bugs/SKILL.md
+++ b/.kimi/skills/fixing-bugs/SKILL.md
@@ -81,7 +81,7 @@ tm create "Bug: [Clear description]" --type bug --priority P1
 
 **Document:**
 ```bash
-bd edit bd-123 --design "
+tm update bd-123 --design "
 ## Bug Description
 [What's wrong]
 
@@ -115,7 +115,7 @@ Use Skill tool: xpowers:debugging-with-tools
 
 **Update bd issue with findings:**
 ```bash
-bd edit bd-123 --design "[previous content]
+tm update bd-123 --design "[previous content]
 
 ## Investigation
 [Root cause found via debugging]
@@ -193,7 +193,7 @@ pytest tests/test_user.py::test_rejects_empty_email
 **REQUIRED: Classify fix status before closing:**
 
 ```bash
-bd edit bd-123 --design "[previous content]
+tm update bd-123 --design "[previous content]
 
 ## Fix Status: FIXED
 **Evidence:**

--- a/.kimi/skills/managing-bd-tasks/SKILL.md
+++ b/.kimi/skills/managing-bd-tasks/SKILL.md
@@ -111,7 +111,7 @@ tm dep tree bd-5
 ### Step 3: Update original task and close
 
 ```bash
-bd edit bd-5 --design "
+tm update bd-5 --design "
 Implement user authentication.
 
 ## Status
@@ -170,7 +170,7 @@ tm show bd-7
 tm show bd-9
 
 # Combine into bd-7
-bd edit bd-7 --design "
+tm update bd-7 --design "
 Add email validation to user creation and update.
 
 ## Background
@@ -202,7 +202,7 @@ tm dep add bd-10 bd-7
 ### Step 4: Close duplicate with reference
 
 ```bash
-bd edit bd-9 --design "DUPLICATE: Merged into bd-7
+tm update bd-9 --design "DUPLICATE: Merged into bd-7
 
 This task was duplicate of bd-7. All work tracked there."
 
@@ -395,7 +395,7 @@ tm dep add bd-10 bd-9     # Add correct
 git log -p -- .beads/issues.jsonl | grep -A 50 "bd-10"
 # Find previous version, copy
 
-bd edit bd-10 --design "[paste previous]"
+tm update bd-10 --design "[paste previous]"
 ```
 
 ### Epic structure wrong
@@ -442,7 +442,7 @@ tm show bd-7  # Only mentions validation on creation
 tm show bd-9  # Mentions validation on update too
 
 # Merge information
-bd edit bd-7 --design "
+tm update bd-7 --design "
 Email validation for user creation and update.
 
 ## Background
@@ -455,7 +455,7 @@ Merged from bd-9.
 "
 
 # Then close duplicate with reference
-bd edit bd-9 --design "DUPLICATE: Merged into bd-7"
+tm update bd-9 --design "DUPLICATE: Merged into bd-7"
 tm close bd-9
 ```
 
@@ -503,7 +503,7 @@ bd-15: "Implement payment processing" (started)
 ```bash
 # 3 hours in, stop and split
 
-bd edit bd-15 --design "
+tm update bd-15 --design "
 Implement payment processing.
 
 ## Status
@@ -594,7 +594,7 @@ tm create "Analytics API endpoints" ...  # bd-20
 tm dep add bd-15 bd-20
 
 # UPDATE bd-15 to document new requirement
-bd edit bd-15 --design "
+tm update bd-15 --design "
 Add analytics to dashboard.
 
 ## Dependencies

--- a/.kimi/skills/refactoring-safely/SKILL.md
+++ b/.kimi/skills/refactoring-safely/SKILL.md
@@ -73,7 +73,7 @@ tm create "Refactor: Extract user validation logic" \
   --type task \
   --priority P2
 
-bd edit bd-456 --design "
+tm update bd-456 --design "
 ## Goal
 Extract user validation logic from UserService into separate Validator class.
 
@@ -246,7 +246,7 @@ git diff main...HEAD
 **Close bd task:**
 
 ```bash
-bd edit bd-456 --design "
+tm update bd-456 --design "
 ... (append to existing design)
 
 ## Completed

--- a/.kimi/skills/refactoring-safely/resources/example-session.md
+++ b/.kimi/skills/refactoring-safely/resources/example-session.md
@@ -13,7 +13,7 @@ Result: ✓ 234 tests pass
 ### Minutes 5-10: Create bd Task
 ```bash
 tm create "Refactor: Extract user validation" --type task
-tm edit bd-456 --design "Extract validation to UserValidator class..."
+tm update bd-456 --design "Extract validation to UserValidator class..."
 tm update bd-456 --status in_progress
 ```
 

--- a/.opencode/agents/ralph.md
+++ b/.opencode/agents/ralph.md
@@ -59,21 +59,21 @@ From `triage.project_health.graph`:
 bv --robot-next 2>/dev/null
 ```
 
-This returns the optimal next task with:
+This returns the optimal next task. Treat any backend command strings in the output as advisory only:
 ```json
 {
   "id": "bd-xxx",
   "title": "...",
   "score": 0.xx,
-  "claim_command": "bd update bd-xxx --status=in_progress",
-  "show_command": "bd show bd-xxx"
+  "claim_command": "<backend-specific command; do not run verbatim>",
+  "show_command": "<backend-specific command; do not run verbatim>"
 }
 ```
 
 ### Step 4: Claim and Execute
 
-1. Run the `claim_command` to mark in_progress
-2. Run the `show_command` to get full details
+1. Extract the issue `id` from the triage output and run `tm update <id> --status in_progress` to mark in_progress
+2. Run `tm show <id>` to get full details
 3. Check issue type:
    - **epic** → Use `execute-ralph` skill for full epic execution.
    - **task/bug/feature/chore** → Use **Stateless Dispatch** for SCIU implementation:
@@ -131,9 +131,9 @@ This returns tracks that can be executed in parallel. Consider spawning parallel
 | Smart next pick | `bv --robot-next` |
 | Full triage | `bv --robot-triage` |
 | Execution plan | `bv --robot-plan` |
-| Ready items | `bd ready --json` |
-| Blocked items | `bd blocked --json` |
-| Claim task | `bd update <id> --status in_progress` |
+| Ready items | `tm ready` |
+| Blocked items | `tm list --status blocked` |
+| Claim task | `tm update <id> --status in_progress` |
 | Verify task closure | `tm show <id> --json` |
 
 ## Integration

--- a/.opencode/skills/xpowers-fixing-bugs/SKILL.md
+++ b/.opencode/skills/xpowers-fixing-bugs/SKILL.md
@@ -53,7 +53,7 @@ tm create "Bug: [Clear description]" --type bug --priority P1
 
 **Document:**
 ```bash
-bd edit bd-123 --design "
+tm update bd-123 --design "
 ## Bug Description
 [What's wrong]
 
@@ -87,7 +87,7 @@ Use Skill tool: xpowers:debugging-with-tools
 
 **Update bd issue with findings:**
 ```bash
-bd edit bd-123 --design "[previous content]
+tm update bd-123 --design "[previous content]
 
 ## Investigation
 [Root cause found via debugging]
@@ -164,7 +164,7 @@ pytest tests/test_user.py::test_rejects_empty_email
 
 **Update with fix details:**
 ```bash
-bd edit bd-123 --design "[previous content]
+tm update bd-123 --design "[previous content]
 
 ## Fix Implemented
 [Description of fix]

--- a/.opencode/skills/xpowers-managing-bd-tasks/SKILL.md
+++ b/.opencode/skills/xpowers-managing-bd-tasks/SKILL.md
@@ -102,7 +102,7 @@ tm dep tree bd-5
 ### Step 3: Update original task and close
 
 ```bash
-bd edit bd-5 --design "
+tm update bd-5 --design "
 Implement user authentication.
 
 ## Status
@@ -161,7 +161,7 @@ tm show bd-7
 tm show bd-9
 
 # Combine into bd-7
-bd edit bd-7 --design "
+tm update bd-7 --design "
 Add email validation to user creation and update.
 
 ## Background
@@ -193,7 +193,7 @@ tm dep add bd-10 bd-7
 ### Step 4: Close duplicate with reference
 
 ```bash
-bd edit bd-9 --design "DUPLICATE: Merged into bd-7
+tm update bd-9 --design "DUPLICATE: Merged into bd-7
 
 This task was duplicate of bd-7. All work tracked there."
 
@@ -386,7 +386,7 @@ tm dep add bd-10 bd-9     # Add correct
 git log -p -- .beads/issues.jsonl | grep -A 50 "bd-10"
 # Find previous version, copy
 
-bd edit bd-10 --design "[paste previous]"
+tm update bd-10 --design "[paste previous]"
 ```
 
 ### Epic structure wrong
@@ -433,7 +433,7 @@ tm show bd-7  # Only mentions validation on creation
 tm show bd-9  # Mentions validation on update too
 
 # Merge information
-bd edit bd-7 --design "
+tm update bd-7 --design "
 Email validation for user creation and update.
 
 ## Background
@@ -446,7 +446,7 @@ Merged from bd-9.
 "
 
 # Then close duplicate with reference
-bd edit bd-9 --design "DUPLICATE: Merged into bd-7"
+tm update bd-9 --design "DUPLICATE: Merged into bd-7"
 tm close bd-9
 ```
 
@@ -494,7 +494,7 @@ bd-15: "Implement payment processing" (started)
 ```bash
 # 3 hours in, stop and split
 
-bd edit bd-15 --design "
+tm update bd-15 --design "
 Implement payment processing.
 
 ## Status
@@ -585,7 +585,7 @@ tm create "Analytics API endpoints" ...  # bd-20
 tm dep add bd-15 bd-20
 
 # UPDATE bd-15 to document new requirement
-bd edit bd-15 --design "
+tm update bd-15 --design "
 Add analytics to dashboard.
 
 ## Dependencies

--- a/.opencode/skills/xpowers-refactoring-safely/SKILL.md
+++ b/.opencode/skills/xpowers-refactoring-safely/SKILL.md
@@ -64,7 +64,7 @@ tm create "Refactor: Extract user validation logic" \
   --type task \
   --priority P2
 
-bd edit bd-456 --design "
+tm update bd-456 --design "
 ## Goal
 Extract user validation logic from UserService into separate Validator class.
 
@@ -237,7 +237,7 @@ git diff main...HEAD
 **Close bd task:**
 
 ```bash
-bd edit bd-456 --design "
+tm update bd-456 --design "
 ... (append to existing design)
 
 ## Completed

--- a/.pi/extensions/xpowers/index.ts
+++ b/.pi/extensions/xpowers/index.ts
@@ -784,16 +784,28 @@ export default function (pi: any) {
         session.hidden = false
       }
 
-      if (session?.hidden) {
-        return { content: [] }
-      }
-
       if (session?.closeTimer) {
         clearTimeout(session.closeTimer)
         session.closeTimer = undefined
       }
 
       const { logMessage, ...stateUpdate } = params
+
+      if (session?.hidden) {
+        session.dashboard?.updateState(stateUpdate)
+        if (logMessage) {
+          session.dashboard?.addLog(logMessage)
+        }
+        if (params.phase === "done") {
+          session.closeTimer = setTimeout(() => {
+            const currSession = ralphSessions.get(sessionKey)
+            if (currSession === session) {
+              ralphSessions.delete(sessionKey)
+            }
+          }, 2000)
+        }
+        return { content: [] }
+      }
 
       if (!session || !session.dashboard) {
         const dashboard = new RalphDashboard({

--- a/.pi/extensions/xpowers/index.ts
+++ b/.pi/extensions/xpowers/index.ts
@@ -736,6 +736,7 @@ export default function (pi: any) {
   const ralphSessions = new Map<string, {
     dashboard: any
     handle: any
+    hidden?: boolean
     closeTimer?: ReturnType<typeof setTimeout>
   }>()
 
@@ -745,6 +746,7 @@ export default function (pi: any) {
     description: "Update the non-blocking Ralph Execution Dashboard TUI with current phase, epic/task status, and logs. The dashboard can be hidden with q/Esc/Ctrl+C and should never block normal Pi input.",
     parameters: Type.Object({
       close: Type.Optional(Type.Boolean({ description: "Close/hide the Ralph dashboard for this session" })),
+      reopen: Type.Optional(Type.Boolean({ description: "Reopen the Ralph dashboard after it was hidden" })),
       phase: Type.Optional(Type.String({ description: "setup, get_task, subagent, review, completion, done" })),
       epicId: Type.Optional(Type.String()),
       epicTitle: Type.Optional(Type.String()),
@@ -774,8 +776,16 @@ export default function (pi: any) {
           session.closeTimer = undefined
         }
         session?.handle?.close?.()
-        ralphSessions.delete(sessionKey)
+        ralphSessions.set(sessionKey, { dashboard: session?.dashboard ?? null, handle: null, hidden: true })
         return { content: [{ type: "text", text: "Ralph dashboard hidden." }] }
+      }
+
+      if (params.reopen === true && session?.hidden) {
+        session.hidden = false
+      }
+
+      if (session?.hidden) {
+        return { content: [] }
       }
 
       if (session?.closeTimer) {
@@ -800,7 +810,8 @@ export default function (pi: any) {
               currSession.closeTimer = undefined
             }
             currSession.handle?.close?.()
-            ralphSessions.delete(sessionKey)
+            currSession.handle = null
+            currSession.hidden = true
           }
         })
         dashboard.tui = ctx.ui.tui // try to grab tui reference if available

--- a/.pi/extensions/xpowers/index.ts
+++ b/.pi/extensions/xpowers/index.ts
@@ -742,8 +742,9 @@ export default function (pi: any) {
   pi.registerTool({
     name: "update_ralph_state",
     label: "Ralph Dashboard",
-    description: "Update the interactive Ralph Execution Dashboard TUI with current phase, epic/task status, and logs. Always use this during execute-ralph to show progress.",
+    description: "Update the non-blocking Ralph Execution Dashboard TUI with current phase, epic/task status, and logs. The dashboard can be hidden with q/Esc/Ctrl+C and should never block normal Pi input.",
     parameters: Type.Object({
+      close: Type.Optional(Type.Boolean({ description: "Close/hide the Ralph dashboard for this session" })),
       phase: Type.Optional(Type.String({ description: "setup, get_task, subagent, review, completion, done" })),
       epicId: Type.Optional(Type.String()),
       epicTitle: Type.Optional(Type.String()),
@@ -766,6 +767,16 @@ export default function (pi: any) {
 
       const sessionKey = ctx?.sessionManager?.getSessionFile?.() || "default"
       let session = ralphSessions.get(sessionKey)
+
+      if (params.close === true) {
+        if (session?.closeTimer) {
+          clearTimeout(session.closeTimer)
+          session.closeTimer = undefined
+        }
+        session?.handle?.close?.()
+        ralphSessions.delete(sessionKey)
+        return { content: [{ type: "text", text: "Ralph dashboard hidden." }] }
+      }
 
       if (session?.closeTimer) {
         clearTimeout(session.closeTimer)
@@ -790,13 +801,6 @@ export default function (pi: any) {
             }
             currSession.handle?.close?.()
             ralphSessions.delete(sessionKey)
-
-            // Abort the pi host execution so the LLM workflow halts
-            if (typeof ctx?.abort === "function") {
-              ctx.abort()
-            } else if (typeof ctx?.ui?.cancel === "function") {
-              ctx.ui.cancel()
-            }
           }
         })
         dashboard.tui = ctx.ui.tui // try to grab tui reference if available
@@ -818,9 +822,9 @@ export default function (pi: any) {
               render: (width: number) => session!.dashboard.render(width),
               invalidate: () => session!.dashboard.invalidate(),
               handleInput: (data: string) => {
-                session!.dashboard.handleInput(data)
-                tui.requestRender?.()
-                return true
+                const handled = session!.dashboard.handleInput(data)
+                if (handled) tui.requestRender?.()
+                return handled
               },
             }
           },

--- a/.pi/extensions/xpowers/ralph-dashboard-tui.ts
+++ b/.pi/extensions/xpowers/ralph-dashboard-tui.ts
@@ -87,7 +87,11 @@ export class RalphDashboard extends Container implements Focusable {
       this.tui?.requestRender?.()
       return true
     }
-    return true
+
+    // Do not swallow normal keyboard input. The dashboard is informational;
+    // if it has focus unexpectedly, unhandled keys must be allowed to fall
+    // through so Pi's main input remains responsive.
+    return false
   }
 
   render(width: number): string[] {
@@ -151,7 +155,7 @@ export class RalphDashboard extends Container implements Focusable {
 
     push("── Execution Logs ──")
 
-    const helpLine = "[q / Esc / Ctrl+C] Cancel Execution"
+    const helpLine = "[q / Esc / Ctrl+C] Hide Dashboard"
     const reservedForHelp = 2
     const remainingRows = Math.max(0, termRows - lines.length - reservedForHelp)
     const maxLogLines = narrow ? Math.min(remainingRows, 3) : remainingRows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,6 +454,8 @@ tm close bd-42
 
 These tools are related, but they are **not interchangeable day-to-day commands**. Use `tm` for canonical workflow guidance with **one backend selected per project** unless a backend-specific guide explicitly calls for `bd`, `br`, `tk`, or `linear`.
 
+Global ralph-tui skills may explicitly use beads-rust (`br`) to create `ralph-tui` task sources. That is a separate backend-specific workflow; inside this XPowers repo, use `tm` for project task tracking unless the user explicitly asks for `ralph-tui`, `beads-rust`, or `br` task-source generation.
+
 ### Workflow for AI Agents
 
 1. **Check ready work**: `tm ready` shows unblocked issues

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ While `tm` provides a unified interface, some backends use different flag names 
 
 This mapping currently applies to `tm create` with the `br` backend.
 
+### Boundary: ralph-tui / beads-rust Skills
+
+Some global skills outside this repo can generate task sources for `ralph-tui` using beads-rust (`br`). Those workflows are explicitly backend-specific. Inside XPowers project work, agents must use `tm` unless the user explicitly asks for `ralph-tui`, `beads-rust`, or `br` task-source generation.
+
 ## Features
 
 ### Skills

--- a/agents/ralph.md
+++ b/agents/ralph.md
@@ -59,21 +59,21 @@ From `triage.project_health.graph`:
 bv --robot-next 2>/dev/null
 ```
 
-This returns the optimal next task with:
+This returns the optimal next task. Treat any backend command strings in the output as advisory only:
 ```json
 {
   "id": "bd-xxx",
   "title": "...",
   "score": 0.xx,
-  "claim_command": "bd update bd-xxx --status=in_progress",
-  "show_command": "bd show bd-xxx"
+  "claim_command": "<backend-specific command; do not run verbatim>",
+  "show_command": "<backend-specific command; do not run verbatim>"
 }
 ```
 
 ### Step 4: Claim and Execute
 
-1. Run the `claim_command` to mark in_progress
-2. Run the `show_command` to get full details
+1. Extract the issue `id` from the triage output and run `tm update <id> --status in_progress` to mark in_progress
+2. Run `tm show <id>` to get full details
 3. Check issue type:
    - **epic** → Use `execute-ralph` skill for full epic execution.
    - **task/bug/feature/chore** → Use **Stateless Dispatch** for SCIU implementation:
@@ -131,9 +131,9 @@ This returns tracks that can be executed in parallel. Consider spawning parallel
 | Smart next pick | `bv --robot-next` |
 | Full triage | `bv --robot-triage` |
 | Execution plan | `bv --robot-plan` |
-| Ready items | `bd ready --json` |
-| Blocked items | `bd blocked --json` |
-| Claim task | `bd update <id> --status in_progress` |
+| Ready items | `tm ready` |
+| Blocked items | `tm list --status blocked` |
+| Claim task | `tm update <id> --status in_progress` |
 | Verify task closure | `tm show <id> --json` |
 
 ## Integration

--- a/skills/fixing-bugs/SKILL.md
+++ b/skills/fixing-bugs/SKILL.md
@@ -72,7 +72,7 @@ tm create "Bug: [Clear description]" --type bug --priority P1
 
 **Document:**
 ```bash
-tm edit bd-123 --design "
+tm update bd-123 --design "
 ## Bug Description
 [What's wrong]
 
@@ -106,7 +106,7 @@ Use Skill tool: xpowers:debugging-with-tools
 
 **Update bd issue with findings:**
 ```bash
-tm edit bd-123 --design "[previous content]
+tm update bd-123 --design "[previous content]
 
 ## Investigation
 [Root cause found via debugging]
@@ -184,7 +184,7 @@ pytest tests/test_user.py::test_rejects_empty_email
 **REQUIRED: Classify fix status before closing:**
 
 ```bash
-tm edit bd-123 --design "[previous content]
+tm update bd-123 --design "[previous content]
 
 ## Fix Status: FIXED
 **Evidence:**

--- a/skills/managing-bd-tasks/SKILL.md
+++ b/skills/managing-bd-tasks/SKILL.md
@@ -102,7 +102,7 @@ tm dep tree bd-5
 ### Step 3: Update original task and close
 
 ```bash
-tm edit bd-5 --design "
+tm update bd-5 --design "
 Implement user authentication.
 
 ## Status
@@ -161,7 +161,7 @@ tm show bd-7
 tm show bd-9
 
 # Combine into bd-7
-tm edit bd-7 --design "
+tm update bd-7 --design "
 Add email validation to user creation and update.
 
 ## Background
@@ -193,7 +193,7 @@ tm dep add bd-10 bd-7
 ### Step 4: Close duplicate with reference
 
 ```bash
-tm edit bd-9 --design "DUPLICATE: Merged into bd-7
+tm update bd-9 --design "DUPLICATE: Merged into bd-7
 
 This task was duplicate of bd-7. All work tracked there."
 
@@ -386,7 +386,7 @@ tm dep add bd-10 bd-9     # Add correct
 git log -p -- .beads/issues.jsonl | grep -A 50 "bd-10"
 # Find previous version, copy
 
-tm edit bd-10 --design "[paste previous]"
+tm update bd-10 --design "[paste previous]"
 ```
 
 ### Epic structure wrong
@@ -433,7 +433,7 @@ tm show bd-7  # Only mentions validation on creation
 tm show bd-9  # Mentions validation on update too
 
 # Merge information
-tm edit bd-7 --design "
+tm update bd-7 --design "
 Email validation for user creation and update.
 
 ## Background
@@ -446,7 +446,7 @@ Merged from bd-9.
 "
 
 # Then close duplicate with reference
-tm edit bd-9 --design "DUPLICATE: Merged into bd-7"
+tm update bd-9 --design "DUPLICATE: Merged into bd-7"
 tm close bd-9
 ```
 
@@ -494,7 +494,7 @@ bd-15: "Implement payment processing" (started)
 ```bash
 # 3 hours in, stop and split
 
-tm edit bd-15 --design "
+tm update bd-15 --design "
 Implement payment processing.
 
 ## Status
@@ -585,7 +585,7 @@ tm create "Analytics API endpoints" ...  # bd-20
 tm dep add bd-15 bd-20
 
 # UPDATE bd-15 to document new requirement
-tm edit bd-15 --design "
+tm update bd-15 --design "
 Add analytics to dashboard.
 
 ## Dependencies

--- a/skills/refactoring-safely/SKILL.md
+++ b/skills/refactoring-safely/SKILL.md
@@ -73,7 +73,7 @@ tm create "Refactor: Extract user validation logic" \
   --type task \
   --priority P2
 
-tm edit bd-456 --design "
+tm update bd-456 --design "
 ## Goal
 Extract user validation logic from UserService into separate Validator class.
 
@@ -246,7 +246,7 @@ git diff main...HEAD
 **Close bd task:**
 
 ```bash
-tm edit bd-456 --design "
+tm update bd-456 --design "
 ... (append to existing design)
 
 ## Completed

--- a/skills/refactoring-safely/resources/example-session.md
+++ b/skills/refactoring-safely/resources/example-session.md
@@ -13,7 +13,7 @@ Result: ✓ 234 tests pass
 ### Minutes 5-10: Create bd Task
 ```bash
 tm create "Refactor: Extract user validation" --type task
-tm edit bd-456 --design "Extract validation to UserValidator class..."
+tm update bd-456 --design "Extract validation to UserValidator class..."
 tm update bd-456 --status in_progress
 ```
 

--- a/tests/pi-brainstorm-tool.test.ts
+++ b/tests/pi-brainstorm-tool.test.ts
@@ -107,7 +107,7 @@ test("update_ralph_state opens dashboard with Pi custom factory", async () => {
   expect(result.content).toEqual([])
 })
 
-test("update_ralph_state can explicitly close dashboard", async () => {
+test("update_ralph_state can explicitly close dashboard and keep it hidden", async () => {
   let ralphTool: any
   const piMock: any = {
     on: () => {},
@@ -119,10 +119,12 @@ test("update_ralph_state can explicitly close dashboard", async () => {
   initExtension(piMock)
 
   let closeCount = 0
+  let customCount = 0
   const ctx = {
     sessionManager: { getSessionFile: () => "ralph-close-test" },
     ui: {
       custom: (factory: any) => {
+        customCount++
         factory({ terminal: { rows: 30, columns: 100 }, requestRender: () => {} }, {}, {}, () => {})
         return { close: () => { closeCount++ }, requestRender: () => {} }
       }
@@ -131,9 +133,42 @@ test("update_ralph_state can explicitly close dashboard", async () => {
 
   await ralphTool.execute("call-id", { phase: "setup" }, undefined, undefined, ctx)
   const result = await ralphTool.execute("call-id", { close: true }, undefined, undefined, ctx)
+  await ralphTool.execute("call-id", { phase: "subagent", logMessage: "should stay hidden" }, undefined, undefined, ctx)
 
   expect(closeCount).toBe(1)
+  expect(customCount).toBe(1)
   expect(result.content[0].text).toBe("Ralph dashboard hidden.")
+})
+
+test("update_ralph_state can reopen dashboard after explicit close", async () => {
+  let ralphTool: any
+  const piMock: any = {
+    on: () => {},
+    registerCommand: () => {},
+    registerTool: (def: any) => {
+      if (def.name === "update_ralph_state") ralphTool = def
+    }
+  }
+  initExtension(piMock)
+
+  let customCount = 0
+  const ctx = {
+    sessionManager: { getSessionFile: () => "ralph-reopen-test" },
+    ui: {
+      custom: (factory: any) => {
+        customCount++
+        factory({ terminal: { rows: 30, columns: 100 }, requestRender: () => {} }, {}, {}, () => {})
+        return { close: () => {}, requestRender: () => {} }
+      }
+    }
+  }
+
+  await ralphTool.execute("call-id", { phase: "setup" }, undefined, undefined, ctx)
+  await ralphTool.execute("call-id", { close: true }, undefined, undefined, ctx)
+  await ralphTool.execute("call-id", { phase: "subagent" }, undefined, undefined, ctx)
+  await ralphTool.execute("call-id", { reopen: true, phase: "review" }, undefined, undefined, ctx)
+
+  expect(customCount).toBe(2)
 })
 
 test("Ralph dashboard hides on cancel hotkeys", async () => {

--- a/tests/pi-brainstorm-tool.test.ts
+++ b/tests/pi-brainstorm-tool.test.ts
@@ -171,6 +171,79 @@ test("update_ralph_state can reopen dashboard after explicit close", async () =>
   expect(customCount).toBe(2)
 })
 
+test("update_ralph_state keeps state fresh while dashboard is hidden", async () => {
+  let ralphTool: any
+  const piMock: any = {
+    on: () => {},
+    registerCommand: () => {},
+    registerTool: (def: any) => {
+      if (def.name === "update_ralph_state") ralphTool = def
+    }
+  }
+  initExtension(piMock)
+
+  let customCount = 0
+  let reopenedDashboard: any
+  const ctx = {
+    sessionManager: { getSessionFile: () => "ralph-hidden-fresh-state-test" },
+    ui: {
+      custom: (factory: any) => {
+        customCount++
+        const dashboard = factory({ terminal: { rows: 30, columns: 100 }, requestRender: () => {} }, {}, {}, () => {})
+        if (customCount === 2) reopenedDashboard = dashboard
+        return { close: () => {}, requestRender: () => {} }
+      }
+    }
+  }
+
+  await ralphTool.execute("call-id", { phase: "setup", currentTaskId: "hyper-old", currentTaskTitle: "Old task" }, undefined, undefined, ctx)
+  await ralphTool.execute("call-id", { close: true }, undefined, undefined, ctx)
+  await ralphTool.execute("call-id", { phase: "subagent", currentTaskId: "hyper-new", currentTaskTitle: "Fresh task", logMessage: "fresh hidden log" }, undefined, undefined, ctx)
+
+  expect(customCount).toBe(1)
+
+  await ralphTool.execute("call-id", { reopen: true, phase: "review" }, undefined, undefined, ctx)
+
+  expect(customCount).toBe(2)
+  const rendered = reopenedDashboard.render(100).join("\n")
+  expect(rendered).toContain("Review")
+  expect(rendered).toContain("hyper-new")
+  expect(rendered).toContain("Fresh task")
+  expect(rendered).toContain("fresh hidden log")
+})
+
+test("update_ralph_state cleans up hidden session when done", async () => {
+  let ralphTool: any
+  const piMock: any = {
+    on: () => {},
+    registerCommand: () => {},
+    registerTool: (def: any) => {
+      if (def.name === "update_ralph_state") ralphTool = def
+    }
+  }
+  initExtension(piMock)
+
+  let customCount = 0
+  const ctx = {
+    sessionManager: { getSessionFile: () => "ralph-hidden-done-cleanup-test" },
+    ui: {
+      custom: (factory: any) => {
+        customCount++
+        factory({ terminal: { rows: 30, columns: 100 }, requestRender: () => {} }, {}, {}, () => {})
+        return { close: () => {}, requestRender: () => {} }
+      }
+    }
+  }
+
+  await ralphTool.execute("call-id", { phase: "setup" }, undefined, undefined, ctx)
+  await ralphTool.execute("call-id", { close: true }, undefined, undefined, ctx)
+  await ralphTool.execute("call-id", { phase: "done", logMessage: "completed while hidden" }, undefined, undefined, ctx)
+  await new Promise(resolve => setTimeout(resolve, 2100))
+  await ralphTool.execute("call-id", { phase: "setup" }, undefined, undefined, ctx)
+
+  expect(customCount).toBe(2)
+})
+
 test("Ralph dashboard hides on cancel hotkeys", async () => {
   const { RalphDashboard } = await import("../.pi/extensions/xpowers/ralph-dashboard-tui")
   let cancelCount = 0

--- a/tests/pi-brainstorm-tool.test.ts
+++ b/tests/pi-brainstorm-tool.test.ts
@@ -103,10 +103,40 @@ test("update_ralph_state opens dashboard with Pi custom factory", async () => {
   expect(customCalled).toBe(true)
   expect(typeof dashboard.render).toBe("function")
   expect(dashboard.handleInput("q")).toBe(true)
+  expect(dashboard.handleInput("a")).toBe(false)
   expect(result.content).toEqual([])
 })
 
-test("Ralph dashboard consumes cancel hotkeys", async () => {
+test("update_ralph_state can explicitly close dashboard", async () => {
+  let ralphTool: any
+  const piMock: any = {
+    on: () => {},
+    registerCommand: () => {},
+    registerTool: (def: any) => {
+      if (def.name === "update_ralph_state") ralphTool = def
+    }
+  }
+  initExtension(piMock)
+
+  let closeCount = 0
+  const ctx = {
+    sessionManager: { getSessionFile: () => "ralph-close-test" },
+    ui: {
+      custom: (factory: any) => {
+        factory({ terminal: { rows: 30, columns: 100 }, requestRender: () => {} }, {}, {}, () => {})
+        return { close: () => { closeCount++ }, requestRender: () => {} }
+      }
+    }
+  }
+
+  await ralphTool.execute("call-id", { phase: "setup" }, undefined, undefined, ctx)
+  const result = await ralphTool.execute("call-id", { close: true }, undefined, undefined, ctx)
+
+  expect(closeCount).toBe(1)
+  expect(result.content[0].text).toBe("Ralph dashboard hidden.")
+})
+
+test("Ralph dashboard hides on cancel hotkeys", async () => {
   const { RalphDashboard } = await import("../.pi/extensions/xpowers/ralph-dashboard-tui")
   let cancelCount = 0
   const dashboard = new RalphDashboard({

--- a/tests/ralph-dashboard-tui.test.ts
+++ b/tests/ralph-dashboard-tui.test.ts
@@ -30,16 +30,25 @@ function expectAllLinesFit(lines: string[], width: number) {
   }
 }
 
-test("q, escape, and ctrl-c hotkeys cancel Ralph dashboard", () => {
+test("q, escape, and ctrl-c hotkeys hide Ralph dashboard", () => {
   for (const key of ["q", "\x1b", "\x03"]) {
-    let cancelled = false
-    const dashboard = new RalphDashboard(makeState(), () => { cancelled = true })
+    let hidden = false
+    const dashboard = new RalphDashboard(makeState(), () => { hidden = true })
 
     const handled = dashboard.handleInput(key)
 
     expect(handled).toBe(true)
-    expect(cancelled).toBe(true)
+    expect(hidden).toBe(true)
   }
+})
+
+test("Ralph dashboard does not consume normal Pi input", () => {
+  let hidden = false
+  const dashboard = new RalphDashboard(makeState(), () => { hidden = true })
+
+  expect(dashboard.handleInput("a")).toBe(false)
+  expect(dashboard.handleInput("/")).toBe(false)
+  expect(hidden).toBe(false)
 })
 
 test("Ralph dashboard renders as stacked single-column layout on narrow terminals", () => {

--- a/tests/stateless-prompt-integration.test.js
+++ b/tests/stateless-prompt-integration.test.js
@@ -16,6 +16,23 @@ test('agents/ralph.md should define itself as a Stateless Orchestrator', () => {
   assert.ok(/status[\s\S]*closed|closed[\s\S]*status/i.test(content), 'Ralph should require task status to be closed');
 });
 
+test('Ralph prompt uses tm for task lifecycle commands', () => {
+  const promptPaths = [
+    'agents/ralph.md',
+    '.opencode/agents/ralph.md',
+    '.gemini-extension/agents/ralph.md',
+    '.kimi/agents/ralph-system.md',
+  ];
+
+  for (const relativePath of promptPaths) {
+    const content = fs.readFileSync(path.join(ROOT_DIR, relativePath), 'utf8');
+    assert.doesNotMatch(content, /`bd (ready|blocked|show|update|close|create|dep)\b/, `${relativePath} must not show executable bd lifecycle commands`);
+    assert.doesNotMatch(content, /"(claim_command|show_command)": "bd /, `${relativePath} must not instruct execution of bd command strings`);
+    assert.match(content, /tm (ready|list)/, `${relativePath} should use tm for task discovery`);
+    assert.match(content, /tm update <id> --status in_progress|tm update bd-xxx --status=in_progress/, `${relativePath} should use tm for claiming tasks`);
+  }
+});
+
 test('agents/planner.md should mandate Immutable Epic Requirements', () => {
   const content = fs.readFileSync(PLANNER_PATH, 'utf8');
   assert.ok(content.includes('Immutable Epic Requirements'), 'Planner should mention "Immutable Epic Requirements"');

--- a/tests/stateless-prompt-integration.test.js
+++ b/tests/stateless-prompt-integration.test.js
@@ -29,7 +29,11 @@ test('Ralph prompt uses tm for task lifecycle commands', () => {
     assert.doesNotMatch(content, /`bd (ready|blocked|show|update|close|create|dep)\b/, `${relativePath} must not show executable bd lifecycle commands`);
     assert.doesNotMatch(content, /"(claim_command|show_command)": "bd /, `${relativePath} must not instruct execution of bd command strings`);
     assert.match(content, /tm (ready|list)/, `${relativePath} should use tm for task discovery`);
-    assert.match(content, /tm update <id> --status in_progress|tm update bd-xxx --status=in_progress/, `${relativePath} should use tm for claiming tasks`);
+    assert.match(
+      content,
+      /tm update (?:<id>|[A-Za-z]+-[A-Za-z0-9_-]+) --status(?:=|\s+)in_progress/,
+      `${relativePath} should use tm for claiming tasks`,
+    );
   }
 });
 

--- a/tests/tm-docs-contract.test.js
+++ b/tests/tm-docs-contract.test.js
@@ -126,6 +126,28 @@ test("Kimi and Codex host docs stay tm-first", () => {
   assert.equal(codexInstall.includes("tm ready"), true)
 })
 
+test("Agent workflow docs use backend-portable tm design updates", () => {
+  const checkedPaths = [
+    "skills/fixing-bugs/SKILL.md",
+    "skills/refactoring-safely/SKILL.md",
+    "skills/managing-bd-tasks/SKILL.md",
+    ".kimi/skills/fixing-bugs/SKILL.md",
+    ".kimi/skills/refactoring-safely/SKILL.md",
+    ".kimi/skills/managing-bd-tasks/SKILL.md",
+    ".opencode/skills/xpowers-fixing-bugs/SKILL.md",
+    ".opencode/skills/xpowers-refactoring-safely/SKILL.md",
+    ".opencode/skills/xpowers-managing-bd-tasks/SKILL.md",
+  ]
+
+  for (const relativePath of checkedPaths) {
+    const content = read(relativePath)
+    assert.equal(content.includes("tm edit "), false, `${relativePath} must not use backend-specific tm edit`)
+    assert.equal(content.includes("bd edit "), false, `${relativePath} must not use direct bd edit`)
+  }
+
+  assert.equal(read("skills/fixing-bugs/SKILL.md").includes("tm update bd-123 --design"), true)
+})
+
 test("Kimi install docs describe the linear preview contract and agent paths consistently", () => {
   const readme = read("README.md")
   const kimiInstall = read(".kimi/INSTALL.md")

--- a/tests/tm-docs-contract.test.js
+++ b/tests/tm-docs-contract.test.js
@@ -137,6 +137,9 @@ test("Agent workflow docs use backend-portable tm design updates", () => {
     ".opencode/skills/xpowers-fixing-bugs/SKILL.md",
     ".opencode/skills/xpowers-refactoring-safely/SKILL.md",
     ".opencode/skills/xpowers-managing-bd-tasks/SKILL.md",
+    ".agents/skills/fixing-bugs/SKILL.md",
+    ".agents/skills/refactoring-safely/SKILL.md",
+    ".agents/skills/managing-bd-tasks/SKILL.md",
   ]
 
   for (const relativePath of checkedPaths) {

--- a/tests/tm-docs-contract.test.js
+++ b/tests/tm-docs-contract.test.js
@@ -160,7 +160,7 @@ test("Agent workflow docs use backend-portable tm design updates", () => {
     assert.equal(content.includes("bd edit "), false, `${relativePath} must not use direct bd edit`)
   }
 
-  assert.equal(read("skills/fixing-bugs/SKILL.md").includes("tm update bd-123 --design"), true)
+  assert.match(read("skills/fixing-bugs/SKILL.md"), /tm update \S+ --design/)
 })
 
 test("Kimi install docs describe the linear preview contract and agent paths consistently", () => {

--- a/tests/tm-docs-contract.test.js
+++ b/tests/tm-docs-contract.test.js
@@ -70,6 +70,18 @@ test("README first-pass classifies bd br and tk with distinct roles", () => {
   assert.equal(readme.includes("`tm` = canonical user-facing task-management interface"), true)
 })
 
+test("docs distinguish tm-first project work from explicit ralph-tui beads-rust workflows", () => {
+  const readme = read("README.md")
+  const agentsGuide = read("AGENTS.md")
+
+  for (const content of [readme, agentsGuide]) {
+    assert.equal(content.includes("ralph-tui"), true)
+    assert.equal(content.includes("beads-rust"), true)
+    assert.equal(content.includes("use `tm`"), true)
+    assert.equal(content.includes("unless the user explicitly asks"), true)
+  }
+})
+
 test("README and AGENTS agree on Codex wrapper location and host support", () => {
   const readme = read("README.md")
   const agentsGuide = read("AGENTS.md")

--- a/tests/tm-first-command-guardrails.test.js
+++ b/tests/tm-first-command-guardrails.test.js
@@ -1,0 +1,64 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const path = require("node:path")
+
+const repoRoot = path.resolve(__dirname, "..")
+
+const scannedRoots = [
+  "agents",
+  "commands",
+  "skills",
+  ".kimi/skills",
+  ".kimi/agents",
+  ".opencode/agents",
+  ".opencode/skills",
+  ".gemini-extension/agents",
+  "README.md",
+  "AGENTS.md",
+]
+
+const allowedFiles = new Set([
+  // Explicit legacy/backend adapter implementation, not normal agent workflow prompts.
+  ".gemini-extension/mcp/bd-server.js",
+])
+
+const forbiddenCommandPattern = /(?:^|[\s`])(?<cmd>bd\s+(?:ready|blocked|show|update|edit|close|create|dep)|br\s+(?:create|dep|sync))\b/gm
+
+function* walk(entry) {
+  const fullPath = path.join(repoRoot, entry)
+  if (!fs.existsSync(fullPath)) return
+  const stat = fs.statSync(fullPath)
+  if (stat.isFile()) {
+    yield entry
+    return
+  }
+  for (const child of fs.readdirSync(fullPath)) {
+    const relative = path.join(entry, child)
+    const childStat = fs.statSync(path.join(repoRoot, relative))
+    if (childStat.isDirectory()) yield* walk(relative)
+    else if (/\.(md|js|ts|json|yaml|toml)$/.test(child)) yield relative
+  }
+}
+
+test("normal XPowers prompt surfaces do not contain executable direct bd/br task commands", () => {
+  const violations = []
+
+  for (const root of scannedRoots) {
+    for (const relativePath of walk(root)) {
+      const normalized = relativePath.split(path.sep).join("/")
+      if (allowedFiles.has(normalized)) continue
+
+      const content = fs.readFileSync(path.join(repoRoot, relativePath), "utf8")
+      const lines = content.split(/\r?\n/)
+      for (const [index, line] of lines.entries()) {
+        forbiddenCommandPattern.lastIndex = 0
+        const match = forbiddenCommandPattern.exec(line)
+        if (!match) continue
+        violations.push(`${normalized}:${index + 1}: ${match.groups.cmd} — use tm or add an explicit backend-specific allowlist entry`)
+      }
+    }
+  }
+
+  assert.deepEqual(violations, [])
+})

--- a/tests/tm-first-command-guardrails.test.js
+++ b/tests/tm-first-command-guardrails.test.js
@@ -9,11 +9,13 @@ const scannedRoots = [
   "agents",
   "commands",
   "skills",
+  ".agents/skills",
   ".kimi/skills",
   ".kimi/agents",
   ".opencode/agents",
   ".opencode/skills",
   ".gemini-extension/agents",
+  ".gemini-extension/mcp",
   "README.md",
   "AGENTS.md",
 ]


### PR DESCRIPTION
## Epic

Closes hyper-6io: Epic: Enforce tm-first task management across XPowers

## Summary
- Converts Ralph lifecycle prompts across host copies to use `tm` instead of direct `bd` command strings.
- Replaces non-portable task-design update examples with `tm update --design` and syncs Kimi/OpenCode/Codex surfaces.
- Makes Gemini default MCP manifest promote `tm` instead of legacy `bd`, and adds regression guardrails for direct backend commands.
- Fixes Pi Ralph dashboard behavior so it can be hidden and does not consume normal input.

## Tasks Completed
- hyper-c4g: Convert Ralph task lifecycle prompts from bd to tm
- hyper-3yt: Resync Kimi and .agents skills to remove stale direct bd commands
- hyper-54a: Replace non-portable tm edit examples with tm update --design
- hyper-8oc: Deprecate Gemini bd MCP surface in favor of tm MCP
- hyper-wtv: Add direct backend command regression guardrails
- hyper-3yk: Clarify global br-specific skill boundary and activation guidance
- hyper-lpp: Fix Ralph dashboard blocking Pi input

## Test Plan
- [x] node --test tests/execute-ralph-contract.test.js
- [x] node --test tests/codex-*.test.js
- [x] node --test tests/*.test.js
- [x] node scripts/sync-codex-skills.js --check
- [x] bun test tests/ralph-dashboard-tui.test.ts tests/pi-brainstorm-tool.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-blocking Ralph dashboard: per-session hide/reopen, delayed cleanup, and explicit close/reopen controls.

* **Bug Fixes**
  * Dashboard no longer swallows normal keyboard input; hide-on-cancel hides state instead of deleting it.
  * Dashboard can be hidden and reopened without aborting execution.

* **Documentation**
  * Task-management docs prefer tm commands and treat backend-provided command strings as advisory.
  * Clarified when to use backend-specific tools vs tm.

* **Chores / Tests**
  * Legacy task-management server removed from default config.
  * New tests enforcing tm-first patterns, manifest validation, and dashboard lifecycle behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->