### PR TITLE
feat: guard installers against legacy conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,24 @@ XPowers turns Claude Code, OpenCode, Gemini CLI, Kimi CLI, and Codex CLI into di
 /plugin install xpowers@xpowers --scope user
 ```
 
+### Rapid Pi install from GitHub
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dpolishuk/xpowers/main/scripts/setup-pi.sh | bash
+```
+
 ### Local installer
 
 ```bash
 git clone https://github.com/dpolishuk/xpowers.git
 cd xpowers
 bun scripts/install.ts
+```
+
+**Conflict safety:** Before installing, XPowers checks for legacy or overlapping `hyperpowers`, `myhyperpowers`, and `superpowers` installs so multiple agent instruction systems do not fight each other. Remove detected conflicts first. Advanced users who intentionally keep both systems can pass `--allow-conflicts`, for example:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dpolishuk/xpowers/main/scripts/setup-pi.sh | bash -s -- --allow-conflicts
 ```
 
 Install docs for other hosts are in [Host-Specific Instructions](#host-specific-instructions), with standalone guides for [Kimi CLI](.kimi/INSTALL.md) and [Pi](docs/pi.md).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,6 +44,7 @@ header() {
 # ---------------------------------------------------------------------------
 
 XDG_CFG="${XDG_CONFIG_HOME:-$HOME/.config}"
+CONFLICT_NAMES=(hyperpowers myhyperpowers superpowers)
 
 ensure_dir() { mkdir -p "$1" 2>/dev/null || { error "Cannot create $1"; return 1; }; }
 
@@ -53,6 +54,46 @@ count_items() {
   # shellcheck disable=SC2012,SC2086
   set +e; local n; n=$(ls -1d $pattern 2>/dev/null | wc -l); set -e
   echo "${n// /}"
+}
+
+conflict_candidates_for() {
+  local name="$1"
+  printf '%s\n' \
+    "${HOME}/.claude/plugins/${name}@${name}" \
+    "${HOME}/.claude/plugins/${name}" \
+    "${XDG_CFG}/opencode/plugins/${name}" \
+    "${XDG_CFG}/opencode/skills/${name}" \
+    "${XDG_CFG}/agents/skills/${name}" \
+    "${HOME}/.codex/skills/${name}" \
+    "${HOME}/.agents/skills/${name}" \
+    "${HOME}/.pi/agent/extensions/${name}"
+}
+
+detect_conflicts() {
+  local found=false
+  for name in "${CONFLICT_NAMES[@]}"; do
+    while IFS= read -r candidate; do
+      if [[ -e "$candidate" ]]; then
+        printf '%s|%s\n' "$name" "$candidate"
+        found=true
+      fi
+    done < <(conflict_candidates_for "$name")
+  done
+  [[ "$found" == true ]]
+}
+
+print_conflict_warning() {
+  local conflicts="$1"
+  error "Conflicting install(s) detected. Remove these before installing XPowers, or rerun with --allow-conflicts if you intentionally want both systems active:"
+  while IFS='|' read -r name candidate; do
+    [[ -n "$name" ]] || continue
+    warn "- ${name}: ${candidate}"
+    if [[ "$candidate" == *"${name}@${name}"* ]]; then
+      warn "  Claude Code: /plugin uninstall ${name}@${name} --scope user"
+    else
+      warn "  Remove or uninstall ${name} from this host before installing XPowers."
+    fi
+  done <<< "$conflicts"
 }
 
 backup_dir() {
@@ -946,6 +987,7 @@ MODES:
     --dry-run           Show what would be installed/removed without doing it
     --purge             With --uninstall: also remove backups and metadata
     --force, --yes      Skip confirmation prompt
+    --allow-conflicts   Advanced: continue despite detected hyperpowers/myhyperpowers/superpowers installs
 
 GENERAL:
     -h, --help          Show this help
@@ -978,6 +1020,7 @@ main() {
   local MODE="install"
   local FORCE=false
   local INTERACTIVE=true
+  local ALLOW_CONFLICTS=false
   local -a SELECTED_AGENTS=()
 
   # Parse arguments
@@ -998,6 +1041,7 @@ main() {
       --dry-run)    DRY_RUN=true; shift ;;
       --purge)      PURGE=true; shift ;;
       --force|--yes) FORCE=true; shift ;;
+      --allow-conflicts) ALLOW_CONFLICTS=true; shift ;;
       *)            error "Unknown option: $1"; echo; usage >&2; exit 1 ;;
     esac
   done
@@ -1050,6 +1094,28 @@ main() {
       warn "No agents detected."
     fi
     exit 0
+  fi
+
+  if [[ "$MODE" == "install" && "$ALLOW_CONFLICTS" != true ]]; then
+    local conflicts=""
+    if conflicts="$(detect_conflicts)"; then
+      if [[ -n "$conflicts" ]]; then
+        if [[ "$INTERACTIVE" == true && "$FORCE" != true ]]; then
+          header
+          print_conflict_warning "$conflicts"
+          local conflict_answer=""
+          read -r -p "  Continue installing XPowers despite these conflicting installs? [y/N] " conflict_answer </dev/tty
+          case "${conflict_answer:-N}" in
+            [Yy]) ;;
+            *) info "Cancelled. Remove the conflicting installs and rerun the installer."; exit 1 ;;
+          esac
+          echo
+        else
+          print_conflict_warning "$conflicts"
+          exit 1
+        fi
+      fi
+    fi
   fi
 
   # Build display list

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -55,6 +55,7 @@ type InstallManifest = {
 
 const xdgConfig = () => process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
 const legacyNs = () => "hyper" + "powers"
+const conflictingNamespaces = ["hyperpowers", "myhyperpowers", "superpowers"]
 const manifestPath = () => join(homedir(), ".xpowers", "manifest.json")
 const legacyManifestPath = () => join(homedir(), `.${legacyNs()}`, "manifest.json")
 
@@ -96,6 +97,46 @@ const listItems = async (dir: string, pattern?: string, exclude?: string[]): Pro
     return true
   })
 }
+
+type ConflictInstall = { name: string, path: string, removalHint: string }
+
+const candidateConflictPaths = (name: string): string[] => [
+  join(homedir(), ".claude", "plugins", `${name}@${name}`),
+  join(homedir(), ".claude", "plugins", name),
+  join(xdgConfig(), "opencode", "plugins", name),
+  join(xdgConfig(), "opencode", "skills", name),
+  join(xdgConfig(), "agents", "skills", name),
+  join(homedir(), ".codex", "skills", name),
+  join(homedir(), ".agents", "skills", name),
+  join(homedir(), ".pi", "agent", "extensions", name),
+]
+
+const removalHintFor = (name: string, conflictPath: string): string => {
+  if (conflictPath.includes(`${name}@${name}`)) return `Claude Code: /plugin uninstall ${name}@${name} --scope user`
+  return `Remove or uninstall ${name} from this host before installing XPowers.`
+}
+
+const detectConflictingInstalls = (): ConflictInstall[] => {
+  const seen = new Set<string>()
+  const conflicts: ConflictInstall[] = []
+
+  for (const name of conflictingNamespaces) {
+    for (const conflictPath of candidateConflictPaths(name)) {
+      if (!existsSync(conflictPath)) continue
+      const key = `${name}\0${conflictPath}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      conflicts.push({ name, path: conflictPath, removalHint: removalHintFor(name, conflictPath) })
+    }
+  }
+
+  return conflicts
+}
+
+const formatConflictMessage = (conflicts: ConflictInstall[]): string => [
+  "Conflicting install(s) detected. Remove these before installing XPowers, or rerun with --allow-conflicts if you intentionally want both systems active:",
+  ...conflicts.map((conflict) => `- ${conflict.name}: ${conflict.path}\n  ${conflict.removalHint}`),
+].join("\n")
 
 // ---------------------------------------------------------------------------
 // Host Configurations (data-driven, not 5x functions)
@@ -707,10 +748,11 @@ type CliArgs = {
   hosts: string[]
   features: string[]
   help: boolean
+  allowConflicts: boolean
 }
 
 const parseArgs = (): CliArgs => {
-  const args: CliArgs = { yes: false, uninstall: false, json: false, hosts: [], features: [], help: false }
+  const args: CliArgs = { yes: false, uninstall: false, json: false, hosts: [], features: [], help: false, allowConflicts: false }
   const argv = process.argv.slice(2)
 
   for (let i = 0; i < argv.length; i++) {
@@ -733,6 +775,9 @@ const parseArgs = (): CliArgs => {
         break
       case "--features":
         args.features = (argv[++i] || "").split(",").filter(Boolean)
+        break
+      case "--allow-conflicts":
+        args.allowConflicts = true
         break
       case "--help":
       case "-h":
@@ -776,6 +821,7 @@ Options:
   --uninstall        Remove all installed files and features
   --hosts <list>     Comma-separated host IDs: claude,opencode,kimi,gemini,pi
   --features <list>  Comma-separated feature IDs: memsearch,supermemory,statusline,routing-wizard,tm-cli
+  --allow-conflicts  Advanced: continue despite detected hyperpowers/myhyperpowers/superpowers installs
   --help, -h         Show this help
 `)
     return
@@ -868,6 +914,26 @@ Options:
     })
     if (p.isCancel(result)) { p.cancel("Cancelled."); return }
     selectedHostIds = result as string[]
+  }
+
+  const conflicts = detectConflictingInstalls()
+  if (conflicts.length > 0 && !args.allowConflicts) {
+    const message = formatConflictMessage(conflicts)
+    const nonInteractive = args.yes || args.json || args.hosts.length > 0 || !process.stdin.isTTY
+    if (nonInteractive) {
+      p.log.error(message)
+      process.exit(1)
+    }
+
+    p.log.warn(message)
+    const continueAnyway = await p.confirm({
+      message: "Continue installing XPowers despite these conflicting installs?",
+      initialValue: false,
+    })
+    if (p.isCancel(continueAnyway) || continueAnyway !== true) {
+      p.cancel("Cancelled. Remove the conflicting installs and rerun the installer.")
+      return
+    }
   }
 
   // Phase 3: Select features

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -900,26 +900,19 @@ Options:
     return
   }
 
-  // Phase 2: Select hosts
-  let selectedHostIds: string[]
-
-  if (args.yes || args.hosts.length > 0) {
-    selectedHostIds = args.hosts.length > 0 ? args.hosts : detected.map((h) => h.id)
-  } else {
-    const result = await p.multiselect({
-      message: "Install to which hosts?",
-      options: detected.map((h) => ({ value: h.id, label: h.name, hint: h.targetDir() })),
-      initialValues: detected.map((h) => h.id),
-      required: true,
-    })
-    if (p.isCancel(result)) { p.cancel("Cancelled."); return }
-    selectedHostIds = result as string[]
-  }
-
   const conflicts = detectConflictingInstalls()
   if (conflicts.length > 0 && !args.allowConflicts) {
     const message = formatConflictMessage(conflicts)
-    const nonInteractive = args.yes || args.json || args.hosts.length > 0 || !process.stdin.isTTY
+    const nonInteractive = args.yes || args.json || process.env.CI === "true" || !process.stdin.isTTY
+    if (args.json) {
+      console.log(JSON.stringify({
+        ok: false,
+        version: VERSION,
+        error: message,
+        conflicts: conflicts.map((conflict) => ({ name: conflict.name, path: conflict.path })),
+      }))
+      process.exit(1)
+    }
     if (nonInteractive) {
       p.log.error(message)
       process.exit(1)
@@ -934,6 +927,22 @@ Options:
       p.cancel("Cancelled. Remove the conflicting installs and rerun the installer.")
       return
     }
+  }
+
+  // Phase 2: Select hosts
+  let selectedHostIds: string[]
+
+  if (args.yes || args.hosts.length > 0) {
+    selectedHostIds = args.hosts.length > 0 ? args.hosts : detected.map((h) => h.id)
+  } else {
+    const result = await p.multiselect({
+      message: "Install to which hosts?",
+      options: detected.map((h) => ({ value: h.id, label: h.name, hint: h.targetDir() })),
+      initialValues: detected.map((h) => h.id),
+      required: true,
+    })
+    if (p.isCancel(result)) { p.cancel("Cancelled."); return }
+    selectedHostIds = result as string[]
   }
 
   // Phase 3: Select features

--- a/scripts/setup-pi.sh
+++ b/scripts/setup-pi.sh
@@ -32,6 +32,22 @@ header() {
   echo
 }
 
+ALLOW_CONFLICTS=false
+for arg in "$@"; do
+  case "$arg" in
+    --allow-conflicts) ALLOW_CONFLICTS=true ;;
+    -h|--help)
+      echo "Usage: setup-pi.sh [--allow-conflicts]"
+      echo "  --allow-conflicts  Advanced: continue despite detected hyperpowers/myhyperpowers/superpowers installs"
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $arg"
+      exit 1
+      ;;
+  esac
+ done
+
 header
 
 # ---------------------------------------------------------------------------
@@ -70,6 +86,46 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Conflict Detection
+# ---------------------------------------------------------------------------
+
+conflict_candidates_for() {
+  local name="$1"
+  printf '%s\n' \
+    "$HOME/.claude/plugins/${name}@${name}" \
+    "$HOME/.claude/plugins/${name}" \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/opencode/plugins/${name}" \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills/${name}" \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/agents/skills/${name}" \
+    "$HOME/.codex/skills/${name}" \
+    "$HOME/.agents/skills/${name}" \
+    "$HOME/.pi/agent/extensions/${name}"
+}
+
+conflicts=""
+for name in hyperpowers myhyperpowers superpowers; do
+  while IFS= read -r candidate; do
+    if [[ -e "$candidate" ]]; then
+      conflicts+="${name}|${candidate}"$'\n'
+    fi
+  done < <(conflict_candidates_for "$name")
+done
+
+if [[ -n "$conflicts" && "$ALLOW_CONFLICTS" != true ]]; then
+  error "Conflicting install(s) detected. Remove these before installing XPowers, or rerun with --allow-conflicts if you intentionally want both systems active:"
+  while IFS='|' read -r name candidate; do
+    [[ -n "$name" ]] || continue
+    warn "- ${name}: ${candidate}"
+    if [[ "$candidate" == *"${name}@${name}"* ]]; then
+      warn "  Claude Code: /plugin uninstall ${name}@${name} --scope user"
+    else
+      warn "  Remove or uninstall ${name} from this host before installing XPowers."
+    fi
+  done <<< "$conflicts"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # Download & Install
 # ---------------------------------------------------------------------------
 
@@ -83,7 +139,11 @@ git clone --depth 1 https://github.com/dpolishuk/xpowers.git . >/dev/null 2>&1
 if [[ "$PM" == "bun" ]]; then
   info "Running Bun interactive installer for Pi..."
   # Just run the native bun installer in Pi mode
-  bun scripts/install.ts --yes --hosts pi
+  if [[ "$ALLOW_CONFLICTS" == true ]]; then
+    bun scripts/install.ts --yes --hosts pi --allow-conflicts
+  else
+    bun scripts/install.ts --yes --hosts pi
+  fi
 else
   info "Running manual setup via npm..."
   PI_EXT_DIR="$HOME/.pi/agent/extensions/xpowers"

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -108,6 +108,7 @@ test("bun installer conflict guard stays before host selection and keeps --hosts
   assert.ok(conflictGuardIndex < phase2Index, "conflict guard should run before host selection UI")
 
   const nonInteractiveLine = source.match(/const nonInteractive = (?<expr>[^\n]+)/)?.groups?.expr || ""
+  assert.ok(nonInteractiveLine.length > 0, "nonInteractive expression should be present in install.ts")
   assert.doesNotMatch(nonInteractiveLine, /args\.hosts/, "--hosts alone must not suppress the conflict prompt")
 })
 

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -64,6 +64,7 @@ test("bun installer fails fast on legacy package conflicts unless explicitly ove
   })
 
   const allowedOutput = combinedOutput(allowed)
+  assert.equal(allowed.status, 0, allowedOutput)
   assert.doesNotMatch(allowedOutput, /conflicting install/i)
 })
 

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -7,6 +7,26 @@ const { spawnSync } = require("node:child_process")
 
 const repoRoot = path.resolve(__dirname, "..")
 
+function makeConflictFixture(home) {
+  const conflicts = [
+    path.join(home, ".claude", "plugins", "hyperpowers@hyperpowers"),
+    path.join(home, ".claude", "plugins", "myhyperpowers@myhyperpowers"),
+    path.join(home, ".config", "opencode", "plugins", "superpowers"),
+    path.join(home, ".pi", "agent", "extensions", "hyperpowers"),
+  ]
+
+  for (const conflict of conflicts) {
+    fs.mkdirSync(conflict, { recursive: true })
+    fs.writeFileSync(path.join(conflict, "marker.txt"), "legacy conflict\n", "utf8")
+  }
+
+  return conflicts
+}
+
+function combinedOutput(result) {
+  return `${result.stdout || ""}\n${result.stderr || ""}`
+}
+
 function installEnv(home, extra = {}) {
   return {
     ...process.env,
@@ -16,6 +36,92 @@ function installEnv(home, extra = {}) {
     ...extra,
   }
 }
+
+test("bun installer fails fast on legacy package conflicts unless explicitly overridden", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-conflict-test-"))
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  const conflicts = makeConflictFixture(home)
+
+  const blocked = spawnSync("bun", ["scripts/install.ts", "--yes", "--hosts", "claude"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const blockedOutput = combinedOutput(blocked)
+  assert.notEqual(blocked.status, 0)
+  assert.match(blockedOutput, /conflicting install/i)
+  assert.match(blockedOutput, /hyperpowers/i)
+  assert.match(blockedOutput, new RegExp(conflicts[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+  assert.match(blockedOutput, /--allow-conflicts/)
+
+  const allowed = spawnSync("bun", ["scripts/install.ts", "--yes", "--hosts", "claude", "--features", "not-a-real-feature", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const allowedOutput = combinedOutput(allowed)
+  assert.doesNotMatch(allowedOutput, /conflicting install/i)
+})
+
+test("install.sh fails fast on legacy package conflicts in non-interactive mode", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-conflict-test-"))
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  const conflicts = makeConflictFixture(home)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--claude", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.notEqual(result.status, 0)
+  assert.match(output, /conflicting install/i)
+  assert.match(output, /hyperpowers/i)
+  assert.match(output, new RegExp(conflicts[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+  assert.match(output, /--allow-conflicts/)
+})
+
+test("setup-pi.sh fails fast on legacy package conflicts before download", { timeout: 60000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "setup-pi-conflict-test-"))
+  const binDir = path.join(home, "bin")
+  fs.mkdirSync(binDir, { recursive: true })
+  for (const cmd of ["pi", "git", "bun"]) {
+    const cmdPath = path.join(binDir, cmd)
+    fs.writeFileSync(cmdPath, "#!/usr/bin/env bash\nexit 0\n", "utf8")
+    fs.chmodSync(cmdPath, 0o755)
+  }
+  const conflicts = makeConflictFixture(home)
+
+  const result = spawnSync("bash", ["scripts/setup-pi.sh"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, { PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}` }),
+    timeout: 60000,
+  })
+
+  const output = combinedOutput(result)
+  assert.notEqual(result.status, 0)
+  assert.match(output, /conflicting install/i)
+  assert.match(output, /hyperpowers/i)
+  assert.match(output, new RegExp(conflicts[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+  assert.match(output, /--allow-conflicts/)
+})
+
+test("README documents safe curl installer and conflict override", () => {
+  const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8")
+
+  assert.match(readme, /curl -fsSL https:\/\/raw\.githubusercontent\.com\/dpolishuk\/xpowers\/main\/scripts\/setup-pi\.sh \| bash/)
+  assert.match(readme, /--allow-conflicts/)
+  assert.match(readme, /hyperpowers/i)
+  assert.match(readme, /myhyperpowers/i)
+  assert.match(readme, /superpowers/i)
+})
 
 test("install.sh full uninstall preserves unrelated ~/.local/bin/node_modules directory", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-test-"))

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -85,6 +85,49 @@ test("install.sh fails fast on legacy package conflicts in non-interactive mode"
   assert.match(output, /hyperpowers/i)
   assert.match(output, new RegExp(conflicts[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
   assert.match(output, /--allow-conflicts/)
+
+  const allowed = spawnSync("bash", ["scripts/install.sh", "--claude", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const allowedOutput = combinedOutput(allowed)
+  assert.equal(allowed.status, 0, allowedOutput)
+  assert.doesNotMatch(allowedOutput, /conflicting install/i)
+})
+
+test("bun installer conflict guard stays before host selection and keeps --hosts interactive", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "install.ts"), "utf8")
+  const conflictGuardIndex = source.indexOf("const conflicts = detectConflictingInstalls()")
+  const phase2Index = source.indexOf("// Phase 2: Select hosts")
+  assert.ok(conflictGuardIndex > -1, "conflict guard should exist")
+  assert.ok(phase2Index > -1, "Phase 2 host selection should exist")
+  assert.ok(conflictGuardIndex < phase2Index, "conflict guard should run before host selection UI")
+
+  const nonInteractiveLine = source.match(/const nonInteractive = (?<expr>[^\n]+)/)?.groups?.expr || ""
+  assert.doesNotMatch(nonInteractiveLine, /args\.hosts/, "--hosts alone must not suppress the conflict prompt")
+})
+
+test("bun installer json mode reports structured conflict failures", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-json-conflict-test-"))
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  const conflicts = makeConflictFixture(home)
+
+  const result = spawnSync("bun", ["scripts/install.ts", "--json", "--hosts", "claude"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  assert.notEqual(result.status, 0)
+  const payload = JSON.parse(result.stdout)
+  assert.equal(payload.ok, false)
+  assert.match(payload.error, /conflicting install/i)
+  assert.match(payload.error, new RegExp(conflicts[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+  assert.match(payload.error, /--allow-conflicts/)
 })
 
 test("setup-pi.sh fails fast on legacy package conflicts before download", { timeout: 60000 }, () => {


### PR DESCRIPTION
## Epic

Closes hyper-2fv: Feature: Safe installer conflict detection and one-line install

## Summary
- Adds conflict detection for legacy/overlapping `hyperpowers`, `myhyperpowers`, and `superpowers` installs across Bun, shell, and Pi curl installers.
- Adds `--allow-conflicts` as an explicit advanced override while failing fast for non-interactive installs by default.
- Documents the rapid GitHub curl install one-liner and conflict safety behavior in the README.

## Tasks Completed
- hyper-3kg: Add installer conflict detection contract and tests

## Test Plan
- [x] RED confirmed with new failing conflict-guard tests before implementation
- [x] `node --test tests/install-script.test.js`
- [x] `bash -n scripts/install.sh && bash -n scripts/setup-pi.sh && node --test tests/*.test.js`
- [x] `node --test tests/execute-ralph-contract.test.js`
- [x] `node --test tests/codex-*.test.js`
- [x] `node scripts/sync-codex-skills.js --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Rapid Pi quick-start install snippet for GitHub (curl | bash).
  * Installer now detects existing hyperpowers / myhyperpowers / superpowers installs and blocks by default.
  * Added a --allow-conflicts option to override the block when desired.

* **Documentation**
  * Expanded setup docs with conflict-safety notes and uninstall/removal guidance.

* **Tests**
  * Added tests covering conflict detection, blocking behavior, and JSON/non-interactive outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->