### PR TITLE
feat(opencode): add 6 XPowers plugins for enhanced TUI experience

### DIFF
--- a/.opencode/plugins/xpowers-context-gauge.ts
+++ b/.opencode/plugins/xpowers-context-gauge.ts
@@ -83,7 +83,14 @@ const loadConfig = async (directory: string): Promise<Required<ContextGaugeConfi
   try {
     const raw = await readFile(configPath, "utf8")
     const parsed = JSON.parse(raw) as ContextGaugeConfig
-    return { ...DEFAULT_CONFIG, ...parsed }
+    return {
+      ...DEFAULT_CONFIG,
+      ...parsed,
+      modelLimits: {
+        ...DEFAULT_MODEL_LIMITS,
+        ...(parsed.modelLimits ?? {}),
+      },
+    }
   } catch {
     return { ...DEFAULT_CONFIG }
   }
@@ -142,17 +149,23 @@ const resolveModelLimit = (
 ): number => {
   if (!modelId) return defaultLimit
 
-  const normalized = modelId.toLowerCase().replace(/[^a-z0-9.-]/g, "")
+  // Strip provider prefix (e.g., "openai/gpt-4o" → "gpt-4o")
+  const withoutProvider = modelId.includes("/")
+    ? modelId.split("/").pop() ?? modelId
+    : modelId
+
+  const normalized = withoutProvider.toLowerCase().replace(/[^a-z0-9.-]/g, "")
 
   // Try exact match first
+  if (limits[withoutProvider]) return limits[withoutProvider]
   if (limits[modelId]) return limits[modelId]
 
   // Try normalized exact match
   if (limits[normalized]) return limits[normalized]
 
-  // Try partial match: model ID must contain the key as a prefix segment
-  // e.g., "gpt-4.1-mini" contains "gpt-4.1" → match
-  // but "gpt-4" does NOT contain "gpt-4.1" → no match
+  // Try partial match: prefer longest/specific match first to avoid
+  // "gpt-4" matching before "gpt-4o" or "gpt-4.1"
+  const candidates: { key: string; limit: number; len: number }[] = []
   for (const [key, limit] of Object.entries(limits)) {
     const normalizedKey = key.toLowerCase().replace(/[^a-z0-9.-]/g, "")
     if (!normalizedKey || normalizedKey === "default") continue
@@ -163,8 +176,14 @@ const resolveModelLimit = (
       normalized.startsWith(normalizedKey + "-") ||
       normalized.startsWith(normalizedKey + ".")
     ) {
-      return limit
+      candidates.push({ key, limit, len: normalizedKey.length })
     }
+  }
+
+  // Prefer longest match (most specific)
+  if (candidates.length > 0) {
+    candidates.sort((a, b) => b.len - a.len)
+    return candidates[0].limit
   }
 
   return defaultLimit
@@ -180,7 +199,7 @@ type GaugeState = {
   contextLimit: number
   compactSuggested: boolean
   createdAt: number
-  seenMessageIds: Set<string>  // deduplicate token counting on streaming updates
+  messageContents: Map<string, string>  // messageId -> previous content for delta counting
 }
 
 const sessions = new Map<string, GaugeState>()
@@ -196,7 +215,7 @@ const getState = (sessionId: string): GaugeState => {
       contextLimit: DEFAULT_CONFIG.defaultLimit,
       compactSuggested: false,
       createdAt: Date.now(),
-      seenMessageIds: new Set(),
+      messageContents: new Map(),
     }
     sessions.set(sessionId, state)
   }
@@ -238,7 +257,7 @@ const xpowersContextGaugePlugin: Plugin = async (ctx) => {
           contextLimit: config.defaultLimit,
           compactSuggested: false,
           createdAt: Date.now(),
-          seenMessageIds: new Set(),
+          messageContents: new Map(),
         })
         return
       }
@@ -271,15 +290,6 @@ const xpowersContextGaugePlugin: Plugin = async (ctx) => {
         const message = (event as any).properties?.message
         if (!message) return
 
-        // Deduplicate: don't double-count the same message on streaming updates
-        const messageId = message.id ?? (event as any).properties?.messageId
-        if (messageId && state.seenMessageIds.has(String(messageId))) {
-          return
-        }
-        if (messageId) {
-          state.seenMessageIds.add(String(messageId))
-        }
-
         // Try to extract content from message
         let content = ""
         if (message.content) {
@@ -309,9 +319,20 @@ const xpowersContextGaugePlugin: Plugin = async (ctx) => {
             .join(" ")
         }
 
-        const addedTokens = estimateTokens(content)
-        state.estimatedTokens += addedTokens
-        state.messageCount += 1
+        // Incremental token counting: only count the delta on streaming updates
+        const messageId = message.id ?? (event as any).properties?.messageId ?? ""
+        const prevContent = messageId ? state.messageContents.get(String(messageId)) : undefined
+        const prevTokens = prevContent !== undefined ? estimateTokens(prevContent) : 0
+        const newTokens = estimateTokens(content)
+        const deltaTokens = Math.max(0, newTokens - prevTokens)
+
+        state.estimatedTokens += deltaTokens
+        if (prevContent === undefined) {
+          state.messageCount += 1 // only count new messages, not streaming updates
+        }
+        if (messageId) {
+          state.messageContents.set(String(messageId), content)
+        }
 
         // Try to detect model from message metadata
         const detectedModel =
@@ -363,7 +384,7 @@ const xpowersContextGaugePlugin: Plugin = async (ctx) => {
               8000,
             )
 
-            if (!state.compactSuggested && config.suggestCompactAt <= config.dangerThreshold) {
+            if (!state.compactSuggested && usage >= config.suggestCompactAt) {
               state.compactSuggested = true
 
               // Inject suggestion into session

--- a/.opencode/plugins/xpowers-context-gauge.ts
+++ b/.opencode/plugins/xpowers-context-gauge.ts
@@ -147,15 +147,21 @@ const resolveModelLimit = (
   // Try exact match first
   if (limits[modelId]) return limits[modelId]
 
-  // Try normalized match
+  // Try normalized exact match
   if (limits[normalized]) return limits[normalized]
 
-  // Try partial match on model family
+  // Try partial match: model ID must contain the key as a prefix segment
+  // e.g., "gpt-4.1-mini" contains "gpt-4.1" → match
+  // but "gpt-4" does NOT contain "gpt-4.1" → no match
   for (const [key, limit] of Object.entries(limits)) {
     const normalizedKey = key.toLowerCase().replace(/[^a-z0-9.-]/g, "")
+    if (!normalizedKey || normalizedKey === "default") continue
+
+    // Key must be a prefix of the model ID, followed by a separator or end
     if (
-      normalized.includes(normalizedKey) ||
-      normalizedKey.includes(normalized)
+      normalized === normalizedKey ||
+      normalized.startsWith(normalizedKey + "-") ||
+      normalized.startsWith(normalizedKey + ".")
     ) {
       return limit
     }
@@ -173,6 +179,8 @@ type GaugeState = {
   modelId: string | null
   contextLimit: number
   compactSuggested: boolean
+  createdAt: number
+  seenMessageIds: Set<string>  // deduplicate token counting on streaming updates
 }
 
 const sessions = new Map<string, GaugeState>()
@@ -187,10 +195,21 @@ const getState = (sessionId: string): GaugeState => {
       modelId: null,
       contextLimit: DEFAULT_CONFIG.defaultLimit,
       compactSuggested: false,
+      createdAt: Date.now(),
+      seenMessageIds: new Set(),
     }
     sessions.set(sessionId, state)
   }
   return state
+}
+
+const cleanupOldGaugeSessions = (ttlMs: number = 86400000) => {
+  const cutoff = Date.now() - ttlMs
+  for (const [id, s] of sessions) {
+    if (s.createdAt < cutoff) {
+      sessions.delete(id)
+    }
+  }
 }
 
 // ── Plugin ──────────────────────────────────────────────────────────────────
@@ -218,6 +237,8 @@ const xpowersContextGaugePlugin: Plugin = async (ctx) => {
           modelId: null,
           contextLimit: config.defaultLimit,
           compactSuggested: false,
+          createdAt: Date.now(),
+          seenMessageIds: new Set(),
         })
         return
       }
@@ -241,12 +262,23 @@ const xpowersContextGaugePlugin: Plugin = async (ctx) => {
 
       if (event.type === "session.deleted" && sessionId) {
         sessions.delete(sessionId)
+        // Cleanup orphaned sessions older than 24 hours
+        cleanupOldGaugeSessions()
         return
       }
 
       if (event.type === "message.updated") {
         const message = (event as any).properties?.message
         if (!message) return
+
+        // Deduplicate: don't double-count the same message on streaming updates
+        const messageId = message.id ?? (event as any).properties?.messageId
+        if (messageId && state.seenMessageIds.has(String(messageId))) {
+          return
+        }
+        if (messageId) {
+          state.seenMessageIds.add(String(messageId))
+        }
 
         // Try to extract content from message
         let content = ""

--- a/.opencode/plugins/xpowers-git-guard.ts
+++ b/.opencode/plugins/xpowers-git-guard.ts
@@ -41,6 +41,7 @@ type SessionState = {
   filesCommitted: Set<string>
   commitMade: boolean
   warnedOnIdle: boolean
+  createdAt: number
 }
 
 const DEFAULT_CONFIG: Required<GitGuardConfig> = {
@@ -259,10 +260,19 @@ const sessions = new Map<string, SessionState>()
 const getSessionState = (sessionId: string): SessionState => {
   let state = sessions.get(sessionId)
   if (!state) {
-    state = { filesModified: new Set(), filesCommitted: new Set(), commitMade: false, warnedOnIdle: false }
+    state = { filesModified: new Set(), filesCommitted: new Set(), commitMade: false, warnedOnIdle: false, createdAt: Date.now() }
     sessions.set(sessionId, state)
   }
   return state
+}
+
+const cleanupOldGitGuardSessions = (ttlMs: number = 86400000) => {
+  const cutoff = Date.now() - ttlMs
+  for (const [id, s] of sessions) {
+    if (s.createdAt < cutoff) {
+      sessions.delete(id)
+    }
+  }
 }
 
 // ── Plugin ──────────────────────────────────────────────────────────────────
@@ -337,6 +347,7 @@ const xpowersGitGuardPlugin: Plugin = async (ctx) => {
           filesCommitted: new Set(),
           commitMade: false,
           warnedOnIdle: false,
+          createdAt: Date.now(),
         })
         return
       }
@@ -367,12 +378,7 @@ const xpowersGitGuardPlugin: Plugin = async (ctx) => {
         }
         sessions.delete(sessionId)
         // Cleanup orphaned sessions older than 24 hours
-        const cutoff = Date.now() - 86400000
-        for (const [id, s] of sessions) {
-          if (!s) {
-            sessions.delete(id)
-          }
-        }
+        cleanupOldGitGuardSessions()
         return
       }
 

--- a/.opencode/plugins/xpowers-git-guard.ts
+++ b/.opencode/plugins/xpowers-git-guard.ts
@@ -126,8 +126,19 @@ const getGitStatus = async ($: any, cwd: string): Promise<GitStatus> => {
     }
 
     // Status line: XY filename or XY "filename with spaces"
+    // Renames: XY "old" -> "new"  (R status in index or worktree)
     const statusCode = line.slice(0, 2)
-    const filePath = line.slice(3).replace(/^"(.*)"$/, "$1")
+    let filePath = line.slice(3)
+
+    // Handle rename entries: R  "old/path" -> "new/path"
+    if (statusCode[0] === "R" || statusCode[1] === "R") {
+      const renameMatch = line.match(/^\S{2}\s+(.+?)\s+->\s+(.+)$/)
+      if (renameMatch) {
+        filePath = renameMatch[2].replace(/^"(.*)"$/, "$1")
+      }
+    } else {
+      filePath = filePath.replace(/^"(.*)"$/, "$1")
+    }
 
     if (!filePath) continue
 
@@ -149,6 +160,12 @@ const getGitStatus = async ($: any, cwd: string): Promise<GitStatus> => {
     }
     if (worktreeStatus === "?") {
       status.untrackedFiles.push(filePath)
+    }
+    // Renames count as modified
+    if (indexStatus === "R" || worktreeStatus === "R") {
+      if (!status.modifiedFiles.includes(filePath)) {
+        status.modifiedFiles.push(filePath)
+      }
     }
   }
 
@@ -180,9 +197,19 @@ const hasUncommittedChanges = async ($: any, cwd: string): Promise<boolean> => {
   return status.hasChanges
 }
 
-const autoCommit = async ($: any, cwd: string, message: string): Promise<{ ok: boolean; error?: string }> => {
+const autoCommit = async (
+  $: any,
+  cwd: string,
+  message: string,
+  filesToCommit: string[],
+): Promise<{ ok: boolean; error?: string }> => {
+  if (filesToCommit.length === 0) {
+    return { ok: true }
+  }
+
   try {
-    const addResult = await $`git -C ${cwd} add -A`.quiet().nothrow()
+    // Only stage files that were modified during this session, not everything
+    const addResult = await $`git -C ${cwd} add ${filesToCommit}`.quiet().nothrow()
     if (addResult.exitCode !== 0) {
       return { ok: false, error: "git add failed" }
     }
@@ -317,8 +344,9 @@ const xpowersGitGuardPlugin: Plugin = async (ctx) => {
       if (event.type === "session.deleted" && sessionId) {
         const state = sessions.get(sessionId)
         if (state && config.autoCommitOnSessionEnd && state.filesModified.size > 0 && !state.commitMade) {
-          // Auto-commit on session end
-          const result = await autoCommit(ctx.$, ctx.directory, config.autoCommitMessage)
+          // Auto-commit on session end — only commit files modified during this session
+          const filesToCommit = Array.from(state.filesModified)
+          const result = await autoCommit(ctx.$, ctx.directory, config.autoCommitMessage, filesToCommit)
           if (result.ok) {
             await showToast(
               ctx.client,
@@ -338,6 +366,13 @@ const xpowersGitGuardPlugin: Plugin = async (ctx) => {
           }
         }
         sessions.delete(sessionId)
+        // Cleanup orphaned sessions older than 24 hours
+        const cutoff = Date.now() - 86400000
+        for (const [id, s] of sessions) {
+          if (!s) {
+            sessions.delete(id)
+          }
+        }
         return
       }
 

--- a/.opencode/plugins/xpowers-git-guard.ts
+++ b/.opencode/plugins/xpowers-git-guard.ts
@@ -42,6 +42,7 @@ type SessionState = {
   commitMade: boolean
   warnedOnIdle: boolean
   createdAt: number
+  pendingCommitStagedFiles: string[]  // staged files captured before git commit
 }
 
 const DEFAULT_CONFIG: Required<GitGuardConfig> = {
@@ -181,12 +182,15 @@ const getGitDiffStat = async ($: any, cwd: string): Promise<{ files: number; ins
   const lastLine = output.split("\n").filter((l) => l.trim()).pop() ?? ""
 
   // Parse: " 5 files changed, 23 insertions(+), 10 deletions(-)"
-  const match = lastLine.match(/(\d+)\s+files?\s+changed.*?(\d+)\s+insertions?.*?(\d+)\s+deletions?/)
-  if (match) {
+  // Note: insertions or deletions may be absent in partial output
+  const filesMatch = lastLine.match(/(\d+)\s+files?\s+changed/)
+  if (filesMatch) {
+    const insertionsMatch = lastLine.match(/(\d+)\s+insertions?/)
+    const deletionsMatch = lastLine.match(/(\d+)\s+deletions?/)
     return {
-      files: parseInt(match[1], 10),
-      insertions: parseInt(match[2], 10),
-      deletions: parseInt(match[3], 10),
+      files: parseInt(filesMatch[1], 10),
+      insertions: insertionsMatch ? parseInt(insertionsMatch[1], 10) : 0,
+      deletions: deletionsMatch ? parseInt(deletionsMatch[1], 10) : 0,
     }
   }
 
@@ -260,7 +264,7 @@ const sessions = new Map<string, SessionState>()
 const getSessionState = (sessionId: string): SessionState => {
   let state = sessions.get(sessionId)
   if (!state) {
-    state = { filesModified: new Set(), filesCommitted: new Set(), commitMade: false, warnedOnIdle: false, createdAt: Date.now() }
+    state = { filesModified: new Set(), filesCommitted: new Set(), commitMade: false, warnedOnIdle: false, createdAt: Date.now(), pendingCommitStagedFiles: [] }
     sessions.set(sessionId, state)
   }
   return state
@@ -285,6 +289,20 @@ const xpowersGitGuardPlugin: Plugin = async (ctx) => {
   }
 
   return {
+    // ── Pre-commit: capture staged files before git commit runs ───────────
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "bash") return
+      const command = String((output.args as any)?.command ?? "")
+      if (!/git\s+commit/.test(command)) return
+
+      const sessionId = (input as any).sessionID ?? "unknown"
+      const state = getSessionState(sessionId)
+
+      // Capture staged files BEFORE the commit executes
+      const status = await getGitStatus(ctx.$, ctx.directory)
+      state.pendingCommitStagedFiles = [...status.stagedFiles]
+    },
+
     // ── Track file modifications and git commits ──────────────────────────
     "tool.execute.after": async (input, output) => {
       const sessionId = (input as any).sessionID ?? "unknown"
@@ -317,12 +335,12 @@ const xpowersGitGuardPlugin: Plugin = async (ctx) => {
         if (/git\s+commit/.test(command)) {
           state.commitMade = true
 
-          // Try to extract committed files from the command or check git status
-          const status = await getGitStatus(ctx.$, ctx.directory)
-          for (const file of status.stagedFiles) {
+          // Use staged files captured BEFORE the commit (post-commit staged list is empty)
+          for (const file of state.pendingCommitStagedFiles) {
             state.filesCommitted.add(file)
             state.filesModified.delete(file)
           }
+          state.pendingCommitStagedFiles = []
 
           await showToast(
             ctx.client,
@@ -348,6 +366,7 @@ const xpowersGitGuardPlugin: Plugin = async (ctx) => {
           commitMade: false,
           warnedOnIdle: false,
           createdAt: Date.now(),
+          pendingCommitStagedFiles: [],
         })
         return
       }

--- a/.opencode/plugins/xpowers-lint-gate.ts
+++ b/.opencode/plugins/xpowers-lint-gate.ts
@@ -218,10 +218,15 @@ const createShellCheckParser = (): LinterConfig["parseOutput"] => {
     for (const line of lines) {
       const match = line.match(/^(.+?):(\d+):(\d+):\s*(\w+):\s*(\w+):\s*(.+)/)
       if (match) {
+        const rawSeverity = match[4].toLowerCase()
+        // ShellCheck emits: error, warning, info, style
+        const severity: LintIssue["severity"] =
+          rawSeverity === "error" ? "error" :
+          rawSeverity === "warning" ? "warning" : "style"
         issues.push({
           line: parseInt(match[2], 10),
           column: parseInt(match[3], 10),
-          severity: match[4] as "error" | "warning",
+          severity,
           rule: match[5],
           message: match[6].trim(),
         })
@@ -237,42 +242,42 @@ const LINTER_REGISTRY: FileLinterMap = {
   ".ts": {
     name: "eslint",
     command: "eslint",
-    args: ["--format", "compact"],
+    args: [],
     fixArgs: ["--fix"],
     parseOutput: createESLintParser("eslint"),
   },
   ".tsx": {
     name: "eslint",
     command: "eslint",
-    args: ["--format", "compact"],
+    args: [],
     fixArgs: ["--fix"],
     parseOutput: createESLintParser("eslint"),
   },
   ".js": {
     name: "eslint",
     command: "eslint",
-    args: ["--format", "compact"],
+    args: [],
     fixArgs: ["--fix"],
     parseOutput: createESLintParser("eslint"),
   },
   ".jsx": {
     name: "eslint",
     command: "eslint",
-    args: ["--format", "compact"],
+    args: [],
     fixArgs: ["--fix"],
     parseOutput: createESLintParser("eslint"),
   },
   ".mjs": {
     name: "eslint",
     command: "eslint",
-    args: ["--format", "compact"],
+    args: [],
     fixArgs: ["--fix"],
     parseOutput: createESLintParser("eslint"),
   },
   ".cjs": {
     name: "eslint",
     command: "eslint",
-    args: ["--format", "compact"],
+    args: [],
     fixArgs: ["--fix"],
     parseOutput: createESLintParser("eslint"),
   },
@@ -423,8 +428,11 @@ const runLinter = async (
   autoFix: boolean,
 ): Promise<LintResult> => {
   try {
+    // When auto-fixing, use fix-mode args instead of check-mode args.
+    // Some linters (black, rustfmt) use check-only base args (--check)
+    // that prevent fixes when combined with fix args.
     const args = autoFix && linter.fixArgs
-      ? [...linter.args, ...linter.fixArgs, filePath]
+      ? [...linter.fixArgs, filePath]
       : [...linter.args, filePath]
 
     // Build command as array for Bun shell to safely pass each arg

--- a/.opencode/plugins/xpowers-lint-gate.ts
+++ b/.opencode/plugins/xpowers-lint-gate.ts
@@ -427,9 +427,12 @@ const runLinter = async (
       ? [...linter.args, ...linter.fixArgs, filePath]
       : [...linter.args, filePath]
 
-    const result = await $`${linter.command} ${args}`.quiet().nothrow()
+    // Build command as array for Bun shell to safely pass each arg
+    const cmdParts = [linter.command, ...args]
+    const result = await $`${cmdParts}`.quiet().nothrow()
     const stdout = await result.text()
-    const stderr = ""
+    // Bun shell returns stderr as a property on the result object
+    const stderr = typeof result.stderr === "string" ? result.stderr : ""
 
     const issues = linter.parseOutput(stdout, stderr)
 
@@ -524,6 +527,9 @@ const xpowersLintGatePlugin: Plugin = async (ctx) => {
     return {}
   }
 
+  // Cache linter detection results per extension to avoid repeated `which` calls
+  const linterCache = new Map<string, LinterConfig | null>()
+
   // Track recent toasts to avoid spam
   const lastToastTime = new Map<string, number>()
 
@@ -570,8 +576,14 @@ const xpowersLintGatePlugin: Plugin = async (ctx) => {
           },
         }
       } else {
-        // Auto-detect project linter
-        linter = await detectProjectLinter(ctx.$, ctx.directory, filePath)
+        // Auto-detect project linter (cached per extension)
+        const ext = extname(filePath).toLowerCase()
+        if (linterCache.has(ext)) {
+          linter = linterCache.get(ext) ?? null
+        } else {
+          linter = await detectProjectLinter(ctx.$, ctx.directory, filePath)
+          linterCache.set(ext, linter)
+        }
       }
 
       if (!linter) {

--- a/.opencode/plugins/xpowers-notify.ts
+++ b/.opencode/plugins/xpowers-notify.ts
@@ -38,7 +38,8 @@ const DEFAULT_CONFIG: Required<NotifyConfig> = {
   onTaskComplete: true,
   onTaskError: true,
   onSessionCompact: false,
-  backends: ["osc777", "osc99", "osascript", "notify-send"],
+  // Prefer native OS notifications; OSC terminals are fallbacks
+  backends: ["osascript", "notify-send", "growlnotify", "osc777", "osc99"],
   durationMs: 4000,
   titlePrefix: "XPowers",
 }
@@ -228,7 +229,11 @@ const xpowersNotifyPlugin: Plugin = async (ctx) => {
   const notify = async (title: string, message: string, variant: NotifyVariant) => {
     const backend = await getBackend()
     if (backend) {
-      await sendDesktopNotification(ctx.$, backend, title, message)
+      const ok = await sendDesktopNotification(ctx.$, backend, title, message)
+      // If OSC backend failed, invalidate cache so fallback is tried next time
+      if (!ok && (backend === "osc777" || backend === "osc99")) {
+        cachedBackend = null
+      }
     }
     await showToast(ctx.client, title, message, variant, config.durationMs)
   }
@@ -236,16 +241,15 @@ const xpowersNotifyPlugin: Plugin = async (ctx) => {
   return {
     // When the AI agent finishes responding and goes idle
     event: async ({ event }) => {
-      if (!config.onAgentIdle) return
-
       if (event.type === "session.idle") {
+        if (!config.onAgentIdle) return
         const title = `${config.titlePrefix}`
         const message = "Agent finished responding"
         await notify(title, message, "info")
         return
       }
 
-      if (config.onSessionCompact && event.type === "session.compacted") {
+      if (event.type === "session.compacted" && config.onSessionCompact) {
         const title = `${config.titlePrefix}`
         const message = "Session compacted"
         await notify(title, message, "info")
@@ -272,11 +276,15 @@ const xpowersNotifyPlugin: Plugin = async (ctx) => {
         const title = `${config.titlePrefix} · ${agentName}${modelSuffix}`
         const message = `Task ${statusText}`
 
-        if (variant === "error" && config.onTaskError) {
-          await notify(title, message, variant)
+        // Error notifications: honor onTaskError config
+        if (variant === "error") {
+          if (config.onTaskError) {
+            await notify(title, message, variant)
+          }
           return
         }
 
+        // Non-error completions: honor onTaskComplete config
         if (config.onTaskComplete) {
           await notify(title, message, variant)
         }

--- a/.opencode/plugins/xpowers-notify.ts
+++ b/.opencode/plugins/xpowers-notify.ts
@@ -96,7 +96,12 @@ const checkBackend = async ($: any, backend: Backend): Promise<boolean> => {
 
 // ── Notification Sending ────────────────────────────────────────────────────
 
-const escapeShell = (text: string) => text.replace(/"/g, '\\"')
+/**
+ * Escape OSC sequence content to prevent terminal injection.
+ * OSC 777/99 payloads must not contain BEL (\x07) or ESC (\x1b).
+ */
+const escapeOsc = (text: string): string =>
+  text.replace(/\x1b/g, "").replace(/\x07/g, "")
 
 const sendDesktopNotification = async (
   $: any,
@@ -106,24 +111,30 @@ const sendDesktopNotification = async (
 ): Promise<boolean> => {
   try {
     switch (backend) {
-      case "osascript":
-        await $`osascript -e ${
-          `display notification "${escapeShell(message)}" with title "${escapeShell(title)}"`
-        }`.quiet().nothrow()
+      case "osascript": {
+        // Use Bun shell template literal which safely escapes arguments
+        const script = `display notification ${JSON.stringify(message)} with title ${JSON.stringify(title)}`
+        await $`osascript -e ${script}`.quiet().nothrow()
         return true
+      }
 
-      case "notify-send":
+      case "notify-send": {
+        // Bun template literal safely passes arguments to subprocess
         await $`notify-send ${title} ${message}`.quiet().nothrow()
         return true
+      }
 
-      case "growlnotify":
+      case "growlnotify": {
         await $`growlnotify -t ${title} -m ${message}`.quiet().nothrow()
         return true
+      }
 
       case "osc777": {
         // OSC 777: Ghostty, iTerm2, WezTerm, rxvt-unicode
         // Format: ESC ] 777 ; notify ; title ; body BEL
-        const osc = `\x1b]777;notify;${title};${message}\x07`
+        const safeTitle = escapeOsc(title)
+        const safeMessage = escapeOsc(message)
+        const osc = `\x1b]777;notify;${safeTitle};${safeMessage}\x07`
         process.stdout.write(osc)
         return true
       }
@@ -131,7 +142,8 @@ const sendDesktopNotification = async (
       case "osc99": {
         // OSC 99: Kitty
         // Format: ESC ] 99 ; i=1:d=0 ; body ESC \
-        const osc = `\x1b]99;i=1:d=0;${message}\x1b\\`
+        const safeMessage = escapeOsc(message)
+        const osc = `\x1b]99;i=1:d=0;${safeMessage}\x1b\\`
         process.stdout.write(osc)
         return true
       }

--- a/.opencode/plugins/xpowers-slow-mode.ts
+++ b/.opencode/plugins/xpowers-slow-mode.ts
@@ -118,35 +118,80 @@ const isProtectedPath = (filePath: string, patterns: string[]): boolean => {
 
 // ── Diff Computation ────────────────────────────────────────────────────────
 
+/**
+ * Compute LCS (Longest Common Subsequence) between two arrays.
+ * Returns a Set of indices into `a` that are part of the LCS.
+ */
+const computeLcsIndices = (a: string[], b: string[]): Set<number> => {
+  const m = a.length
+  const n = b.length
+  // Use two rows for space efficiency
+  let prev = new Array(n + 1).fill(0)
+  let curr = new Array(n + 1).fill(0)
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        curr[j] = prev[j - 1] + 1
+      } else {
+        curr[j] = Math.max(prev[j], curr[j - 1])
+      }
+    }
+    ;[prev, curr] = [curr, prev]
+  }
+
+  // Backtrack to find which indices of `a` are in the LCS
+  const lcsIndices = new Set<number>()
+  let i = m
+  let j = n
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      lcsIndices.add(i - 1)
+      i--
+      j--
+    } else if (prev[j] > curr[j - 1]) {
+      i--
+    } else {
+      j--
+    }
+  }
+  return lcsIndices
+}
+
 const computeLineDiff = (original: string, updated: string): { added: number; removed: number; diffLines: string[] } => {
   const origLines = original.split("\n")
   const newLines = updated.split("\n")
 
-  // Simple LCS-based diff would be ideal; using a simplified approach:
-  // Track which lines appear in both, then report additions/removals
-  const origSet = new Set(origLines)
-  const newSet = new Set(newLines)
+  const lcsIndices = computeLcsIndices(origLines, newLines)
 
   let added = 0
   let removed = 0
   const diffLines: string[] = []
 
-  // Find removed lines (in original but not in new)
-  for (const line of origLines) {
-    if (!newSet.has(line) && line.trim().length > 0) {
+  // Lines in original but not in LCS = removed
+  for (let i = 0; i < origLines.length; i++) {
+    if (!lcsIndices.has(i) && origLines[i].trim().length > 0) {
       removed++
       if (diffLines.length < 20) {
-        diffLines.push(`- ${line.slice(0, 80)}`)
+        diffLines.push(`- ${origLines[i].slice(0, 80)}`)
       }
     }
   }
 
-  // Find added lines (in new but not in original)
-  for (const line of newLines) {
-    if (!origSet.has(line) && line.trim().length > 0) {
+  // Build a set of LCS lines for quick lookup on the new side
+  const lcsLines = new Set<string>()
+  for (let i = 0; i < origLines.length; i++) {
+    if (lcsIndices.has(i)) lcsLines.add(origLines[i])
+  }
+
+  // Lines in new but not in LCS = added
+  // We use a separate pass to handle duplicates correctly
+  const newLcsIndices = computeLcsIndices(newLines, origLines)
+  for (let i = 0; i < newLines.length; i++) {
+    if (!newLcsIndices.has(i) && newLines[i].trim().length > 0) {
       added++
       if (diffLines.length < 20) {
-        diffLines.push(`+ ${line.slice(0, 80)}`)
+        diffLines.push(`+ ${newLines[i].slice(0, 80)}`)
       }
     }
   }
@@ -238,6 +283,7 @@ const xpowersSlowModePlugin: Plugin = async (ctx) => {
     changes: FileChange[]
     pendingOriginals: Map<string, string | null>  // filePath -> original content
     createdAt: number
+    summaryLogged: boolean  // prevent duplicate session summaries in review.log
   }
 
   const sessions = new Map<string, SlowModeSession>()
@@ -245,7 +291,7 @@ const xpowersSlowModePlugin: Plugin = async (ctx) => {
   const getSessionState = (sessionId: string): SlowModeSession => {
     let state = sessions.get(sessionId)
     if (!state) {
-      state = { changes: [], pendingOriginals: new Map(), createdAt: Date.now() }
+      state = { changes: [], pendingOriginals: new Map(), createdAt: Date.now(), summaryLogged: false }
       sessions.set(sessionId, state)
     }
     return state
@@ -390,8 +436,11 @@ const xpowersSlowModePlugin: Plugin = async (ctx) => {
 
       if (event.type === "session.deleted" && sessionId) {
         const state = sessions.get(sessionId)
-        if (state) {
+        if (state && !state.summaryLogged) {
           await logSessionSummary(logDir, sessionId, state.changes)
+          state.summaryLogged = true
+        }
+        if (state) {
           sessions.delete(sessionId)
         }
         // Cleanup orphaned sessions older than 24 hours
@@ -401,7 +450,7 @@ const xpowersSlowModePlugin: Plugin = async (ctx) => {
 
       if (event.type === "session.idle") {
         const state = sessions.get(sessionId)
-        if (state && state.changes.length > 0) {
+        if (state && state.changes.length > 0 && !state.summaryLogged) {
           const files = [...new Set(state.changes.map((c) => c.filePath))]
           const totalAdded = state.changes.reduce((sum, c) => sum + c.linesAdded, 0)
           const totalRemoved = state.changes.reduce((sum, c) => sum + c.linesRemoved, 0)
@@ -414,8 +463,9 @@ const xpowersSlowModePlugin: Plugin = async (ctx) => {
             6000,
           )
 
-          // Write summary to log
+          // Write summary to log (only once per session)
           await logSessionSummary(logDir, sessionId, state.changes)
+          state.summaryLogged = true
         }
       }
     },

--- a/.opencode/plugins/xpowers-slow-mode.ts
+++ b/.opencode/plugins/xpowers-slow-mode.ts
@@ -87,16 +87,20 @@ const showToast = async (
 
 // ── Path Matching ───────────────────────────────────────────────────────────
 
+const escapeRegex = (text: string): string =>
+  text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
 const matchGlob = (pattern: string, path: string): boolean => {
   const normalizedPath = path.replace(/\\/g, "/")
   const normalizedPattern = pattern.replace(/\\/g, "/")
 
   // Simple glob matching: ** (any depth), * (any chars within segment)
-  const regexPattern = normalizedPattern
-    .replace(/\*\*/g, "\u0000")
-    .replace(/\*/g, "[^/]*")
-    .replace(/\u0000/g, ".*")
-    .replace(/\?/g, ".")
+  // Escape regex special chars in the pattern first, then restore glob wildcards
+  const regexPattern = escapeRegex(normalizedPattern)
+    .replace(/\\\*\\\*/g, "\u0000")   // restore **
+    .replace(/\\\*/g, "[^/]*")         // restore *
+    .replace(/\u0000/g, ".*")           // ** = any depth
+    .replace(/\\\?/g, ".")             // restore ?
 
   const regex = new RegExp(`^(.*/)?${regexPattern}$`, "i")
   return regex.test(normalizedPath)
@@ -230,18 +234,30 @@ const xpowersSlowModePlugin: Plugin = async (ctx) => {
   }
 
   // Per-session state tracking
-  const sessions = new Map<string, {
+  type SlowModeSession = {
     changes: FileChange[]
     pendingOriginals: Map<string, string | null>  // filePath -> original content
-  }>()
+    createdAt: number
+  }
 
-  const getSessionState = (sessionId: string) => {
+  const sessions = new Map<string, SlowModeSession>()
+
+  const getSessionState = (sessionId: string): SlowModeSession => {
     let state = sessions.get(sessionId)
     if (!state) {
-      state = { changes: [], pendingOriginals: new Map() }
+      state = { changes: [], pendingOriginals: new Map(), createdAt: Date.now() }
       sessions.set(sessionId, state)
     }
     return state
+  }
+
+  const cleanupOldSessions = (ttlMs: number = 86400000) => {
+    const cutoff = Date.now() - ttlMs
+    for (const [id, s] of sessions) {
+      if (s.createdAt < cutoff) {
+        sessions.delete(id)
+      }
+    }
   }
 
   const logDir = join(ctx.directory, config.logDir)
@@ -378,6 +394,8 @@ const xpowersSlowModePlugin: Plugin = async (ctx) => {
           await logSessionSummary(logDir, sessionId, state.changes)
           sessions.delete(sessionId)
         }
+        // Cleanup orphaned sessions older than 24 hours
+        cleanupOldSessions()
         return
       }
 

--- a/.opencode/plugins/xpowers-task-monitor.ts
+++ b/.opencode/plugins/xpowers-task-monitor.ts
@@ -100,17 +100,31 @@ const parseTasks = (output: string): ParsedTask[] => {
     if (trimmed.startsWith("Status:")) continue
     if (trimmed.includes("no active blockers")) continue
 
-    // Match: [indicator] [id] [status] P[priority] [title]
+    // Try agent-style format first: [indicator] [id] [status] P[priority] [title]
     // ○ hyper-5ct ● P1 [epic] Project: Rename repository to xpowers
-    // Supports priorities P0-P99 (multi-digit)
-    const match = trimmed.match(
+    const agentMatch = trimmed.match(
       /^[○◐●✓❄]\s+([a-z]+-[a-z0-9]+)\s+.*?P(\d+)\s+(.+)/,
     )
-    if (match) {
+    if (agentMatch) {
       tasks.push({
-        id: match[1],
-        priority: parseInt(match[2], 10),
-        title: match[3].trim(),
+        id: agentMatch[1],
+        priority: parseInt(agentMatch[2], 10),
+        title: agentMatch[3].trim(),
+      })
+      continue
+    }
+
+    // Fallback: simple format without priority — [indicator] [ID] [title]
+    // ○ ENG_CORE-123 Some Task
+    // ○ ENG-456 In Progress Task
+    const simpleMatch = trimmed.match(
+      /^[○◐●✓❄]\s+([A-Z_]+-\d+)\s+(.+)/,
+    )
+    if (simpleMatch) {
+      tasks.push({
+        id: simpleMatch[1],
+        priority: 2, // default medium priority when not specified
+        title: simpleMatch[2].trim(),
       })
     }
   }
@@ -191,7 +205,10 @@ const xpowersTaskMonitorPlugin: Plugin = async (ctx) => {
   let isShuttingDown = false
 
   const notifyNewTasks = async (tasks: ParsedTask[]) => {
-    const newTasks = tasks.filter((t) => !seenTasks.has(t.id))
+    // When trackSeenTasks is disabled, treat all tasks as new
+    const newTasks = config.trackSeenTasks
+      ? tasks.filter((t) => !seenTasks.has(t.id))
+      : tasks
 
     if (newTasks.length === 0) return
 
@@ -217,12 +234,13 @@ const xpowersTaskMonitorPlugin: Plugin = async (ctx) => {
       )
     }
 
-    // Record newly seen tasks
-    for (const task of newTasks) {
-      seenTasks.set(task.id, { ...task, firstSeenAt: Date.now() })
+    // Record newly seen tasks (only when tracking is enabled)
+    if (config.trackSeenTasks) {
+      for (const task of newTasks) {
+        seenTasks.set(task.id, { ...task, firstSeenAt: Date.now() })
+      }
+      await saveSeenTasks(cachePath, seenTasks)
     }
-
-    await saveSeenTasks(cachePath, seenTasks)
   }
 
   const notifyTaskCount = async (count: number, changed: boolean) => {
@@ -332,10 +350,10 @@ const xpowersTaskMonitorPlugin: Plugin = async (ctx) => {
         return
       }
 
-      // Cleanup timer when session ends
-      if (event.type === "session.deleted") {
-        stopPolling()
-      }
+      // Note: pollTimer is per-plugin, not per-session.
+      // In long-lived OpenCode processes, new sessions after deletion
+      // should still receive task notifications, so we do NOT stop polling here.
+      // The timer is only cleaned up when the plugin itself is destroyed.
     },
 
     // Custom tool: AI can query task status

--- a/.opencode/plugins/xpowers-task-monitor.ts
+++ b/.opencode/plugins/xpowers-task-monitor.ts
@@ -102,8 +102,9 @@ const parseTasks = (output: string): ParsedTask[] => {
 
     // Match: [indicator] [id] [status] P[priority] [title]
     // ○ hyper-5ct ● P1 [epic] Project: Rename repository to xpowers
+    // Supports priorities P0-P99 (multi-digit)
     const match = trimmed.match(
-      /^[○◐●✓❄]\s+([a-z]+-[a-z0-9]+)\s+.*?P(\d)\s+(.+)/,
+      /^[○◐●✓❄]\s+([a-z]+-[a-z0-9]+)\s+.*?P(\d+)\s+(.+)/,
     )
     if (match) {
       tasks.push({
@@ -187,6 +188,7 @@ const xpowersTaskMonitorPlugin: Plugin = async (ctx) => {
   let lastTaskCount = 0
   let pollTimer: ReturnType<typeof setInterval> | null = null
   let isPolling = false
+  let isShuttingDown = false
 
   const notifyNewTasks = async (tasks: ParsedTask[]) => {
     const newTasks = tasks.filter((t) => !seenTasks.has(t.id))
@@ -242,7 +244,7 @@ const xpowersTaskMonitorPlugin: Plugin = async (ctx) => {
   }
 
   const doPoll = async () => {
-    if (isPolling) return
+    if (isPolling || isShuttingDown) return
     isPolling = true
 
     try {
@@ -262,6 +264,14 @@ const xpowersTaskMonitorPlugin: Plugin = async (ctx) => {
       }
     } finally {
       isPolling = false
+    }
+  }
+
+  const stopPolling = () => {
+    isShuttingDown = true
+    if (pollTimer) {
+      clearInterval(pollTimer)
+      pollTimer = null
     }
   }
 
@@ -323,9 +333,8 @@ const xpowersTaskMonitorPlugin: Plugin = async (ctx) => {
       }
 
       // Cleanup timer when session ends
-      if (event.type === "session.deleted" && pollTimer) {
-        clearInterval(pollTimer)
-        pollTimer = null
+      if (event.type === "session.deleted") {
+        stopPolling()
       }
     },
 


### PR DESCRIPTION
## Summary

This PR adds 6 new OpenCode plugins that enhance the terminal development experience with notifications, safety gates, task tracking, and quality enforcement.

## New Plugins

### 1. `xpowers-notify.ts` — Desktop Notifications
Sends desktop notifications when AI agents finish responding or tasks complete.
- Multi-backend: OSC 777/99, osascript, notify-send, growlnotify
- TUI toast notifications as fallback
- Configurable events: agent idle, task complete, task error

### 2. `xpowers-slow-mode.ts` — Edit Review Gate
Review gate for `write` and `edit` tool calls.
- Captures original content before edits
- Computes line-by-line diffs after edits
- Shows toast with change stats and diff preview
- Logs all changes to `.opencode/cache/slow-mode/{session}/review.log`
- Blocks edits to protected paths (.env, .git/hooks, keys)
- Injects review reminder on session stop

### 3. `xpowers-task-monitor.ts` — Live Task Polling
Live polling of `tm ready` with toast notifications.
- Background polling every 60s (configurable)
- Toast notifications when new tasks become available
- Task count summary on session idle
- Seen-task tracking with TTL to avoid notification spam
- Custom tool `xpowers_task_status` for AI to query task board

### 4. `xpowers-git-guard.ts` — Git Commit Reminders
Tracks file modifications and git commits during sessions.
- Warns on session idle if uncommitted changes exist
- Injects reminder on stop if files modified but not committed
- Optionally blocks stop until changes are committed
- Optionally auto-commits on session end
- Git status parsing (modified, staged, untracked, deleted, ahead/behind)

### 5. `xpowers-context-gauge.ts` — Context Monitoring
Monitors estimated context window usage in real-time.
- Warns at 70% usage (warning toast)
- Critical alert at 90% usage (error toast + /compact suggestion)
- Model-aware context limits (OpenAI, Anthropic, Google, Groq)
- Token estimation from message content
- Resets counter on session compaction

### 6. `xpowers-lint-gate.ts` — Post-Edit Linting
Runs project-appropriate linters after write/edit tool calls.
- Auto-detects linter from project config files
- Supports: ESLint, Prettier, Flake8, Black, Rustfmt, Gofmt, ShellCheck
- Configurable auto-fix and block-on-error
- Spam prevention with quiet duration

## Configuration

Each plugin includes a `.opencode/*-config.json` file for customization:
- `notify-config.json`
- `slow-mode-config.json`
- `task-monitor-config.json`
- `git-guard-config.json`
- `context-gauge-config.json`
- `lint-gate-config.json`

## Design Patterns

All plugins follow consistent patterns:
- **Safe error handling**: try/catch around all TUI calls
- **Per-session state**: Session-scoped Maps with cleanup
- **Lazy initialization**: Config loaded once, backends detected on first use
- **Non-blocking**: Failures never block the main workflow
- **Configurable**: JSON config files with sensible defaults

## Testing

Plugins are loaded automatically by OpenCode from `.opencode/plugins/*.ts`.
No manual installation required — just checkout the branch and restart OpenCode.

## Inspired By

- [pi-agent-extensions](https://github.com/rytswd/pi-agent-extensions) by rytswd
- [OpenCode Plugin Docs](https://opencode.ai/docs/plugins/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context usage gauge with warn/danger thresholds, per-model limits, token-toasts, and compaction suggestions
  * Git guard that warns on uncommitted edits, protects sensitive paths, and reminds about commits
  * Lint gate that runs linters on edits, summarizes issues, and can block on errors
  * Notification system with multiple backends for agent/task events
  * Slow mode for deliberate review with diff previews and review logs
  * Task board monitor with polling, priority filtering, and new-task toasts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->