### PR TITLE
[codex] Install third-party tool bundle by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ bun scripts/install.ts --uninstall
 ```
 
 Available hosts: `claude`, `opencode`, `kimi`, `gemini`, `pi`
-Available features: `memsearch`, `supermemory`, `statusline`, `routing-wizard`, `tm-cli`
+Available features: `memsearch`, `br`, `bv`, `graphify`, `claude-mem`, `supermemory`, `statusline`, `routing-wizard`, `tm-cli`
+
+`--yes` includes third-party tool installers. Set `XPOWERS_SKIP_THIRD_PARTY_FEATURES=1` when you need a host-only install without external downloads.
 
 ### For Humans (interactive TUI)
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ bun scripts/install.ts --uninstall
 Available hosts: `claude`, `opencode`, `kimi`, `gemini`, `pi`
 Available features: `memsearch`, `br`, `bv`, `graphify`, `claude-mem`, `supermemory`, `statusline`, `routing-wizard`, `tm-cli`
 
-`--yes` includes third-party tool installers. Set `XPOWERS_SKIP_THIRD_PARTY_FEATURES=1` when you need a host-only install without external downloads.
+`--yes` includes third-party tool installers. `graphify` runs its upstream platform setup only for supported selected hosts (Claude Code, Codex via `install.sh`, OpenCode, Gemini CLI, and Pi). Set `XPOWERS_SKIP_THIRD_PARTY_FEATURES=1` when you need a host-only install without external downloads.
 
 ### For Humans (interactive TUI)
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ bun scripts/install.ts --uninstall
 Available hosts: `claude`, `opencode`, `kimi`, `gemini`, `pi`
 Available features: `memsearch`, `br`, `bv`, `graphify`, `claude-mem`, `supermemory`, `statusline`, `routing-wizard`, `tm-cli`
 
-`--yes` includes third-party tool installers. `graphify` runs its upstream platform setup only for supported selected hosts (Claude Code, Codex via `install.sh`, OpenCode, Gemini CLI, and Pi). Set `XPOWERS_SKIP_THIRD_PARTY_FEATURES=1` when you need a host-only install without external downloads.
+`--yes` includes third-party tool installers. `br` and `bv` bootstrap from pinned upstream installer refs; maintainers can override them with `XPOWERS_BEADS_RUST_INSTALL_REF` and `XPOWERS_BEADS_VIEWER_INSTALL_REF` when intentionally updating. `graphify` runs its upstream platform setup only for supported selected hosts (Claude Code, Codex via `install.sh`, OpenCode, Gemini CLI, and Pi). Set `XPOWERS_SKIP_THIRD_PARTY_FEATURES=1` when you need a host-only install without external downloads.
 
 ### For Humans (interactive TUI)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1260,6 +1260,27 @@ uninstall_tm_cli() {
 
 THIRD_PARTY_SKIP_ENV="XPOWERS_SKIP_THIRD_PARTY_FEATURES"
 
+third_party_state_file() {
+  printf "%s\n" "${HOME}/.xpowers/third-party-tools"
+}
+
+third_party_mark_installed() {
+  local tool="$1"
+  local state_file
+  state_file="$(third_party_state_file)"
+  mkdir -p "$(dirname "$state_file")"
+  if [[ ! -f "$state_file" ]] || ! grep -qxF "$tool" "$state_file"; then
+    printf "%s\n" "$tool" >> "$state_file"
+  fi
+}
+
+third_party_was_installed() {
+  local tool="$1"
+  local state_file
+  state_file="$(third_party_state_file)"
+  [[ -f "$state_file" ]] && grep -qxF "$tool" "$state_file"
+}
+
 third_party_features_skipped() {
   local value="${XPOWERS_SKIP_THIRD_PARTY_FEATURES:-}"
   case "${value,,}" in
@@ -1301,12 +1322,14 @@ install_third_party_tools() {
     if command -v curl >/dev/null 2>&1; then
       if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)" | bash -s -- --skip-skills --quiet --no-gum >/dev/null 2>&1; then
         success "br installed"
+        third_party_mark_installed "br"
       else
         warn "br install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
       fi
 
       if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash >/dev/null 2>&1; then
         success "bv installed"
+        third_party_mark_installed "bv"
       else
         warn "bv install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
       fi
@@ -1318,6 +1341,7 @@ install_third_party_tools() {
       if python3 -m pip install --user graphifyy --quiet >/dev/null 2>&1 \
         && PATH="${HOME}/.local/bin:${PATH}" graphify install >/dev/null 2>&1; then
         success "graphify installed"
+        third_party_mark_installed "graphify"
       else
         warn "graphify install failed — try: python3 -m pip install --user graphifyy && graphify install"
       fi
@@ -1338,6 +1362,7 @@ install_third_party_tools() {
       claude)
         if npx --yes claude-mem install >/dev/null 2>&1; then
           installed_cmem+=("Claude Code")
+          third_party_mark_installed "claude-mem"
         else
           warn "claude-mem install failed for Claude Code — try: npx --yes claude-mem install"
         fi
@@ -1345,6 +1370,7 @@ install_third_party_tools() {
       opencode)
         if npx --yes claude-mem install --ide opencode >/dev/null 2>&1; then
           installed_cmem+=("OpenCode")
+          third_party_mark_installed "claude-mem"
         else
           warn "claude-mem install failed for OpenCode — try: npx --yes claude-mem install --ide opencode"
         fi
@@ -1352,6 +1378,7 @@ install_third_party_tools() {
       gemini)
         if npx --yes claude-mem install --ide gemini-cli >/dev/null 2>&1; then
           installed_cmem+=("Gemini CLI")
+          third_party_mark_installed "claude-mem"
         else
           warn "claude-mem install failed for Gemini CLI — try: npx --yes claude-mem install --ide gemini-cli"
         fi
@@ -1367,6 +1394,51 @@ install_third_party_tools() {
     done
     success "claude-mem installed for ${joined}"
   fi
+}
+
+uninstall_third_party_tools() {
+  local state_file
+  state_file="$(third_party_state_file)"
+  [[ -f "$state_file" ]] || return 0
+
+  info "Removing tracked third-party tool bundle"
+
+  if third_party_was_installed "br"; then
+    rm -f "${HOME}/.local/bin/br" "${HOME}/.local/bin/br.exe"
+    success "br removed"
+  fi
+
+  if third_party_was_installed "bv"; then
+    rm -f "${HOME}/.local/bin/bv" "${HOME}/.local/bin/bv.exe"
+    success "bv removed"
+  fi
+
+  if third_party_was_installed "graphify"; then
+    if command -v python3 >/dev/null 2>&1; then
+      if python3 -m pip uninstall -y graphifyy >/dev/null 2>&1; then
+        success "graphify removed"
+      else
+        warn "graphify uninstall failed — try: python3 -m pip uninstall -y graphifyy"
+      fi
+    else
+      warn "python3 not found — skipping graphify uninstall"
+    fi
+  fi
+
+  if third_party_was_installed "claude-mem"; then
+    if command -v npx >/dev/null 2>&1; then
+      if npx --yes claude-mem uninstall >/dev/null 2>&1; then
+        success "claude-mem removed"
+      else
+        warn "claude-mem uninstall failed — try: npx --yes claude-mem uninstall"
+      fi
+    else
+      warn "npx not found — skipping claude-mem uninstall"
+    fi
+  fi
+
+  rm -f "$state_file"
+  rmdir "$(dirname "$state_file")" 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
@@ -1606,7 +1678,7 @@ main() {
   # (run AFTER resolution so --all auto-detected Pi is included)
   local has_pi=false
   local pi_delegated=false
-  local pi_delegation_succeeded=false
+  local pi_host_independent_features_succeeded=false
   for agent in "${SELECTED_AGENTS[@]}"; do
     [[ "$agent" == "pi" ]] && has_pi=true
   done
@@ -1636,8 +1708,14 @@ main() {
         cd "${REPO_ROOT}" && exec bun scripts/install.ts "${PI_ARGS[@]}"
       else
         # Pi is one of multiple — run without exec, capture exit code, then continue
-        if (cd "${REPO_ROOT}" && bun scripts/install.ts "${PI_ARGS[@]}"); then
-          pi_delegation_succeeded=true
+        local pi_output=""
+        if pi_output="$(cd "${REPO_ROOT}" && bun scripts/install.ts "${PI_ARGS[@]}" --json)"; then
+          if [[ "$pi_output" == *'"br":true'* && "$pi_output" == *'"bv":true'* && "$pi_output" == *'"graphify":true'* ]]; then
+            pi_host_independent_features_succeeded=true
+            third_party_mark_installed "br"
+            third_party_mark_installed "bv"
+            third_party_mark_installed "graphify"
+          fi
         else
           FAILED_AGENTS+=("pi")
         fi
@@ -1774,7 +1852,7 @@ main() {
   done
 
   if [[ "$MODE" == "install" && "$FORCE" == true ]]; then
-    if [[ "$pi_delegation_succeeded" == true ]]; then
+    if [[ "$pi_host_independent_features_succeeded" == true ]]; then
       install_third_party_tools --skip-host-independent "${SELECTED_AGENTS[@]}"
     else
       install_third_party_tools "${SELECTED_AGENTS[@]}"
@@ -1789,8 +1867,11 @@ main() {
   [[ "$MODE" == "uninstall" ]] && action_past="Uninstalled"
 
   if [[ ${#FAILED_AGENTS[@]} -eq 0 ]]; then
-    if [[ "$MODE" == "uninstall" ]] && [[ ${#SELECTED_AGENTS[@]} -eq $total_detected_agents ]]; then
-      uninstall_tm_cli
+    if [[ "$MODE" == "uninstall" ]]; then
+      uninstall_third_party_tools
+      if [[ ${#SELECTED_AGENTS[@]} -eq $total_detected_agents ]]; then
+        uninstall_tm_cli
+      fi
     fi
     success "${action_past} to ${ok_count} agent(s): ${agent_list}"
   else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1432,6 +1432,7 @@ uninstall_third_party_tools() {
   fi
 
   info "Removing tracked third-party tool bundle"
+  local failed=false
 
   if third_party_was_installed "br"; then
     rm -f "${HOME}/.local/bin/br" "${HOME}/.local/bin/br.exe"
@@ -1449,9 +1450,11 @@ uninstall_third_party_tools() {
         success "graphify removed"
       else
         warn "graphify uninstall failed — try: python3 -m pip uninstall -y graphifyy"
+        failed=true
       fi
     else
       warn "python3 not found — skipping graphify uninstall"
+      failed=true
     fi
   fi
 
@@ -1461,14 +1464,20 @@ uninstall_third_party_tools() {
         success "claude-mem removed"
       else
         warn "claude-mem uninstall failed — try: npx --yes claude-mem uninstall"
+        failed=true
       fi
     else
       warn "npx not found — skipping claude-mem uninstall"
+      failed=true
     fi
   fi
 
-  rm -f "$state_file"
-  rmdir "$(dirname "$state_file")" 2>/dev/null || true
+  if [[ "$failed" == true ]]; then
+    warn "Keeping third-party state file for retry: ${state_file}"
+  else
+    rm -f "$state_file"
+    rmdir "$(dirname "$state_file")" 2>/dev/null || true
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -1731,7 +1740,11 @@ main() {
     else
       # Build filtered args for install.ts (only flags it understands)
       local -a PI_ARGS=("--hosts" "pi")
-      [[ "$FORCE" == true ]] && PI_ARGS+=("--yes")
+      if [[ "$FORCE" == true ]]; then
+        PI_ARGS+=("--yes")
+      else
+        PI_ARGS+=("--features" "tm-cli")
+      fi
       [[ "$ALLOW_CONFLICTS" == true ]] && PI_ARGS+=("--allow-conflicts")
       if [[ ${#SELECTED_AGENTS[@]} -eq 1 ]]; then
         if [[ "$FORCE" == true ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1283,13 +1283,23 @@ third_party_was_installed() {
 
 record_pi_host_independent_third_party_state() {
   local pi_output="$1"
-  if [[ "$pi_output" == *'"br":true'* && "$pi_output" == *'"bv":true'* && "$pi_output" == *'"graphify":true'* ]]; then
+  local all_succeeded=true
+  if [[ "$pi_output" == *'"br":true'* ]]; then
     third_party_mark_installed "br"
-    third_party_mark_installed "bv"
-    third_party_mark_installed "graphify"
-    return 0
+  else
+    all_succeeded=false
   fi
-  return 1
+  if [[ "$pi_output" == *'"bv":true'* ]]; then
+    third_party_mark_installed "bv"
+  else
+    all_succeeded=false
+  fi
+  if [[ "$pi_output" == *'"graphify":true'* ]]; then
+    third_party_mark_installed "graphify"
+  else
+    all_succeeded=false
+  fi
+  [[ "$all_succeeded" == true ]]
 }
 
 third_party_features_skipped() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1281,6 +1281,17 @@ third_party_was_installed() {
   [[ -f "$state_file" ]] && grep -qxF "$tool" "$state_file"
 }
 
+record_pi_host_independent_third_party_state() {
+  local pi_output="$1"
+  if [[ "$pi_output" == *'"br":true'* && "$pi_output" == *'"bv":true'* && "$pi_output" == *'"graphify":true'* ]]; then
+    third_party_mark_installed "br"
+    third_party_mark_installed "bv"
+    third_party_mark_installed "graphify"
+    return 0
+  fi
+  return 1
+}
+
 third_party_features_skipped() {
   local value="${XPOWERS_SKIP_THIRD_PARTY_FEATURES:-}"
   case "${value,,}" in
@@ -1723,17 +1734,27 @@ main() {
       [[ "$FORCE" == true ]] && PI_ARGS+=("--yes")
       [[ "$ALLOW_CONFLICTS" == true ]] && PI_ARGS+=("--allow-conflicts")
       if [[ ${#SELECTED_AGENTS[@]} -eq 1 ]]; then
-        # Pi is the only host — exec for efficiency
-        cd "${REPO_ROOT}" && exec bun scripts/install.ts "${PI_ARGS[@]}"
+        if [[ "$FORCE" == true ]]; then
+          # Pi is the only host in non-interactive mode — capture JSON so the
+          # shell wrapper can keep third-party uninstall ownership in sync.
+          local pi_output=""
+          if pi_output="$(cd "${REPO_ROOT}" && bun scripts/install.ts "${PI_ARGS[@]}" --json)"; then
+            if record_pi_host_independent_third_party_state "$pi_output"; then
+              pi_host_independent_features_succeeded=true
+            fi
+          else
+            FAILED_AGENTS+=("pi")
+          fi
+        else
+          # Pi is the only interactive host — exec for efficiency.
+          cd "${REPO_ROOT}" && exec bun scripts/install.ts "${PI_ARGS[@]}"
+        fi
       else
         # Pi is one of multiple — run without exec, capture exit code, then continue
         local pi_output=""
         if pi_output="$(cd "${REPO_ROOT}" && bun scripts/install.ts "${PI_ARGS[@]}" --json)"; then
-          if [[ "$pi_output" == *'"br":true'* && "$pi_output" == *'"bv":true'* && "$pi_output" == *'"graphify":true'* ]]; then
+          if record_pi_host_independent_third_party_state "$pi_output"; then
             pi_host_independent_features_succeeded=true
-            third_party_mark_installed "br"
-            third_party_mark_installed "bv"
-            third_party_mark_installed "graphify"
           fi
         else
           FAILED_AGENTS+=("pi")
@@ -1887,8 +1908,8 @@ main() {
 
   if [[ ${#FAILED_AGENTS[@]} -eq 0 ]]; then
     if [[ "$MODE" == "uninstall" ]]; then
-      uninstall_third_party_tools
       if [[ ${#SELECTED_AGENTS[@]} -eq $total_detected_agents ]]; then
+        uninstall_third_party_tools
         uninstall_tm_cli
       fi
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1255,6 +1255,103 @@ uninstall_tm_cli() {
 }
 
 # ---------------------------------------------------------------------------
+# Third-party tool bundle
+# ---------------------------------------------------------------------------
+
+THIRD_PARTY_SKIP_ENV="XPOWERS_SKIP_THIRD_PARTY_FEATURES"
+
+third_party_features_skipped() {
+  local value="${XPOWERS_SKIP_THIRD_PARTY_FEATURES:-}"
+  case "${value,,}" in
+    1|true|yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+install_third_party_tools() {
+  if [[ "$DRY_RUN" == true ]]; then
+    info "Would install third-party tool bundle: br, bv, graphify, claude-mem"
+    return 0
+  fi
+
+  if third_party_features_skipped; then
+    info "Skipping third-party tool bundle (${THIRD_PARTY_SKIP_ENV}=1)"
+    return 0
+  fi
+
+  info "Installing third-party tool bundle: br, bv, graphify, claude-mem"
+
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)" | bash -s -- --skip-skills --quiet --no-gum >/dev/null 2>&1; then
+      success "br installed"
+    else
+      warn "br install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
+    fi
+
+    if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash >/dev/null 2>&1; then
+      success "bv installed"
+    else
+      warn "bv install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+    fi
+  else
+    warn "curl not found — skipping br and bv installers"
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    if python3 -m pip install --user graphifyy --quiet >/dev/null 2>&1 \
+      && PATH="${HOME}/.local/bin:${PATH}" graphify install >/dev/null 2>&1; then
+      success "graphify installed"
+    else
+      warn "graphify install failed — try: python3 -m pip install --user graphifyy && graphify install"
+    fi
+  else
+    warn "python3 not found — skipping graphify"
+  fi
+
+  if ! command -v npx >/dev/null 2>&1; then
+    warn "npx not found — skipping claude-mem"
+    return 0
+  fi
+
+  local installed_cmem=()
+  local agent
+  for agent in "$@"; do
+    case "$agent" in
+      claude)
+        if npx --yes claude-mem install >/dev/null 2>&1; then
+          installed_cmem+=("Claude Code")
+        else
+          warn "claude-mem install failed for Claude Code — try: npx --yes claude-mem install"
+        fi
+        ;;
+      opencode)
+        if npx --yes claude-mem install --ide opencode >/dev/null 2>&1; then
+          installed_cmem+=("OpenCode")
+        else
+          warn "claude-mem install failed for OpenCode — try: npx --yes claude-mem install --ide opencode"
+        fi
+        ;;
+      gemini)
+        if npx --yes claude-mem install --ide gemini-cli >/dev/null 2>&1; then
+          installed_cmem+=("Gemini CLI")
+        else
+          warn "claude-mem install failed for Gemini CLI — try: npx --yes claude-mem install --ide gemini-cli"
+        fi
+        ;;
+    esac
+  done
+
+  if [[ ${#installed_cmem[@]} -gt 0 ]]; then
+    local joined=""
+    for agent in "${installed_cmem[@]}"; do
+      [[ -n "$joined" ]] && joined+=", "
+      joined+="$agent"
+    done
+    success "claude-mem installed for ${joined}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # CLI usage
 # ---------------------------------------------------------------------------
 
@@ -1284,6 +1381,10 @@ MODES:
     --allow-conflicts   Advanced: continue despite detected hyperpowers/myhyperpowers/superpowers installs
     --remove-legacy     Detect and remove legacy installs (hyperpowers, myhyperpowers, superpowers)
     --replace-legacy    Remove legacy installs, then proceed with XPowers install
+
+FEATURES:
+    --yes installs third-party tools: br, bv, graphify, claude-mem
+    Set XPOWERS_SKIP_THIRD_PARTY_FEATURES=1 to skip external tool installers
 
 GENERAL:
     -h, --help          Show this help
@@ -1650,6 +1751,10 @@ main() {
       fi
     fi
   done
+
+  if [[ "$MODE" == "install" ]]; then
+    install_third_party_tools "${SELECTED_AGENTS[@]}"
+  fi
 
   echo
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1280,6 +1280,7 @@ install_third_party_tools() {
   fi
 
   info "Installing third-party tool bundle: br, bv, graphify, claude-mem"
+  warn "Third-party tool bundle runs upstream installers/packages. Set ${THIRD_PARTY_SKIP_ENV}=1 to skip."
 
   if command -v curl >/dev/null 2>&1; then
     if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)" | bash -s -- --skip-skills --quiet --no-gum >/dev/null 2>&1; then
@@ -1752,7 +1753,7 @@ main() {
     fi
   done
 
-  if [[ "$MODE" == "install" ]]; then
+  if [[ "$MODE" == "install" && "$FORCE" == true ]]; then
     install_third_party_tools "${SELECTED_AGENTS[@]}"
   fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1269,8 +1269,18 @@ third_party_features_skipped() {
 }
 
 install_third_party_tools() {
+  local skip_host_independent=false
+  if [[ "${1:-}" == "--skip-host-independent" ]]; then
+    skip_host_independent=true
+    shift
+  fi
+
   if [[ "$DRY_RUN" == true ]]; then
-    info "Would install third-party tool bundle: br, bv, graphify, claude-mem"
+    if [[ "$skip_host_independent" == true ]]; then
+      info "Would install third-party tool bundle: claude-mem"
+    else
+      info "Would install third-party tool bundle: br, bv, graphify, claude-mem"
+    fi
     return 0
   fi
 
@@ -1279,34 +1289,41 @@ install_third_party_tools() {
     return 0
   fi
 
-  info "Installing third-party tool bundle: br, bv, graphify, claude-mem"
+  if [[ "$skip_host_independent" == true ]]; then
+    info "Installing third-party tool bundle: claude-mem"
+    info "Skipping br, bv, and graphify; Pi delegation already handled host-independent tools"
+  else
+    info "Installing third-party tool bundle: br, bv, graphify, claude-mem"
+  fi
   warn "Third-party tool bundle runs upstream installers/packages. Set ${THIRD_PARTY_SKIP_ENV}=1 to skip."
 
-  if command -v curl >/dev/null 2>&1; then
-    if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)" | bash -s -- --skip-skills --quiet --no-gum >/dev/null 2>&1; then
-      success "br installed"
+  if [[ "$skip_host_independent" != true ]]; then
+    if command -v curl >/dev/null 2>&1; then
+      if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)" | bash -s -- --skip-skills --quiet --no-gum >/dev/null 2>&1; then
+        success "br installed"
+      else
+        warn "br install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
+      fi
+
+      if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash >/dev/null 2>&1; then
+        success "bv installed"
+      else
+        warn "bv install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+      fi
     else
-      warn "br install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
+      warn "curl not found — skipping br and bv installers"
     fi
 
-    if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash >/dev/null 2>&1; then
-      success "bv installed"
+    if command -v python3 >/dev/null 2>&1; then
+      if python3 -m pip install --user graphifyy --quiet >/dev/null 2>&1 \
+        && PATH="${HOME}/.local/bin:${PATH}" graphify install >/dev/null 2>&1; then
+        success "graphify installed"
+      else
+        warn "graphify install failed — try: python3 -m pip install --user graphifyy && graphify install"
+      fi
     else
-      warn "bv install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+      warn "python3 not found — skipping graphify"
     fi
-  else
-    warn "curl not found — skipping br and bv installers"
-  fi
-
-  if command -v python3 >/dev/null 2>&1; then
-    if python3 -m pip install --user graphifyy --quiet >/dev/null 2>&1 \
-      && PATH="${HOME}/.local/bin:${PATH}" graphify install >/dev/null 2>&1; then
-      success "graphify installed"
-    else
-      warn "graphify install failed — try: python3 -m pip install --user graphifyy && graphify install"
-    fi
-  else
-    warn "python3 not found — skipping graphify"
   fi
 
   if ! command -v npx >/dev/null 2>&1; then
@@ -1589,6 +1606,7 @@ main() {
   # (run AFTER resolution so --all auto-detected Pi is included)
   local has_pi=false
   local pi_delegated=false
+  local pi_delegation_succeeded=false
   for agent in "${SELECTED_AGENTS[@]}"; do
     [[ "$agent" == "pi" ]] && has_pi=true
   done
@@ -1618,7 +1636,9 @@ main() {
         cd "${REPO_ROOT}" && exec bun scripts/install.ts "${PI_ARGS[@]}"
       else
         # Pi is one of multiple — run without exec, capture exit code, then continue
-        if ! (cd "${REPO_ROOT}" && bun scripts/install.ts "${PI_ARGS[@]}"); then
+        if (cd "${REPO_ROOT}" && bun scripts/install.ts "${PI_ARGS[@]}"); then
+          pi_delegation_succeeded=true
+        else
           FAILED_AGENTS+=("pi")
         fi
       fi
@@ -1754,7 +1774,11 @@ main() {
   done
 
   if [[ "$MODE" == "install" && "$FORCE" == true ]]; then
-    install_third_party_tools "${SELECTED_AGENTS[@]}"
+    if [[ "$pi_delegation_succeeded" == true ]]; then
+      install_third_party_tools --skip-host-independent "${SELECTED_AGENTS[@]}"
+    else
+      install_third_party_tools "${SELECTED_AGENTS[@]}"
+    fi
   fi
 
   echo

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1401,6 +1401,25 @@ uninstall_third_party_tools() {
   state_file="$(third_party_state_file)"
   [[ -f "$state_file" ]] || return 0
 
+  if [[ "$DRY_RUN" == true ]]; then
+    info "Would remove tracked third-party tool bundle"
+    if third_party_was_installed "br"; then
+      echo "  Would remove: ${HOME}/.local/bin/br"
+      echo "  Would remove: ${HOME}/.local/bin/br.exe"
+    fi
+    if third_party_was_installed "bv"; then
+      echo "  Would remove: ${HOME}/.local/bin/bv"
+      echo "  Would remove: ${HOME}/.local/bin/bv.exe"
+    fi
+    if third_party_was_installed "graphify"; then
+      echo "  Would run: python3 -m pip uninstall -y graphifyy"
+    fi
+    if third_party_was_installed "claude-mem"; then
+      echo "  Would run: npx --yes claude-mem uninstall"
+    fi
+    return 0
+  fi
+
   info "Removing tracked third-party tool bundle"
 
   if third_party_was_installed "br"; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1264,6 +1264,50 @@ third_party_state_file() {
   printf "%s\n" "${HOME}/.xpowers/third-party-tools"
 }
 
+third_party_manifest_file() {
+  printf "%s\n" "${HOME}/.xpowers/manifest.json"
+}
+
+third_party_manifest_has_installed() {
+  local tool="$1"
+  local manifest_file
+  manifest_file="$(third_party_manifest_file)"
+  [[ -f "$manifest_file" ]] || return 1
+
+  if command -v node >/dev/null 2>&1; then
+    node -e 'const fs = require("fs"); const [manifestPath, tool] = process.argv.slice(1); const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); process.exit(manifest.features?.[tool]?.installed === true ? 0 : 1)' "$manifest_file" "$tool" >/dev/null 2>&1
+  elif command -v bun >/dev/null 2>&1; then
+    bun -e 'const fs = require("fs"); const [manifestPath, tool] = process.argv.slice(1); const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); process.exit(manifest.features?.[tool]?.installed === true ? 0 : 1)' "$manifest_file" "$tool" >/dev/null 2>&1
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys; data = json.load(open(sys.argv[1])); sys.exit(0 if data.get("features", {}).get(sys.argv[2], {}).get("installed") is True else 1)' "$manifest_file" "$tool" >/dev/null 2>&1
+  elif command -v awk >/dev/null 2>&1; then
+    awk -v tool="$tool" '
+      index($0, "\"" tool "\"") && $0 ~ /:[[:space:]]*[{]/ { in_tool = 1 }
+      in_tool && $0 ~ /"installed"[[:space:]]*:[[:space:]]*true/ { found = 1 }
+      in_tool && $0 ~ /^[[:space:]]*[}][,]?[[:space:]]*$/ { exit }
+      END { exit(found ? 0 : 1) }
+    ' "$manifest_file"
+  else
+    return 1
+  fi
+}
+
+third_party_clear_manifest_features() {
+  local manifest_file
+  manifest_file="$(third_party_manifest_file)"
+  [[ -f "$manifest_file" ]] || return 0
+
+  if command -v node >/dev/null 2>&1; then
+    node -e 'const fs = require("fs"); const manifestPath = process.argv[1]; const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); for (const tool of ["br", "bv", "graphify", "claude-mem"]) { if (manifest.features?.[tool]) manifest.features[tool].installed = false } fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n")' "$manifest_file" >/dev/null 2>&1
+  elif command -v bun >/dev/null 2>&1; then
+    bun -e 'const fs = require("fs"); const manifestPath = process.argv[1]; const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); for (const tool of ["br", "bv", "graphify", "claude-mem"]) { if (manifest.features?.[tool]) manifest.features[tool].installed = false } fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n")' "$manifest_file" >/dev/null 2>&1
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys; path = sys.argv[1]; data = json.load(open(path)); [data.get("features", {}).get(tool, {}).update({"installed": False}) for tool in ("br", "bv", "graphify", "claude-mem") if tool in data.get("features", {})]; open(path, "w").write(json.dumps(data, indent=2) + "\n")' "$manifest_file" >/dev/null 2>&1
+  else
+    return 1
+  fi
+}
+
 third_party_mark_installed() {
   local tool="$1"
   local state_file
@@ -1278,7 +1322,45 @@ third_party_was_installed() {
   local tool="$1"
   local state_file
   state_file="$(third_party_state_file)"
-  [[ -f "$state_file" ]] && grep -qxF "$tool" "$state_file"
+  if [[ -f "$state_file" ]] && grep -qxF "$tool" "$state_file"; then
+    return 0
+  fi
+  third_party_manifest_has_installed "$tool"
+}
+
+third_party_has_tracked_install() {
+  local tool
+  for tool in br bv graphify claude-mem; do
+    if third_party_was_installed "$tool"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+selected_agents_cover_detected_agents() {
+  local detected_count=0
+  local detected_agent
+  local selected_agent
+
+  for detected_agent in "${AGENT_ORDER[@]}"; do
+    [[ -n "${AGENT_PATHS[$detected_agent]:-}" ]] || continue
+    detected_count=$((detected_count + 1))
+    local selected=false
+    for selected_agent in "${SELECTED_AGENTS[@]}"; do
+      if [[ "$selected_agent" == "$detected_agent" ]]; then
+        selected=true
+        break
+      fi
+    done
+    [[ "$selected" == true ]] || return 1
+  done
+
+  if [[ $detected_count -eq 0 ]]; then
+    [[ ${#SELECTED_AGENTS[@]} -gt 0 ]]
+  else
+    return 0
+  fi
 }
 
 pi_feature_succeeded_this_run() {
@@ -1430,7 +1512,7 @@ install_third_party_tools() {
 uninstall_third_party_tools() {
   local state_file
   state_file="$(third_party_state_file)"
-  [[ -f "$state_file" ]] || return 0
+  third_party_has_tracked_install || return 0
 
   if [[ "$DRY_RUN" == true ]]; then
     info "Would remove tracked third-party tool bundle"
@@ -1493,8 +1575,11 @@ uninstall_third_party_tools() {
   fi
 
   if [[ "$failed" == true ]]; then
-    warn "Keeping third-party state file for retry: ${state_file}"
+    warn "Keeping third-party tracking for retry: ${state_file} / $(third_party_manifest_file)"
   else
+    if ! third_party_clear_manifest_features; then
+      warn "Could not update third-party entries in $(third_party_manifest_file)"
+    fi
     rm -f "$state_file"
     rmdir "$(dirname "$state_file")" 2>/dev/null || true
   fi
@@ -1878,16 +1963,6 @@ main() {
     exit 1
   fi
 
-  local total_detected_agents=${#SELECTED_AGENTS[@]}
-  if [[ ${#AGENT_PATHS[@]} -gt 0 ]]; then
-    total_detected_agents=0
-    for agent in "${AGENT_ORDER[@]}"; do
-      if [[ -n "${AGENT_PATHS[$agent]:-}" ]]; then
-        total_detected_agents=$((total_detected_agents + 1))
-      fi
-    done
-  fi
-
   # --- Install tm CLI tool (shared across all agents) ---
   if [[ "$MODE" == "install" ]]; then
     install_tm_cli
@@ -1948,7 +2023,7 @@ main() {
 
   if [[ ${#FAILED_AGENTS[@]} -eq 0 ]]; then
     if [[ "$MODE" == "uninstall" ]]; then
-      if [[ ${#SELECTED_AGENTS[@]} -eq $total_detected_agents ]]; then
+      if selected_agents_cover_detected_agents; then
         uninstall_third_party_tools
         uninstall_tm_cli
       fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1722,6 +1722,7 @@ main() {
   fi
 
   local -a FAILED_AGENTS=()
+  local -a SUCCESSFUL_AGENTS=()
 
   # Pi delegation: TypeScript installer handles Pi install only
   # (run AFTER resolution so --all auto-detected Pi is included)
@@ -1762,6 +1763,7 @@ main() {
           # shell wrapper can keep third-party uninstall ownership in sync.
           local pi_output=""
           if pi_output="$(cd "${REPO_ROOT}" && bun scripts/install.ts "${PI_ARGS[@]}" --json)"; then
+            SUCCESSFUL_AGENTS+=("pi")
             if record_pi_host_independent_third_party_state "$pi_output"; then
               pi_host_independent_features_succeeded=true
             fi
@@ -1776,6 +1778,7 @@ main() {
         # Pi is one of multiple — run without exec, capture exit code, then continue
         local pi_output=""
         if pi_output="$(cd "${REPO_ROOT}" && bun scripts/install.ts "${PI_ARGS[@]}" --json)"; then
+          SUCCESSFUL_AGENTS+=("pi")
           if record_pi_host_independent_third_party_state "$pi_output"; then
             pi_host_independent_features_succeeded=true
           fi
@@ -1899,9 +1902,11 @@ main() {
       fi
     elif [[ "$DRY_RUN" == true ]]; then
       echo -e "  ${DIM}Would install to ${BOLD}${label}${RESET}${DIM} (dry-run)${RESET}"
+      SUCCESSFUL_AGENTS+=("$agent")
     else
       printf "  Installing to ${BOLD}%-16s${RESET} " "$label..."
       if "install_${agent}" 2>/dev/null; then
+        SUCCESSFUL_AGENTS+=("$agent")
         if "validate_${agent}" 2>/dev/null; then
           echo -e "${GREEN}✓${RESET}"
         else
@@ -1915,10 +1920,12 @@ main() {
   done
 
   if [[ "$MODE" == "install" && "$FORCE" == true ]]; then
-    if [[ "$pi_host_independent_features_succeeded" == true ]]; then
-      install_third_party_tools --skip-host-independent "${SELECTED_AGENTS[@]}"
+    if [[ ${#SUCCESSFUL_AGENTS[@]} -eq 0 ]]; then
+      warn "Skipping third-party tool bundle because no selected agents installed successfully."
+    elif [[ "$pi_host_independent_features_succeeded" == true ]]; then
+      install_third_party_tools --skip-host-independent "${SUCCESSFUL_AGENTS[@]}"
     else
-      install_third_party_tools "${SELECTED_AGENTS[@]}"
+      install_third_party_tools "${SUCCESSFUL_AGENTS[@]}"
     fi
   fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1402,6 +1402,98 @@ third_party_features_skipped() {
   esac
 }
 
+join_labels() {
+  local joined=""
+  local item
+  for item in "$@"; do
+    [[ -n "$joined" ]] && joined+=", "
+    joined+="$item"
+  done
+  printf "%s" "$joined"
+}
+
+install_graphify_for_agents() {
+  local skip_delegated_pi="$1"
+  shift
+
+  local -a targets=()
+  local skipped_delegated_pi=false
+  local agent
+  for agent in "$@"; do
+    if [[ "$skip_delegated_pi" == true && "$agent" == "pi" ]]; then
+      skipped_delegated_pi=true
+      continue
+    fi
+    case "$agent" in
+      claude|codex|opencode|gemini|pi) targets+=("$agent") ;;
+    esac
+  done
+
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    if [[ "$skipped_delegated_pi" == true ]]; then
+      info "Skipping Pi graphify; Pi delegation already handled it"
+    else
+      warn "graphify skipped — Claude Code, Codex, OpenCode, Gemini CLI, or Pi Agent not selected"
+    fi
+    return 0
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    warn "python3 not found — skipping graphify"
+    return 0
+  fi
+
+  if ! python3 -m pip install --user graphifyy --quiet >/dev/null 2>&1; then
+    warn "graphify package install failed — try: python3 -m pip install --user graphifyy"
+    return 0
+  fi
+
+  local -a installed_graphify=()
+  for agent in "${targets[@]}"; do
+    local label=""
+    local try_command=""
+    local -a graphify_args=()
+    case "$agent" in
+      claude)
+        label="Claude Code"
+        try_command="graphify install"
+        graphify_args=(install)
+        ;;
+      codex)
+        label="Codex"
+        try_command="graphify install --platform codex"
+        graphify_args=(install --platform codex)
+        ;;
+      opencode)
+        label="OpenCode"
+        try_command="graphify install --platform opencode"
+        graphify_args=(install --platform opencode)
+        ;;
+      gemini)
+        label="Gemini CLI"
+        try_command="graphify install --platform gemini"
+        graphify_args=(install --platform gemini)
+        ;;
+      pi)
+        label="Pi Agent"
+        try_command="graphify install --platform pi"
+        graphify_args=(install --platform pi)
+        ;;
+    esac
+
+    if PATH="${HOME}/.local/bin:${PATH}" graphify "${graphify_args[@]}" >/dev/null 2>&1; then
+      installed_graphify+=("$label")
+    else
+      warn "graphify install failed for ${label} — try: ${try_command}"
+    fi
+  done
+
+  if [[ ${#installed_graphify[@]} -gt 0 ]]; then
+    success "graphify installed for $(join_labels "${installed_graphify[@]}")"
+    third_party_mark_installed "graphify"
+  fi
+}
+
 install_third_party_tools() {
   local skip_host_independent=false
   if [[ "${1:-}" == "--skip-host-independent" ]]; then
@@ -1411,7 +1503,7 @@ install_third_party_tools() {
 
   if [[ "$DRY_RUN" == true ]]; then
     if [[ "$skip_host_independent" == true ]]; then
-      info "Would install third-party tool bundle: claude-mem"
+      info "Would install third-party tool bundle: graphify for non-Pi supported hosts, claude-mem"
     else
       info "Would install third-party tool bundle: br, bv, graphify, claude-mem"
     fi
@@ -1424,8 +1516,8 @@ install_third_party_tools() {
   fi
 
   if [[ "$skip_host_independent" == true ]]; then
-    info "Installing third-party tool bundle: claude-mem"
-    info "Skipping br, bv, and graphify; Pi delegation already handled host-independent tools"
+    info "Installing third-party tool bundle: graphify, claude-mem"
+    info "Skipping br, bv, and delegated Pi graphify; Pi delegation already handled them"
   else
     info "Installing third-party tool bundle: br, bv, graphify, claude-mem"
   fi
@@ -1449,19 +1541,9 @@ install_third_party_tools() {
     else
       warn "curl not found — skipping br and bv installers"
     fi
-
-    if command -v python3 >/dev/null 2>&1; then
-      if python3 -m pip install --user graphifyy --quiet >/dev/null 2>&1 \
-        && PATH="${HOME}/.local/bin:${PATH}" graphify install >/dev/null 2>&1; then
-        success "graphify installed"
-        third_party_mark_installed "graphify"
-      else
-        warn "graphify install failed — try: python3 -m pip install --user graphifyy && graphify install"
-      fi
-    else
-      warn "python3 not found — skipping graphify"
-    fi
   fi
+
+  install_graphify_for_agents "$skip_host_independent" "$@"
 
   if ! command -v npx >/dev/null 2>&1; then
     warn "npx not found — skipping claude-mem"
@@ -1500,12 +1582,7 @@ install_third_party_tools() {
   done
 
   if [[ ${#installed_cmem[@]} -gt 0 ]]; then
-    local joined=""
-    for agent in "${installed_cmem[@]}"; do
-      [[ -n "$joined" ]] && joined+=", "
-      joined+="$agent"
-    done
-    success "claude-mem installed for ${joined}"
+    success "claude-mem installed for $(join_labels "${installed_cmem[@]}")"
   fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1281,20 +1281,30 @@ third_party_was_installed() {
   [[ -f "$state_file" ]] && grep -qxF "$tool" "$state_file"
 }
 
+pi_feature_succeeded_this_run() {
+  local pi_output="$1"
+  local tool="$2"
+  local marker='"featureResults":{'
+  local feature_results="${pi_output#*${marker}}"
+  [[ "$feature_results" != "$pi_output" ]] || return 1
+  feature_results="${feature_results%%\}*}"
+  [[ "$feature_results" == *"\"${tool}\":true"* ]]
+}
+
 record_pi_host_independent_third_party_state() {
   local pi_output="$1"
   local all_succeeded=true
-  if [[ "$pi_output" == *'"br":true'* ]]; then
+  if pi_feature_succeeded_this_run "$pi_output" "br"; then
     third_party_mark_installed "br"
   else
     all_succeeded=false
   fi
-  if [[ "$pi_output" == *'"bv":true'* ]]; then
+  if pi_feature_succeeded_this_run "$pi_output" "bv"; then
     third_party_mark_installed "bv"
   else
     all_succeeded=false
   fi
-  if [[ "$pi_output" == *'"graphify":true'* ]]; then
+  if pi_feature_succeeded_this_run "$pi_output" "graphify"; then
     third_party_mark_installed "graphify"
   else
     all_succeeded=false

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1622,7 +1622,7 @@ uninstall_third_party_tools() {
       echo "  Would run: python3 -m pip uninstall -y graphifyy"
     fi
     if third_party_was_installed "claude-mem"; then
-      echo "  Would run: npx --yes claude-mem uninstall"
+      echo "  Would run: npx --yes claude-mem uninstall --all"
     fi
     return 0
   fi
@@ -1656,10 +1656,10 @@ uninstall_third_party_tools() {
 
   if third_party_was_installed "claude-mem"; then
     if command -v npx >/dev/null 2>&1; then
-      if npx --yes claude-mem uninstall >/dev/null 2>&1; then
+      if npx --yes claude-mem uninstall --all >/dev/null 2>&1; then
         success "claude-mem removed"
       else
-        warn "claude-mem uninstall failed — try: npx --yes claude-mem uninstall"
+        warn "claude-mem uninstall failed — try: npx --yes claude-mem uninstall --all"
         failed=true
       fi
     else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1259,9 +1259,19 @@ uninstall_tm_cli() {
 # ---------------------------------------------------------------------------
 
 THIRD_PARTY_SKIP_ENV="XPOWERS_SKIP_THIRD_PARTY_FEATURES"
+BEADS_RUST_INSTALL_REF="${XPOWERS_BEADS_RUST_INSTALL_REF:-f4687e51a5aa155fe27cb8ea6d7fdae942b0154f}"
+BEADS_VIEWER_INSTALL_REF="${XPOWERS_BEADS_VIEWER_INSTALL_REF:-bb977f5b812b2987d77544872287b502b5b3a444}"
 
 third_party_state_file() {
   printf "%s\n" "${HOME}/.xpowers/third-party-tools"
+}
+
+beads_rust_install_url() {
+  printf "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/%s/install.sh" "$BEADS_RUST_INSTALL_REF"
+}
+
+beads_viewer_install_url() {
+  printf "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/%s/install.sh" "$BEADS_VIEWER_INSTALL_REF"
 }
 
 third_party_manifest_file() {
@@ -1525,18 +1535,22 @@ install_third_party_tools() {
 
   if [[ "$skip_host_independent" != true ]]; then
     if command -v curl >/dev/null 2>&1; then
-      if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)" | bash -s -- --skip-skills --quiet --no-gum >/dev/null 2>&1; then
+      local br_install_url
+      br_install_url="$(beads_rust_install_url)"
+      if curl -fsSL "$br_install_url" | bash -s -- --skip-skills --quiet --no-gum >/dev/null 2>&1; then
         success "br installed"
         third_party_mark_installed "br"
       else
-        warn "br install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
+        warn "br install failed — try: curl -fsSL ${br_install_url} | bash -s -- --skip-skills"
       fi
 
-      if curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash >/dev/null 2>&1; then
+      local bv_install_url
+      bv_install_url="$(beads_viewer_install_url)"
+      if curl -fsSL "$bv_install_url" | bash >/dev/null 2>&1; then
         success "bv installed"
         third_party_mark_installed "bv"
       else
-        warn "bv install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+        warn "bv install failed — try: curl -fsSL ${bv_install_url} | bash"
       fi
     else
       warn "curl not found — skipping br and bv installers"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1285,21 +1285,23 @@ third_party_manifest_has_installed() {
   [[ -f "$manifest_file" ]] || return 1
 
   if command -v node >/dev/null 2>&1; then
-    node -e 'const fs = require("fs"); const [manifestPath, tool] = process.argv.slice(1); const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); process.exit(manifest.features?.[tool]?.installed === true ? 0 : 1)' "$manifest_file" "$tool" >/dev/null 2>&1
-  elif command -v bun >/dev/null 2>&1; then
-    bun -e 'const fs = require("fs"); const [manifestPath, tool] = process.argv.slice(1); const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); process.exit(manifest.features?.[tool]?.installed === true ? 0 : 1)' "$manifest_file" "$tool" >/dev/null 2>&1
-  elif command -v python3 >/dev/null 2>&1; then
-    python3 -c 'import json, sys; data = json.load(open(sys.argv[1])); sys.exit(0 if data.get("features", {}).get(sys.argv[2], {}).get("installed") is True else 1)' "$manifest_file" "$tool" >/dev/null 2>&1
-  elif command -v awk >/dev/null 2>&1; then
+    node -e 'var fs = require("fs"); var manifestPath = process.argv[1]; var tool = process.argv[2]; var manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); var features = manifest.features || {}; process.exit(features[tool] && features[tool].installed === true ? 0 : 1)' "$manifest_file" "$tool" >/dev/null 2>&1 && return 0
+  fi
+  if command -v bun >/dev/null 2>&1; then
+    bun -e 'var fs = require("fs"); var manifestPath = process.argv[1]; var tool = process.argv[2]; var manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); var features = manifest.features || {}; process.exit(features[tool] && features[tool].installed === true ? 0 : 1)' "$manifest_file" "$tool" >/dev/null 2>&1 && return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys; data = json.load(open(sys.argv[1])); sys.exit(0 if data.get("features", {}).get(sys.argv[2], {}).get("installed") is True else 1)' "$manifest_file" "$tool" >/dev/null 2>&1 && return 0
+  fi
+  if command -v awk >/dev/null 2>&1; then
     awk -v tool="$tool" '
       index($0, "\"" tool "\"") && $0 ~ /:[[:space:]]*[{]/ { in_tool = 1 }
       in_tool && $0 ~ /"installed"[[:space:]]*:[[:space:]]*true/ { found = 1 }
       in_tool && $0 ~ /^[[:space:]]*[}][,]?[[:space:]]*$/ { exit }
       END { exit(found ? 0 : 1) }
-    ' "$manifest_file"
-  else
-    return 1
+    ' "$manifest_file" && return 0
   fi
+  return 1
 }
 
 third_party_clear_manifest_features() {
@@ -1308,14 +1310,15 @@ third_party_clear_manifest_features() {
   [[ -f "$manifest_file" ]] || return 0
 
   if command -v node >/dev/null 2>&1; then
-    node -e 'const fs = require("fs"); const manifestPath = process.argv[1]; const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); for (const tool of ["br", "bv", "graphify", "claude-mem"]) { if (manifest.features?.[tool]) manifest.features[tool].installed = false } fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n")' "$manifest_file" >/dev/null 2>&1
-  elif command -v bun >/dev/null 2>&1; then
-    bun -e 'const fs = require("fs"); const manifestPath = process.argv[1]; const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); for (const tool of ["br", "bv", "graphify", "claude-mem"]) { if (manifest.features?.[tool]) manifest.features[tool].installed = false } fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n")' "$manifest_file" >/dev/null 2>&1
-  elif command -v python3 >/dev/null 2>&1; then
-    python3 -c 'import json, sys; path = sys.argv[1]; data = json.load(open(path)); [data.get("features", {}).get(tool, {}).update({"installed": False}) for tool in ("br", "bv", "graphify", "claude-mem") if tool in data.get("features", {})]; open(path, "w").write(json.dumps(data, indent=2) + "\n")' "$manifest_file" >/dev/null 2>&1
-  else
-    return 1
+    node -e 'var fs = require("fs"); var manifestPath = process.argv[1]; var manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); var features = manifest.features || {}; ["br", "bv", "graphify", "claude-mem"].forEach(function (tool) { if (features[tool]) features[tool].installed = false }); fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n")' "$manifest_file" >/dev/null 2>&1 && return 0
   fi
+  if command -v bun >/dev/null 2>&1; then
+    bun -e 'var fs = require("fs"); var manifestPath = process.argv[1]; var manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")); var features = manifest.features || {}; ["br", "bv", "graphify", "claude-mem"].forEach(function (tool) { if (features[tool]) features[tool].installed = false }); fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n")' "$manifest_file" >/dev/null 2>&1 && return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys; path = sys.argv[1]; data = json.load(open(path)); [data.get("features", {}).get(tool, {}).update({"installed": False}) for tool in ("br", "bv", "graphify", "claude-mem") if tool in data.get("features", {})]; open(path, "w").write(json.dumps(data, indent=2) + "\n")' "$manifest_file" >/dev/null 2>&1 && return 0
+  fi
+  return 1
 }
 
 third_party_mark_installed() {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -561,7 +561,16 @@ const FEATURES: FeatureConfig[] = [
       }
       return `claude-mem installed for ${installed.join(", ")}`
     },
-    uninstall: async () => { /* third-party plugin owns its uninstall state */ },
+    uninstall: async () => {
+      if (!commandExists("npx")) {
+        p.log.warn("npx not found — skipping claude-mem uninstall")
+        return
+      }
+      const result = Bun.spawnSync(["npx", "--yes", "claude-mem", "uninstall"], { stdout: "pipe", stderr: "pipe" })
+      if (result.exitCode !== 0) {
+        p.log.warn("claude-mem uninstall failed — try: npx --yes claude-mem uninstall")
+      }
+    },
   },
   {
     id: "supermemory",

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -545,12 +545,19 @@ const FEATURES: FeatureConfig[] = [
       if (!commandExists("npx")) return "npx not found — install manually: npx --yes claude-mem install"
 
       const installed: string[] = []
+      const failed: string[] = []
       for (const target of targets) {
         const result = Bun.spawnSync(target.args, { stdout: "pipe", stderr: "pipe" })
         if (result.exitCode !== 0) {
-          return `claude-mem install failed for ${target.label} — try: ${target.args.join(" ")}`
+          failed.push(`${target.label} (exit ${result.exitCode}; try: ${target.args.join(" ")})`)
+          continue
         }
         installed.push(target.label)
+      }
+      if (failed.length > 0) {
+        return installed.length > 0
+          ? `claude-mem installed for ${installed.join(", ")}; could not install for ${failed.join(", ")}`
+          : `claude-mem install failed for ${failed.join(", ")}`
       }
       return `claude-mem installed for ${installed.join(", ")}`
     },

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -75,6 +75,17 @@ const throwOnSpawnFailure = (result: { exitCode: number, stdout: Uint8Array, std
   throw new Error(`${label}${stderr || stdout ? `: ${stderr || stdout}` : ""}`)
 }
 
+const THIRD_PARTY_SKIP_ENV = "XPOWERS_SKIP_THIRD_PARTY_FEATURES"
+const THIRD_PARTY_FEATURES = new Set(["br", "bv", "graphify", "claude-mem"])
+const HOST_INDEPENDENT_FEATURES = new Set(["tm-cli", ...THIRD_PARTY_FEATURES])
+
+const skipThirdPartyFeatures = () => {
+  const value = process.env[THIRD_PARTY_SKIP_ENV]?.toLowerCase()
+  return value === "1" || value === "true" || value === "yes"
+}
+
+const thirdPartySkipMessage = () => `skipped (${THIRD_PARTY_SKIP_ENV}=1)`
+
 const copyDir = async (src: string, dest: string) => {
   await mkdir(dest, { recursive: true })
   await cp(src, dest, { recursive: true })
@@ -449,6 +460,103 @@ const FEATURES: FeatureConfig[] = [
     },
   },
   {
+    id: "br",
+    name: "Beads Rust (br)",
+    hint: "classic beads-compatible Rust task CLI",
+    install: async () => {
+      if (skipThirdPartyFeatures()) return thirdPartySkipMessage()
+      if (!commandExists("curl")) {
+        return "curl not found — install manually: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
+      }
+      const result = Bun.spawnSync([
+        "bash",
+        "-lc",
+        "curl -fsSL \"https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)\" | bash -s -- --skip-skills --quiet --no-gum",
+      ], { stdout: "pipe", stderr: "pipe" })
+      return result.exitCode === 0
+        ? "br installed"
+        : "br install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
+    },
+    uninstall: async () => {
+      await unlink(join(homedir(), ".local", "bin", "br")).catch(() => {})
+      await unlink(join(homedir(), ".local", "bin", "br.exe")).catch(() => {})
+    },
+  },
+  {
+    id: "bv",
+    name: "Beads Viewer (bv)",
+    hint: "graph-aware Beads TUI and robot-mode triage sidecar",
+    install: async () => {
+      if (skipThirdPartyFeatures()) return thirdPartySkipMessage()
+      if (!commandExists("curl")) {
+        return "curl not found — install manually: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+      }
+      const result = Bun.spawnSync([
+        "bash",
+        "-lc",
+        "curl -fsSL \"https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)\" | bash",
+      ], { stdout: "pipe", stderr: "pipe" })
+      return result.exitCode === 0
+        ? "bv installed"
+        : "bv install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+    },
+    uninstall: async () => {
+      await unlink(join(homedir(), ".local", "bin", "bv")).catch(() => {})
+      await unlink(join(homedir(), ".local", "bin", "bv.exe")).catch(() => {})
+    },
+  },
+  {
+    id: "graphify",
+    name: "graphify knowledge graph",
+    hint: "code/docs/media knowledge graph skill and CLI",
+    install: async () => {
+      if (skipThirdPartyFeatures()) return thirdPartySkipMessage()
+      if (!commandExists("python3")) {
+        return "python3 not found — install manually: python3 -m pip install --user graphifyy && graphify install"
+      }
+      const result = Bun.spawnSync([
+        "bash",
+        "-lc",
+        "python3 -m pip install --user graphifyy --quiet && PATH=\"$HOME/.local/bin:$PATH\" graphify install",
+      ], { stdout: "pipe", stderr: "pipe" })
+      return result.exitCode === 0
+        ? "graphify installed"
+        : "graphify install failed — try: python3 -m pip install --user graphifyy && graphify install"
+    },
+    uninstall: async () => {
+      if (commandExists("python3")) {
+        Bun.spawnSync(["python3", "-m", "pip", "uninstall", "-y", "graphifyy"], { stdout: "pipe", stderr: "pipe" })
+      }
+    },
+  },
+  {
+    id: "claude-mem",
+    name: "Claude-Mem",
+    hint: "persistent memory plugin for Claude Code, OpenCode, and Gemini CLI",
+    install: async (hosts) => {
+      if (skipThirdPartyFeatures()) return thirdPartySkipMessage()
+      if (!commandExists("npx")) return "npx not found — install manually: npx --yes claude-mem install"
+
+      const targets: Array<{ label: string, args: string[] }> = []
+      if (hosts.includes("claude")) targets.push({ label: "Claude Code", args: ["npx", "--yes", "claude-mem", "install"] })
+      if (hosts.includes("opencode")) targets.push({ label: "OpenCode", args: ["npx", "--yes", "claude-mem", "install", "--ide", "opencode"] })
+      if (hosts.includes("gemini")) targets.push({ label: "Gemini CLI", args: ["npx", "--yes", "claude-mem", "install", "--ide", "gemini-cli"] })
+
+      if (targets.length === 0) return "skipped (Claude Code, OpenCode, or Gemini CLI not selected)"
+
+      const installed: string[] = []
+      for (const target of targets) {
+        const result = Bun.spawnSync(target.args, { stdout: "pipe", stderr: "pipe" })
+        if (result.exitCode !== 0) {
+          return `claude-mem install failed for ${target.label} — try: ${target.args.join(" ")}`
+        }
+        installed.push(target.label)
+      }
+      return `claude-mem installed for ${installed.join(", ")}`
+    },
+    uninstall: async () => { /* third-party plugin owns its uninstall state */ },
+  },
+  {
     id: "supermemory",
     name: "supermemory (cloud)",
     hint: "cloud-hosted memory by supermemory.ai — requires API key (free tier available)",
@@ -820,7 +928,7 @@ Options:
   --json, -j         Output structured JSON (implies --yes, for AI agents)
   --uninstall        Remove all installed files and features
   --hosts <list>     Comma-separated host IDs: claude,opencode,kimi,gemini,pi
-  --features <list>  Comma-separated feature IDs: memsearch,supermemory,statusline,routing-wizard,tm-cli
+  --features <list>  Comma-separated feature IDs: memsearch,br,bv,graphify,claude-mem,supermemory,statusline,routing-wizard,tm-cli
   --allow-conflicts  Advanced: continue despite detected hyperpowers/myhyperpowers/superpowers installs
   --help, -h         Show this help
 `)
@@ -895,7 +1003,7 @@ Options:
 
   if (detected.length === 0 && args.hosts.length === 0 && args.features.length === 0) {
     p.log.error("No supported hosts detected. Install Claude Code, OpenCode, or another supported tool first.")
-    p.log.info("You can still install host-independent features: bun scripts/install.ts --features tm-cli")
+    p.log.info("You can still install host-independent features: bun scripts/install.ts --features tm-cli,br,bv,graphify")
     p.outro("Nothing to install.")
     return
   }
@@ -947,7 +1055,7 @@ Options:
 
   // Phase 3: Select features
   const availableFeatures = FEATURES.filter((f) =>
-    f.id === "tm-cli" || selectedHostIds.some((hid) => HOSTS.find((h) => h.id === hid)?.availableFeatures.includes(f.id)),
+    HOST_INDEPENDENT_FEATURES.has(f.id) || selectedHostIds.some((hid) => HOSTS.find((h) => h.id === hid)?.availableFeatures.includes(f.id)),
   )
 
   let selectedFeatureIds: string[]

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -1093,11 +1093,6 @@ Options:
     }
   }
 
-  const selectedThirdPartyFeatureIds = selectedFeatureIds.filter((id) => THIRD_PARTY_FEATURES.has(id))
-  if (selectedThirdPartyFeatureIds.length > 0 && !skipThirdPartyFeatures() && !args.json) {
-    p.log.warn(`Third-party features run upstream installers/packages: ${selectedThirdPartyFeatureIds.join(", ")}`)
-  }
-
   // Phase 4: Install hosts
   const s = p.spinner()
   const existingManifest = await readManifest()
@@ -1109,6 +1104,7 @@ Options:
   }
 
   let hostInstallFailed = false
+  const successfulHostIds: string[] = []
 
   for (const hostId of selectedHostIds) {
     const host = HOSTS.find((h) => h.id === hostId)
@@ -1122,6 +1118,7 @@ Options:
     try {
       const files = await installHost(host)
       manifest.hosts[hostId] = { targetDir: host.targetDir(), files }
+      successfulHostIds.push(hostId)
       s.stop(`${host.name}: ${files.length} items installed`)
     } catch (err) {
       hostInstallFailed = true
@@ -1130,7 +1127,20 @@ Options:
   }
 
   // Phase 5: Install features
-  for (const featureId of selectedFeatureIds) {
+  const featuresWereExplicitlyRequested = args.features.length > 0
+  const shouldInstallFeatures = featuresWereExplicitlyRequested || successfulHostIds.length > 0
+  const featureHostIds = featuresWereExplicitlyRequested ? selectedHostIds : successfulHostIds
+
+  if (!shouldInstallFeatures && selectedFeatureIds.length > 0) {
+    p.log.warn("Skipping default feature setup because no selected hosts installed successfully.")
+  }
+
+  const selectedThirdPartyFeatureIds = selectedFeatureIds.filter((id) => THIRD_PARTY_FEATURES.has(id))
+  if (shouldInstallFeatures && selectedThirdPartyFeatureIds.length > 0 && !skipThirdPartyFeatures() && !args.json) {
+    p.log.warn(`Third-party features run upstream installers/packages: ${selectedThirdPartyFeatureIds.join(", ")}`)
+  }
+
+  for (const featureId of shouldInstallFeatures ? selectedFeatureIds : []) {
     const feature = FEATURES.find((f) => f.id === featureId)
     if (!feature) {
       p.log.warn(`Unknown feature "${featureId}" — skipping. Supported: ${FEATURES.map((f) => f.id).join(", ")}`)
@@ -1138,7 +1148,7 @@ Options:
     }
 
     s.start(`Setting up ${feature.name}...`)
-    const result = await feature.install(selectedHostIds, REPO_ROOT)
+    const result = await feature.install(featureHostIds, REPO_ROOT)
     const success = !result.includes("failed") && !result.includes("not found") && !result.includes("skipped")
     const existingFeature = manifest.features[featureId]
     manifest.features[featureId] = {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -1124,7 +1124,11 @@ Options:
     s.start(`Setting up ${feature.name}...`)
     const result = await feature.install(selectedHostIds, REPO_ROOT)
     const success = !result.includes("failed") && !result.includes("not found") && !result.includes("skipped")
-    manifest.features[featureId] = { installed: success, metadata: { lastResult: result } }
+    const existingFeature = manifest.features[featureId]
+    manifest.features[featureId] = {
+      installed: success || existingFeature?.installed === true,
+      metadata: { ...(existingFeature?.metadata ?? {}), lastResult: result },
+    }
     s.stop(result)
   }
 

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -77,7 +77,7 @@ const throwOnSpawnFailure = (result: { exitCode: number, stdout: Uint8Array, std
 
 const THIRD_PARTY_SKIP_ENV = "XPOWERS_SKIP_THIRD_PARTY_FEATURES"
 const THIRD_PARTY_FEATURES = new Set(["br", "bv", "graphify", "claude-mem"])
-const HOST_INDEPENDENT_FEATURES = new Set(["tm-cli", ...THIRD_PARTY_FEATURES])
+const HOST_INDEPENDENT_FEATURES = new Set(["tm-cli", "br", "bv", "graphify"])
 
 const skipThirdPartyFeatures = () => {
   const value = process.env[THIRD_PARTY_SKIP_ENV]?.toLowerCase()
@@ -165,7 +165,7 @@ const HOSTS: HostConfig[] = [
       commands: { from: "commands" },
       hooks: { from: "hooks" },
     },
-    availableFeatures: ["memsearch", "statusline"],
+    availableFeatures: ["memsearch", "statusline", "claude-mem"],
     postInstall: async (targetDir) => {
       // Copy statusline script
       const src = join(REPO_ROOT, "scripts", "xpowers-statusline.sh")
@@ -186,7 +186,7 @@ const HOSTS: HostConfig[] = [
       plugins: { from: ".opencode/plugins" },
       scripts: { from: ".opencode/scripts" },
     },
-    availableFeatures: ["memsearch", "supermemory", "routing-wizard"],
+    availableFeatures: ["memsearch", "supermemory", "routing-wizard", "claude-mem"],
     postInstall: async (targetDir) => {
       // Copy package.json and run bun install
       const pkgSrc = join(REPO_ROOT, ".opencode", "package.json")
@@ -260,7 +260,7 @@ const HOSTS: HostConfig[] = [
     detect: () => commandExists("gemini"),
     targetDir: () => join(REPO_ROOT, ".gemini-extension"),
     sources: {},
-    availableFeatures: [],
+    availableFeatures: ["claude-mem"],
     postInstall: async () => {
       if (!commandExists("gemini")) {
         throw new Error("gemini CLI not found — cannot install extension")
@@ -535,7 +535,6 @@ const FEATURES: FeatureConfig[] = [
     hint: "persistent memory plugin for Claude Code, OpenCode, and Gemini CLI",
     install: async (hosts) => {
       if (skipThirdPartyFeatures()) return thirdPartySkipMessage()
-      if (!commandExists("npx")) return "npx not found — install manually: npx --yes claude-mem install"
 
       const targets: Array<{ label: string, args: string[] }> = []
       if (hosts.includes("claude")) targets.push({ label: "Claude Code", args: ["npx", "--yes", "claude-mem", "install"] })
@@ -543,6 +542,7 @@ const FEATURES: FeatureConfig[] = [
       if (hosts.includes("gemini")) targets.push({ label: "Gemini CLI", args: ["npx", "--yes", "claude-mem", "install", "--ide", "gemini-cli"] })
 
       if (targets.length === 0) return "skipped (Claude Code, OpenCode, or Gemini CLI not selected)"
+      if (!commandExists("npx")) return "npx not found — install manually: npx --yes claude-mem install"
 
       const installed: string[] = []
       for (const target of targets) {
@@ -1075,6 +1075,11 @@ Options:
     } else {
       selectedFeatureIds = []
     }
+  }
+
+  const selectedThirdPartyFeatureIds = selectedFeatureIds.filter((id) => THIRD_PARTY_FEATURES.has(id))
+  if (selectedThirdPartyFeatureIds.length > 0 && !skipThirdPartyFeatures() && !args.json) {
+    p.log.warn(`Third-party features run upstream installers/packages: ${selectedThirdPartyFeatureIds.join(", ")}`)
   }
 
   // Phase 4: Install hosts

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -493,7 +493,7 @@ const FEATURES: FeatureConfig[] = [
       const result = Bun.spawnSync([
         "bash",
         "-lc",
-        `curl -fsSL ${shellQuote(installUrl)} | bash -s -- --skip-skills --quiet --no-gum`,
+        `set -o pipefail; curl -fsSL ${shellQuote(installUrl)} | bash -s -- --skip-skills --quiet --no-gum`,
       ], { stdout: "pipe", stderr: "pipe" })
       return result.exitCode === 0
         ? "br installed"
@@ -517,7 +517,7 @@ const FEATURES: FeatureConfig[] = [
       const result = Bun.spawnSync([
         "bash",
         "-lc",
-        `curl -fsSL ${shellQuote(installUrl)} | bash`,
+        `set -o pipefail; curl -fsSL ${shellQuote(installUrl)} | bash`,
       ], { stdout: "pipe", stderr: "pipe" })
       return result.exitCode === 0
         ? "bv installed"

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -612,9 +612,9 @@ const FEATURES: FeatureConfig[] = [
         p.log.warn("npx not found — skipping claude-mem uninstall")
         return
       }
-      const result = Bun.spawnSync(["npx", "--yes", "claude-mem", "uninstall"], { stdout: "pipe", stderr: "pipe" })
+      const result = Bun.spawnSync(["npx", "--yes", "claude-mem", "uninstall", "--all"], { stdout: "pipe", stderr: "pipe" })
       if (result.exitCode !== 0) {
-        p.log.warn("claude-mem uninstall failed — try: npx --yes claude-mem uninstall")
+        p.log.warn("claude-mem uninstall failed — try: npx --yes claude-mem uninstall --all")
       }
     },
   },

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -1130,9 +1130,11 @@ Options:
   const featuresWereExplicitlyRequested = args.features.length > 0
   const shouldInstallFeatures = featuresWereExplicitlyRequested || successfulHostIds.length > 0
   const featureHostIds = featuresWereExplicitlyRequested ? selectedHostIds : successfulHostIds
+  const featureResults: Record<string, boolean> = {}
 
   if (!shouldInstallFeatures && selectedFeatureIds.length > 0) {
     p.log.warn("Skipping default feature setup because no selected hosts installed successfully.")
+    for (const featureId of selectedFeatureIds) featureResults[featureId] = false
   }
 
   const selectedThirdPartyFeatureIds = selectedFeatureIds.filter((id) => THIRD_PARTY_FEATURES.has(id))
@@ -1144,12 +1146,14 @@ Options:
     const feature = FEATURES.find((f) => f.id === featureId)
     if (!feature) {
       p.log.warn(`Unknown feature "${featureId}" — skipping. Supported: ${FEATURES.map((f) => f.id).join(", ")}`)
+      featureResults[featureId] = false
       continue
     }
 
     s.start(`Setting up ${feature.name}...`)
     const result = await feature.install(featureHostIds, REPO_ROOT)
     const success = !result.includes("failed") && !result.includes("not found") && !result.includes("skipped")
+    featureResults[featureId] = success
     const existingFeature = manifest.features[featureId]
     manifest.features[featureId] = {
       installed: success || existingFeature?.installed === true,
@@ -1170,6 +1174,7 @@ Options:
       features: Object.fromEntries(
         Object.entries(manifest.features).map(([k, v]) => [k, v.installed]),
       ),
+      featureResults,
       manifestPath: manifestPath(),
     }))
   } else {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -77,7 +77,7 @@ const throwOnSpawnFailure = (result: { exitCode: number, stdout: Uint8Array, std
 
 const THIRD_PARTY_SKIP_ENV = "XPOWERS_SKIP_THIRD_PARTY_FEATURES"
 const THIRD_PARTY_FEATURES = new Set(["br", "bv", "graphify", "claude-mem"])
-const HOST_INDEPENDENT_FEATURES = new Set(["tm-cli", "br", "bv", "graphify"])
+const HOST_INDEPENDENT_FEATURES = new Set(["tm-cli", "br", "bv"])
 
 const skipThirdPartyFeatures = () => {
   const value = process.env[THIRD_PARTY_SKIP_ENV]?.toLowerCase()
@@ -85,6 +85,23 @@ const skipThirdPartyFeatures = () => {
 }
 
 const thirdPartySkipMessage = () => `skipped (${THIRD_PARTY_SKIP_ENV}=1)`
+
+const GRAPHIFY_SUPPORTED_HOSTS = "Claude Code, Codex, OpenCode, Gemini CLI, or Pi Agent"
+const GRAPHIFY_TARGETS = [
+  { hostId: "claude", label: "Claude Code", args: ["graphify", "install"] },
+  { hostId: "codex", label: "Codex", args: ["graphify", "install", "--platform", "codex"] },
+  { hostId: "opencode", label: "OpenCode", args: ["graphify", "install", "--platform", "opencode"] },
+  { hostId: "gemini", label: "Gemini CLI", args: ["graphify", "install", "--platform", "gemini"] },
+  { hostId: "pi", label: "Pi Agent", args: ["graphify", "install", "--platform", "pi"] },
+]
+
+const graphifyTargetsForHosts = (hosts: string[]) => {
+  const selectedHosts = new Set(hosts)
+  return GRAPHIFY_TARGETS.filter((target) => selectedHosts.has(target.hostId))
+}
+
+const shellQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`
+const graphifyCommand = (args: string[]) => args.join(" ")
 
 const copyDir = async (src: string, dest: string) => {
   await mkdir(dest, { recursive: true })
@@ -165,7 +182,7 @@ const HOSTS: HostConfig[] = [
       commands: { from: "commands" },
       hooks: { from: "hooks" },
     },
-    availableFeatures: ["memsearch", "statusline", "claude-mem"],
+    availableFeatures: ["memsearch", "statusline", "graphify", "claude-mem"],
     postInstall: async (targetDir) => {
       // Copy statusline script
       const src = join(REPO_ROOT, "scripts", "xpowers-statusline.sh")
@@ -186,7 +203,7 @@ const HOSTS: HostConfig[] = [
       plugins: { from: ".opencode/plugins" },
       scripts: { from: ".opencode/scripts" },
     },
-    availableFeatures: ["memsearch", "supermemory", "routing-wizard", "claude-mem"],
+    availableFeatures: ["memsearch", "supermemory", "routing-wizard", "graphify", "claude-mem"],
     postInstall: async (targetDir) => {
       // Copy package.json and run bun install
       const pkgSrc = join(REPO_ROOT, ".opencode", "package.json")
@@ -260,7 +277,7 @@ const HOSTS: HostConfig[] = [
     detect: () => commandExists("gemini"),
     targetDir: () => join(REPO_ROOT, ".gemini-extension"),
     sources: {},
-    availableFeatures: ["claude-mem"],
+    availableFeatures: ["graphify", "claude-mem"],
     postInstall: async () => {
       if (!commandExists("gemini")) {
         throw new Error("gemini CLI not found — cannot install extension")
@@ -283,7 +300,7 @@ const HOSTS: HostConfig[] = [
     sources: {
       "extensions/xpowers": { from: ".pi/extensions/xpowers", exclude: ["routing.json"] },
     },
-    availableFeatures: ["memsearch"],
+    availableFeatures: ["memsearch", "graphify"],
     postInstall: async (targetDir) => {
       const extDir = join(targetDir, "extensions", "xpowers")
 
@@ -509,19 +526,42 @@ const FEATURES: FeatureConfig[] = [
     id: "graphify",
     name: "graphify knowledge graph",
     hint: "code/docs/media knowledge graph skill and CLI",
-    install: async () => {
+    install: async (hosts) => {
       if (skipThirdPartyFeatures()) return thirdPartySkipMessage()
+      const targets = graphifyTargetsForHosts(hosts)
+      if (targets.length === 0) return `skipped (${GRAPHIFY_SUPPORTED_HOSTS} not selected)`
       if (!commandExists("python3")) {
-        return "python3 not found — install manually: python3 -m pip install --user graphifyy && graphify install"
+        return `python3 not found — install manually: python3 -m pip install --user graphifyy && ${graphifyCommand(targets[0].args)}`
       }
-      const result = Bun.spawnSync([
-        "bash",
-        "-lc",
-        "python3 -m pip install --user graphifyy --quiet && PATH=\"$HOME/.local/bin:$PATH\" graphify install",
-      ], { stdout: "pipe", stderr: "pipe" })
-      return result.exitCode === 0
-        ? "graphify installed"
-        : "graphify install failed — try: python3 -m pip install --user graphifyy && graphify install"
+      const packageResult = Bun.spawnSync(["python3", "-m", "pip", "install", "--user", "graphifyy", "--quiet"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      if (packageResult.exitCode !== 0) {
+        return "graphify package install failed — try: python3 -m pip install --user graphifyy"
+      }
+
+      const installed: string[] = []
+      const failed: string[] = []
+      for (const target of targets) {
+        const result = Bun.spawnSync([
+          "bash",
+          "-lc",
+          `PATH="$HOME/.local/bin:$PATH" ${target.args.map(shellQuote).join(" ")}`,
+        ], { stdout: "pipe", stderr: "pipe" })
+        if (result.exitCode !== 0) {
+          failed.push(`${target.label} (exit ${result.exitCode}; try: ${graphifyCommand(target.args)})`)
+          continue
+        }
+        installed.push(target.label)
+      }
+
+      if (failed.length > 0) {
+        return installed.length > 0
+          ? `graphify installed for ${installed.join(", ")}; could not install for ${failed.join(", ")}`
+          : `graphify install failed for ${failed.join(", ")}`
+      }
+      return `graphify installed for ${installed.join(", ")}`
     },
     uninstall: async () => {
       if (commandExists("python3")) {
@@ -1019,7 +1059,7 @@ Options:
 
   if (detected.length === 0 && args.hosts.length === 0 && args.features.length === 0) {
     p.log.error("No supported hosts detected. Install Claude Code, OpenCode, or another supported tool first.")
-    p.log.info("You can still install host-independent features: bun scripts/install.ts --features tm-cli,br,bv,graphify")
+    p.log.info("You can still install host-independent features: bun scripts/install.ts --features tm-cli,br,bv")
     p.outro("Nothing to install.")
     return
   }

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -78,6 +78,8 @@ const throwOnSpawnFailure = (result: { exitCode: number, stdout: Uint8Array, std
 const THIRD_PARTY_SKIP_ENV = "XPOWERS_SKIP_THIRD_PARTY_FEATURES"
 const THIRD_PARTY_FEATURES = new Set(["br", "bv", "graphify", "claude-mem"])
 const HOST_INDEPENDENT_FEATURES = new Set(["tm-cli", "br", "bv"])
+const BEADS_RUST_INSTALL_REF = process.env.XPOWERS_BEADS_RUST_INSTALL_REF || "f4687e51a5aa155fe27cb8ea6d7fdae942b0154f"
+const BEADS_VIEWER_INSTALL_REF = process.env.XPOWERS_BEADS_VIEWER_INSTALL_REF || "bb977f5b812b2987d77544872287b502b5b3a444"
 
 const skipThirdPartyFeatures = () => {
   const value = process.env[THIRD_PARTY_SKIP_ENV]?.toLowerCase()
@@ -102,6 +104,8 @@ const graphifyTargetsForHosts = (hosts: string[]) => {
 
 const shellQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`
 const graphifyCommand = (args: string[]) => args.join(" ")
+const beadsRustInstallUrl = () => `https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/${BEADS_RUST_INSTALL_REF}/install.sh`
+const beadsViewerInstallUrl = () => `https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/${BEADS_VIEWER_INSTALL_REF}/install.sh`
 
 const copyDir = async (src: string, dest: string) => {
   await mkdir(dest, { recursive: true })
@@ -482,17 +486,18 @@ const FEATURES: FeatureConfig[] = [
     hint: "classic beads-compatible Rust task CLI",
     install: async () => {
       if (skipThirdPartyFeatures()) return thirdPartySkipMessage()
+      const installUrl = beadsRustInstallUrl()
       if (!commandExists("curl")) {
-        return "curl not found — install manually: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
+        return `curl not found — install manually: curl -fsSL ${installUrl} | bash -s -- --skip-skills`
       }
       const result = Bun.spawnSync([
         "bash",
         "-lc",
-        "curl -fsSL \"https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)\" | bash -s -- --skip-skills --quiet --no-gum",
+        `curl -fsSL ${shellQuote(installUrl)} | bash -s -- --skip-skills --quiet --no-gum`,
       ], { stdout: "pipe", stderr: "pipe" })
       return result.exitCode === 0
         ? "br installed"
-        : "br install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash -s -- --skip-skills"
+        : `br install failed — try: curl -fsSL ${installUrl} | bash -s -- --skip-skills`
     },
     uninstall: async () => {
       await unlink(join(homedir(), ".local", "bin", "br")).catch(() => {})
@@ -505,17 +510,18 @@ const FEATURES: FeatureConfig[] = [
     hint: "graph-aware Beads TUI and robot-mode triage sidecar",
     install: async () => {
       if (skipThirdPartyFeatures()) return thirdPartySkipMessage()
+      const installUrl = beadsViewerInstallUrl()
       if (!commandExists("curl")) {
-        return "curl not found — install manually: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+        return `curl not found — install manually: curl -fsSL ${installUrl} | bash`
       }
       const result = Bun.spawnSync([
         "bash",
         "-lc",
-        "curl -fsSL \"https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)\" | bash",
+        `curl -fsSL ${shellQuote(installUrl)} | bash`,
       ], { stdout: "pipe", stderr: "pipe" })
       return result.exitCode === 0
         ? "bv installed"
-        : "bv install failed — try: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+        : `bv install failed — try: curl -fsSL ${installUrl} | bash`
     },
     uninstall: async () => {
       await unlink(join(homedir(), ".local", "bin", "bv")).catch(() => {})

--- a/tests/execute-ralph-host-parity.test.js
+++ b/tests/execute-ralph-host-parity.test.js
@@ -49,6 +49,26 @@ function createFakePiShim(binDir) {
   fs.chmodSync(piPath, 0o755)
 }
 
+function removeWritableTree(targetPath) {
+  if (!fs.existsSync(targetPath)) return
+
+  const makeWritable = (entryPath) => {
+    const stat = fs.lstatSync(entryPath)
+    if (stat.isSymbolicLink()) return
+    if (stat.isDirectory()) {
+      for (const child of fs.readdirSync(entryPath)) {
+        makeWritable(path.join(entryPath, child))
+      }
+      fs.chmodSync(entryPath, 0o700)
+      return
+    }
+    fs.chmodSync(entryPath, 0o600)
+  }
+
+  makeWritable(targetPath)
+  fs.rmSync(targetPath, { recursive: true, force: true })
+}
+
 test("Claude and OpenCode execute-ralph command wrappers stay aligned to the same contract clauses", () => {
   const files = [
     ["Claude canonical wrapper", "commands/execute-ralph.md"],
@@ -125,7 +145,7 @@ test("Pi installed runtime resolves execute-ralph through the canonical command 
     assertContainsAll(output, REQUIRED_COMMAND_CLAUSES, "Pi installed execute-ralph output")
     assert.equal(output.includes("Pi invocation arguments: --reviewer-model=sonnet"), true)
   } finally {
-    fs.rmSync(home, { recursive: true, force: true })
-    fs.rmSync(binDir, { recursive: true, force: true })
+    removeWritableTree(home)
+    removeWritableTree(binDir)
   }
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -139,7 +139,7 @@ test("install.sh --hosts pi delegates through the Bun installer entrypoint", { t
   )
   fs.chmodSync(bunShim, 0o755)
 
-  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "pi", "--yes", "--allow-conflicts"], {
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "pi", "--allow-conflicts"], {
     cwd: repoRoot,
     encoding: "utf8",
     env: installEnv(home, {
@@ -155,7 +155,6 @@ test("install.sh --hosts pi delegates through the Bun installer entrypoint", { t
     "scripts/install.ts",
     "--hosts",
     "pi",
-    "--yes",
     "--allow-conflicts",
   ])
   assert.doesNotMatch(output, /setup-pi\.sh/)
@@ -304,6 +303,37 @@ test("install.sh mixed claude+pi install retries host-independent tools when Pi 
   assert.equal(
     fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"),
     "br\nbv\ngraphify\nclaude-mem\n",
+  )
+
+  fs.rmSync(binDir, { recursive: true, force: true })
+})
+
+test("install.sh pi-only install records delegated third-party ownership", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-pi-only-third-party-state-home-"))
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-pi-only-third-party-state-bin-"))
+
+  fs.writeFileSync(
+    path.join(binDir, "bun"),
+    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":true}}'\nexit 0\n",
+    "utf8",
+  )
+  fs.chmodSync(path.join(binDir, "bun"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "pi", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(
+    fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"),
+    "br\nbv\ngraphify\n",
   )
 
   fs.rmSync(binDir, { recursive: true, force: true })
@@ -586,7 +616,7 @@ test("install.sh uninstall removes tracked third-party tools", { timeout: 120000
     cwd: repoRoot,
     encoding: "utf8",
     env: installEnv(home, {
-      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      PATH: `${tmpBinDir}${path.delimiter}/usr/bin:/bin`,
       PIP_LOG: pipLog,
       NPX_LOG: npxLog,
     }),
@@ -625,7 +655,7 @@ test("install.sh dry-run uninstall preserves tracked third-party tools", { timeo
     cwd: repoRoot,
     encoding: "utf8",
     env: installEnv(home, {
-      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      PATH: `${tmpBinDir}${path.delimiter}/usr/bin:/bin`,
       PIP_LOG: pipLog,
       NPX_LOG: npxLog,
     }),
@@ -640,6 +670,47 @@ test("install.sh dry-run uninstall preserves tracked third-party tools", { timeo
   assert.equal(fs.existsSync(pipLog), false)
   assert.equal(fs.existsSync(npxLog), false)
   assert.equal(fs.existsSync(path.join(home, ".xpowers", "third-party-tools")), true)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh partial uninstall preserves tracked third-party tools", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-partial-uninstall-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-partial-uninstall-bin-"))
+  const pipLog = path.join(home, "pip-uninstall")
+  const npxLog = path.join(home, "npx-uninstall")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".codex"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".local", "bin"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", ".xpowers-manifest"), "# .xpowers-manifest\n", "utf8")
+  fs.writeFileSync(path.join(home, ".codex", ".xpowers-manifest"), "# .xpowers-manifest\n", "utf8")
+  fs.writeFileSync(path.join(home, ".xpowers", "third-party-tools"), "br\nbv\ngraphify\nclaude-mem\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "br"), "br\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "bv"), "bv\n", "utf8")
+  fs.writeFileSync(path.join(tmpBinDir, "python3"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$PIP_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}/usr/bin:/bin`,
+      PIP_LOG: pipLog,
+      NPX_LOG: npxLog,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), true)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), true)
+  assert.equal(fs.existsSync(pipLog), false)
+  assert.equal(fs.existsSync(npxLog), false)
+  assert.equal(fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"), "br\nbv\ngraphify\nclaude-mem\n")
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -319,6 +319,40 @@ test("bun installer reports claude-mem skipped before requiring npx for unsuppor
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("bun installer preserves installed state when third-party features are skipped", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-third-party-preserve-"))
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.writeFileSync(
+    path.join(home, ".xpowers", "manifest.json"),
+    JSON.stringify({
+      version: "test",
+      installedAt: "2026-05-04T00:00:00.000Z",
+      hosts: {},
+      features: {
+        br: { installed: true, metadata: { lastResult: "br installed" } },
+      },
+    }) + "\n",
+    "utf8",
+  )
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "claude", "--features", "br", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const payload = JSON.parse(result.stdout.trim())
+  assert.equal(payload.features.br, true)
+  const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
+  assert.equal(manifest.features.br.installed, true)
+  assert.equal(manifest.features.br.metadata.lastResult, "skipped (XPOWERS_SKIP_THIRD_PARTY_FEATURES=1)")
+})
+
 test("install.sh skips third-party tool bundle when requested by environment", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-skip-"))
   fs.mkdirSync(path.join(home, ".claude"), { recursive: true })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -155,6 +155,8 @@ test("install.sh --hosts pi delegates through the Bun installer entrypoint", { t
     "scripts/install.ts",
     "--hosts",
     "pi",
+    "--features",
+    "tm-cli",
     "--allow-conflicts",
   ])
   assert.doesNotMatch(output, /setup-pi\.sh/)
@@ -630,6 +632,36 @@ test("install.sh uninstall removes tracked third-party tools", { timeout: 120000
   assert.match(fs.readFileSync(pipLog, "utf8"), /pip uninstall -y graphifyy/)
   assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall/)
   assert.equal(fs.existsSync(path.join(home, ".xpowers", "third-party-tools")), false)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh uninstall preserves third-party state when cleanup fails", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-uninstall-fail-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-uninstall-fail-bin-"))
+  const pipLog = path.join(home, "pip-uninstall")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", ".xpowers-manifest"), "# .xpowers-manifest\n", "utf8")
+  fs.writeFileSync(path.join(home, ".xpowers", "third-party-tools"), "graphify\n", "utf8")
+  fs.writeFileSync(path.join(tmpBinDir, "python3"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$PIP_LOG\"\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}/usr/bin:/bin`,
+      PIP_LOG: pipLog,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.match(fs.readFileSync(pipLog, "utf8"), /pip uninstall -y graphifyy/)
+  assert.equal(fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"), "graphify\n")
+  assert.match(output, /Keeping third-party state file for retry/)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -193,6 +193,54 @@ test("install.sh mixed claude+pi install reports both agents in summary", { time
   assert.match(output, /Pi Agent/)
 })
 
+test("install.sh mixed claude+pi install does not replay host-independent third-party tools", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-mixed-pi-third-party-home-"))
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-mixed-pi-third-party-bin-"))
+  const hostIndependentMarker = path.join(home, "host-independent-third-party-called")
+  const npxMarker = path.join(home, "npx-called")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+
+  fs.writeFileSync(path.join(binDir, "bun"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(binDir, "bun"), 0o755)
+
+  fs.writeFileSync(path.join(binDir, "curl"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$0 $*\" >> \"$HOST_INDEPENDENT_MARKER\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(binDir, "curl"), 0o755)
+  fs.writeFileSync(
+    path.join(binDir, "python3"),
+    [
+      "#!/usr/bin/env bash",
+      "case \"$*\" in",
+      "  *'pip install --user graphifyy'*) printf '%s\\n' \"$0 $*\" >> \"$HOST_INDEPENDENT_MARKER\" ;;",
+      "esac",
+      "exit 0",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  fs.chmodSync(path.join(binDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(binDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_MARKER\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(binDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude,pi", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      HOST_INDEPENDENT_MARKER: hostIndependentMarker,
+      NPX_MARKER: npxMarker,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(fs.existsSync(hostIndependentMarker), false, "Pi delegation should own br/bv/graphify for mixed installs")
+  assert.match(fs.readFileSync(npxMarker, "utf8"), /claude-mem install/)
+
+  fs.rmSync(binDir, { recursive: true, force: true })
+})
+
 test("install.sh --all detects Pi when pi executable is in PATH even without ~/.pi", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-pi-detect-exec-home-"))
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-pi-detect-exec-bin-"))
@@ -315,6 +363,51 @@ test("bun installer reports claude-mem skipped before requiring npx for unsuppor
   assert.equal(result.status, 0, output)
   const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
   assert.equal(manifest.features["claude-mem"].metadata.lastResult, "skipped (Claude Code, OpenCode, or Gemini CLI not selected)")
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("bun installer attempts all claude-mem targets before reporting failures", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-claude-mem-all-targets-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-claude-mem-all-targets-bin-"))
+  const npxLog = path.join(home, "npx-calls")
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.writeFileSync(
+    path.join(tmpBinDir, "npx"),
+    [
+      "#!/usr/bin/env bash",
+      "printf '%s\\n' \"$*\" >> \"$NPX_LOG\"",
+      "case \"$*\" in",
+      "  *'--ide opencode'*) exit 0 ;;",
+      "  *) exit 7 ;;",
+      "esac",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "claude,opencode", "--features", "claude-mem", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      NPX_LOG: npxLog,
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const calls = fs.readFileSync(npxLog, "utf8").trim().split("\n")
+  assert.equal(calls.length, 2)
+  assert.match(calls[0], /claude-mem install$/)
+  assert.match(calls[1], /claude-mem install --ide opencode$/)
+  const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
+  assert.match(manifest.features["claude-mem"].metadata.lastResult, /installed for OpenCode/)
+  assert.match(manifest.features["claude-mem"].metadata.lastResult, /Claude Code/)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -200,7 +200,11 @@ test("install.sh mixed claude+pi install does not replay host-independent third-
   const npxMarker = path.join(home, "npx-called")
   fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
 
-  fs.writeFileSync(path.join(binDir, "bun"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.writeFileSync(
+    path.join(binDir, "bun"),
+    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":true}}'\nexit 0\n",
+    "utf8",
+  )
   fs.chmodSync(path.join(binDir, "bun"), 0o755)
 
   fs.writeFileSync(path.join(binDir, "curl"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$0 $*\" >> \"$HOST_INDEPENDENT_MARKER\"\nexit 0\n", "utf8")
@@ -237,6 +241,70 @@ test("install.sh mixed claude+pi install does not replay host-independent third-
   assert.equal(result.status, 0, output)
   assert.equal(fs.existsSync(hostIndependentMarker), false, "Pi delegation should own br/bv/graphify for mixed installs")
   assert.match(fs.readFileSync(npxMarker, "utf8"), /claude-mem install/)
+  assert.equal(
+    fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"),
+    "br\nbv\ngraphify\nclaude-mem\n",
+  )
+
+  fs.rmSync(binDir, { recursive: true, force: true })
+})
+
+test("install.sh mixed claude+pi install retries host-independent tools when Pi features fail", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-mixed-pi-third-party-retry-home-"))
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-mixed-pi-third-party-retry-bin-"))
+  const hostIndependentMarker = path.join(home, "host-independent-third-party-called")
+  const npxMarker = path.join(home, "npx-called")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+
+  fs.writeFileSync(
+    path.join(binDir, "bun"),
+    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":false,\"bv\":false,\"graphify\":false}}'\nexit 0\n",
+    "utf8",
+  )
+  fs.chmodSync(path.join(binDir, "bun"), 0o755)
+  fs.writeFileSync(path.join(binDir, "curl"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$0 $*\" >> \"$HOST_INDEPENDENT_MARKER\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(binDir, "curl"), 0o755)
+  fs.writeFileSync(
+    path.join(binDir, "python3"),
+    [
+      "#!/usr/bin/env bash",
+      "case \"$*\" in",
+      "  *'pip install --user graphifyy'*) printf '%s\\n' \"$0 $*\" >> \"$HOST_INDEPENDENT_MARKER\" ;;",
+      "esac",
+      "exit 0",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  fs.chmodSync(path.join(binDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(binDir, "graphify"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(binDir, "graphify"), 0o755)
+  fs.writeFileSync(path.join(binDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_MARKER\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(binDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude,pi", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      HOST_INDEPENDENT_MARKER: hostIndependentMarker,
+      NPX_MARKER: npxMarker,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const hostIndependentCalls = fs.readFileSync(hostIndependentMarker, "utf8")
+  assert.match(hostIndependentCalls, /beads_rust/)
+  assert.match(hostIndependentCalls, /beads_viewer/)
+  assert.match(hostIndependentCalls, /graphifyy/)
+  assert.match(fs.readFileSync(npxMarker, "utf8"), /claude-mem install/)
+  assert.equal(
+    fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"),
+    "br\nbv\ngraphify\nclaude-mem\n",
+  )
 
   fs.rmSync(binDir, { recursive: true, force: true })
 })
@@ -493,6 +561,45 @@ test("install.sh does not run third-party tool bundle without --yes", { timeout:
   const output = combinedOutput(result)
   assert.equal(result.status, 0, output)
   assert.equal(fs.existsSync(markerPath), false, "third-party installer shims should not run without --yes")
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh uninstall removes tracked third-party tools", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-uninstall-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-uninstall-bin-"))
+  const pipLog = path.join(home, "pip-uninstall")
+  const npxLog = path.join(home, "npx-uninstall")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".local", "bin"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", ".xpowers-manifest"), "# .xpowers-manifest\n", "utf8")
+  fs.writeFileSync(path.join(home, ".xpowers", "third-party-tools"), "br\nbv\ngraphify\nclaude-mem\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "br"), "br\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "bv"), "bv\n", "utf8")
+  fs.writeFileSync(path.join(tmpBinDir, "python3"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$PIP_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      PIP_LOG: pipLog,
+      NPX_LOG: npxLog,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), false)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), false)
+  assert.match(fs.readFileSync(pipLog, "utf8"), /pip uninstall -y graphifyy/)
+  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall/)
+  assert.equal(fs.existsSync(path.join(home, ".xpowers", "third-party-tools")), false)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -488,6 +488,45 @@ test("bun installer omits claude-mem for unsupported hosts by default", { timeou
   assert.equal(Object.hasOwn(payload.features, "claude-mem"), false, "claude-mem should not be selected for Kimi-only installs")
 })
 
+test("bun installer skips default features when selected hosts are invalid", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-invalid-host-default-features-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-invalid-host-default-features-bin-"))
+  const markerPath = path.join(home, "feature-tool-called")
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+
+  for (const name of ["curl", "python3", "npx", "npm"]) {
+    fs.writeFileSync(
+      path.join(tmpBinDir, name),
+      "#!/usr/bin/env bash\nprintf '%s\\n' \"${0##*/} $*\" >> \"$FEATURE_TOOL_MARKER\"\nexit 0\n",
+      "utf8",
+    )
+    fs.chmodSync(path.join(tmpBinDir, name), 0o755)
+  }
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "not-a-host", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      FEATURE_TOOL_MARKER: markerPath,
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 1, output)
+  const payload = JSON.parse(result.stdout.trim())
+  assert.equal(payload.ok, false)
+  assert.deepEqual(payload.hosts, [])
+  assert.deepEqual(payload.features, {})
+  assert.equal(fs.existsSync(markerPath), false, "default feature installers should not run after invalid host selection")
+  const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
+  assert.deepEqual(manifest.features, {})
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("bun installer reports claude-mem skipped before requiring npx for unsupported hosts", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-claude-mem-skip-"))
   const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-claude-mem-skip-bin-"))

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -265,7 +265,7 @@ test("bun installer --yes includes third-party tool features by default", { time
   const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "claude", "--yes", "--json", "--allow-conflicts"], {
     cwd: repoRoot,
     encoding: "utf8",
-    env: installEnv(home, { PATH: tmpBinDir }),
+    env: installEnv(home, { PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}` }),
     timeout: 120000,
   })
 
@@ -275,6 +275,46 @@ test("bun installer --yes includes third-party tool features by default", { time
   for (const feature of ["br", "bv", "graphify", "claude-mem"]) {
     assert.equal(Object.hasOwn(payload.features, feature), true, `${feature} should be part of the default feature set`)
   }
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("bun installer omits claude-mem for unsupported hosts by default", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-unsupported-claude-mem-"))
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".config", "agents"), { recursive: true })
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "kimi", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const payload = JSON.parse(result.stdout.trim())
+  assert.equal(Object.hasOwn(payload.features, "claude-mem"), false, "claude-mem should not be selected for Kimi-only installs")
+})
+
+test("bun installer reports claude-mem skipped before requiring npx for unsupported hosts", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-claude-mem-skip-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-claude-mem-skip-bin-"))
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".config", "agents"), { recursive: true })
+  fs.symlinkSync("/bin/bash", path.join(tmpBinDir, "bash"))
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "kimi", "--features", "claude-mem", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, { PATH: tmpBinDir, XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0" }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
+  assert.equal(manifest.features["claude-mem"].metadata.lastResult, "skipped (Claude Code, OpenCode, or Gemini CLI not selected)")
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
@@ -293,6 +333,41 @@ test("install.sh skips third-party tool bundle when requested by environment", {
   const output = combinedOutput(result)
   assert.equal(result.status, 0, output)
   assert.match(output, /Skipping third-party tool bundle/)
+})
+
+test("install.sh does not run third-party tool bundle without --yes", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-no-force-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-no-force-bin-"))
+  const markerPath = path.join(home, "third-party-called")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", "settings.json"), JSON.stringify({ statusline: "existing" }) + "\n", "utf8")
+  for (const name of ["curl", "npx"]) {
+    fs.writeFileSync(
+      path.join(tmpBinDir, name),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$0 $*" >> "$THIRD_PARTY_MARKER"\nexit 0\n`,
+      "utf8",
+    )
+    fs.chmodSync(path.join(tmpBinDir, name), 0o755)
+  }
+  fs.writeFileSync(path.join(tmpBinDir, "python3"), "#!/usr/bin/env bash\nexit 1\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--claude", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      THIRD_PARTY_MARKER: markerPath,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(fs.existsSync(markerPath), false, "third-party installer shims should not run without --yes")
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
 test("bun installer fails fast on legacy package conflicts unless explicitly overridden", { timeout: 120000 }, () => {

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -310,6 +310,49 @@ test("install.sh mixed claude+pi install retries host-independent tools when Pi 
   fs.rmSync(binDir, { recursive: true, force: true })
 })
 
+test("install.sh mixed claude+pi install records partial Pi third-party success before retry", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-mixed-pi-third-party-partial-home-"))
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-mixed-pi-third-party-partial-bin-"))
+  const npxMarker = path.join(home, "npx-called")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+
+  fs.writeFileSync(
+    path.join(binDir, "bun"),
+    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":false}}'\nexit 0\n",
+    "utf8",
+  )
+  fs.chmodSync(path.join(binDir, "bun"), 0o755)
+  fs.writeFileSync(path.join(binDir, "curl"), "#!/usr/bin/env bash\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(binDir, "curl"), 0o755)
+  fs.writeFileSync(path.join(binDir, "python3"), "#!/usr/bin/env bash\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(binDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(binDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_MARKER\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(binDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude,pi", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      NPX_MARKER: npxMarker,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.match(output, /br install failed/)
+  assert.match(output, /bv install failed/)
+  assert.equal(
+    fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"),
+    "br\nbv\nclaude-mem\n",
+  )
+  assert.match(fs.readFileSync(npxMarker, "utf8"), /claude-mem install/)
+
+  fs.rmSync(binDir, { recursive: true, force: true })
+})
+
 test("install.sh pi-only install records delegated third-party ownership", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-pi-only-third-party-state-home-"))
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-pi-only-third-party-state-bin-"))

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -42,6 +42,7 @@ function installEnv(home, extra = {}) {
     HOME: home,
     XDG_CONFIG_HOME: path.join(home, ".config"),
     NO_COLOR: "1",
+    XPOWERS_SKIP_THIRD_PARTY_FEATURES: "1",
     ...extra,
   }
 }
@@ -253,6 +254,45 @@ test("install.sh deduplicates duplicate --hosts entries", { timeout: 120000 }, (
   // Should only mention one Claude Code install, not two
   const matches = output.match(/Would install to Claude Code/g)
   assert.equal(matches ? matches.length : 0, 1, `Expected exactly one Claude mention, got: ${output}`)
+})
+
+test("bun installer --yes includes third-party tool features by default", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-third-party-features-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-third-party-bin-"))
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "claude", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, { PATH: tmpBinDir }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const payload = JSON.parse(result.stdout.trim())
+  for (const feature of ["br", "bv", "graphify", "claude-mem"]) {
+    assert.equal(Object.hasOwn(payload.features, feature), true, `${feature} should be part of the default feature set`)
+  }
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh skips third-party tool bundle when requested by environment", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-skip-"))
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--claude", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.match(output, /Skipping third-party tool bundle/)
 })
 
 test("bun installer fails fast on legacy package conflicts unless explicitly overridden", { timeout: 120000 }, () => {

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -604,6 +604,46 @@ test("install.sh uninstall removes tracked third-party tools", { timeout: 120000
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("install.sh dry-run uninstall preserves tracked third-party tools", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-dry-run-uninstall-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-dry-run-uninstall-bin-"))
+  const pipLog = path.join(home, "pip-uninstall")
+  const npxLog = path.join(home, "npx-uninstall")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".local", "bin"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", ".xpowers-manifest"), "# .xpowers-manifest\n", "utf8")
+  fs.writeFileSync(path.join(home, ".xpowers", "third-party-tools"), "br\nbv\ngraphify\nclaude-mem\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "br"), "br\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "bv"), "bv\n", "utf8")
+  fs.writeFileSync(path.join(tmpBinDir, "python3"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$PIP_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--uninstall", "--dry-run", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      PIP_LOG: pipLog,
+      NPX_LOG: npxLog,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.match(output, /Would remove tracked third-party tool bundle/)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), true)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), true)
+  assert.equal(fs.existsSync(pipLog), false)
+  assert.equal(fs.existsSync(npxLog), false)
+  assert.equal(fs.existsSync(path.join(home, ".xpowers", "third-party-tools")), true)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("bun installer fails fast on legacy package conflicts unless explicitly overridden", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-conflict-test-"))
   fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
@@ -918,6 +958,43 @@ test("bun installer uninstall reads legacy manifest location", { timeout: 60000 
   assert.equal(result.status, 0, result.stderr || result.stdout)
   assert.equal(fs.existsSync(legacyFile), false)
   assert.equal(fs.existsSync(path.join(legacyManifestDir, "manifest.json")), false)
+})
+
+test("bun installer uninstall runs claude-mem cleanup", { timeout: 60000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-claude-mem-uninstall-test-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-claude-mem-uninstall-bin-"))
+  const manifestDir = path.join(home, ".xpowers")
+  const npxLog = path.join(home, "npx-uninstall")
+
+  fs.mkdirSync(manifestDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(manifestDir, "manifest.json"),
+    JSON.stringify({
+      version: "test",
+      installedAt: "2026-01-01T00:00:00Z",
+      hosts: {},
+      features: { "claude-mem": { installed: true } },
+    }, null, 2) + "\n",
+    "utf8",
+  )
+  fs.writeFileSync(path.join(tmpBinDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+
+  const result = spawnSync("bun", ["scripts/install.ts", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      NPX_LOG: npxLog,
+    }),
+    timeout: 120000,
+  })
+
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall/)
+  assert.equal(fs.existsSync(path.join(manifestDir, "manifest.json")), false)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
 test("bun installer statusline uninstall removes legacy statusline path", { timeout: 60000 }, () => {

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -1047,7 +1047,7 @@ test("install.sh uninstall removes tracked third-party tools", { timeout: 120000
   assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), false)
   assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), false)
   assert.match(fs.readFileSync(pipLog, "utf8"), /pip uninstall -y graphifyy/)
-  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall/)
+  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall --all/)
   assert.equal(fs.existsSync(path.join(home, ".xpowers", "third-party-tools")), false)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
@@ -1101,7 +1101,7 @@ test("install.sh uninstall removes manifest-only third-party tools", { timeout: 
   assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), false)
   assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), false)
   assert.match(fs.readFileSync(pipLog, "utf8"), /pip uninstall -y graphifyy/)
-  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall/)
+  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall --all/)
   assert.equal(fs.existsSync(path.join(home, ".xpowers", "third-party-tools")), false)
   const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
   assert.equal(manifest.features.br.installed, false)
@@ -1723,7 +1723,7 @@ test("bun installer uninstall runs claude-mem cleanup", { timeout: 60000 }, () =
   })
 
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall/)
+  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall --all/)
   assert.equal(fs.existsSync(path.join(manifestDir, "manifest.json")), false)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -536,6 +536,35 @@ test("bun installer pins br and bv upstream installer refs by default", { timeou
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("bun installer treats failed br and bv downloads as feature failures", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-third-party-pipefail-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-third-party-pipefail-bin-"))
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.writeFileSync(path.join(tmpBinDir, "curl"), "#!/usr/bin/env bash\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "curl"), 0o755)
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "claude", "--features", "br,bv", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const payload = JSON.parse(result.stdout.trim())
+  assert.equal(payload.featureResults.br, false)
+  assert.equal(payload.featureResults.bv, false)
+  assert.equal(payload.features.br, false)
+  assert.equal(payload.features.bv, false)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("bun installer omits claude-mem for unsupported hosts by default", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-unsupported-claude-mem-"))
   const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -203,7 +203,7 @@ test("install.sh mixed claude+pi install does not replay host-independent third-
 
   fs.writeFileSync(
     path.join(binDir, "bun"),
-    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":true}}'\nexit 0\n",
+    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":true},\"featureResults\":{\"br\":true,\"bv\":true,\"graphify\":true}}'\nexit 0\n",
     "utf8",
   )
   fs.chmodSync(path.join(binDir, "bun"), 0o755)
@@ -259,7 +259,7 @@ test("install.sh mixed claude+pi install retries host-independent tools when Pi 
 
   fs.writeFileSync(
     path.join(binDir, "bun"),
-    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":false,\"bv\":false,\"graphify\":false}}'\nexit 0\n",
+    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":true},\"featureResults\":{\"br\":false,\"bv\":false,\"graphify\":false}}'\nexit 0\n",
     "utf8",
   )
   fs.chmodSync(path.join(binDir, "bun"), 0o755)
@@ -318,7 +318,7 @@ test("install.sh mixed claude+pi install records partial Pi third-party success 
 
   fs.writeFileSync(
     path.join(binDir, "bun"),
-    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":false}}'\nexit 0\n",
+    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":true},\"featureResults\":{\"br\":true,\"bv\":true,\"graphify\":false}}'\nexit 0\n",
     "utf8",
   )
   fs.chmodSync(path.join(binDir, "bun"), 0o755)
@@ -359,7 +359,7 @@ test("install.sh pi-only install records delegated third-party ownership", { tim
 
   fs.writeFileSync(
     path.join(binDir, "bun"),
-    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":true}}'\nexit 0\n",
+    "#!/usr/bin/env bash\nprintf '%s\\n' '{\"features\":{\"br\":true,\"bv\":true,\"graphify\":true},\"featureResults\":{\"br\":true,\"bv\":true,\"graphify\":true}}'\nexit 0\n",
     "utf8",
   )
   fs.chmodSync(path.join(binDir, "bun"), 0o755)
@@ -623,6 +623,7 @@ test("bun installer preserves installed state when third-party features are skip
   assert.equal(result.status, 0, output)
   const payload = JSON.parse(result.stdout.trim())
   assert.equal(payload.features.br, true)
+  assert.equal(payload.featureResults.br, false)
   const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
   assert.equal(manifest.features.br.installed, true)
   assert.equal(manifest.features.br.metadata.lastResult, "skipped (XPOWERS_SKIP_THIRD_PARTY_FEATURES=1)")

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -506,6 +506,36 @@ test("bun installer --yes includes third-party tool features by default", { time
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("bun installer pins br and bv upstream installer refs by default", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-pinned-third-party-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-pinned-third-party-bin-"))
+  const curlLog = path.join(home, "curl-calls")
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.writeFileSync(path.join(tmpBinDir, "curl"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$CURL_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "curl"), 0o755)
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "claude", "--features", "br,bv", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      CURL_LOG: curlLog,
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const curlCalls = fs.readFileSync(curlLog, "utf8")
+  assert.match(curlCalls, /beads_rust\/f4687e51a5aa155fe27cb8ea6d7fdae942b0154f\/install\.sh/)
+  assert.match(curlCalls, /beads_viewer\/bb977f5b812b2987d77544872287b502b5b3a444\/install\.sh/)
+  assert.doesNotMatch(curlCalls, /beads_(rust|viewer)\/main\/install\.sh/)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("bun installer omits claude-mem for unsupported hosts by default", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-unsupported-claude-mem-"))
   const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
@@ -915,6 +945,42 @@ test("install.sh runs graphify Codex platform setup for Codex installs", { timeo
   assert.equal(result.status, 0, output)
   assert.match(fs.readFileSync(pythonLog, "utf8"), /pip install --user graphifyy/)
   assert.deepEqual(fs.readFileSync(graphifyLog, "utf8").trim().split("\n"), ["install --platform codex"])
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh supports pinned third-party installer ref overrides", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-pinned-third-party-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-pinned-third-party-bin-"))
+  const curlLog = path.join(home, "curl-calls")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", "settings.json"), JSON.stringify({ statusline: "existing" }) + "\n", "utf8")
+  fs.writeFileSync(path.join(tmpBinDir, "curl"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$CURL_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "curl"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "python3"), "#!/usr/bin/env bash\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "npx"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      CURL_LOG: curlLog,
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_BEADS_RUST_INSTALL_REF: "rust-test-ref",
+      XPOWERS_BEADS_VIEWER_INSTALL_REF: "viewer-test-ref",
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const curlCalls = fs.readFileSync(curlLog, "utf8")
+  assert.match(curlCalls, /beads_rust\/rust-test-ref\/install\.sh/)
+  assert.match(curlCalls, /beads_viewer\/viewer-test-ref\/install\.sh/)
+  assert.doesNotMatch(curlCalls, /beads_(rust|viewer)\/main\/install\.sh/)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -47,6 +47,35 @@ function installEnv(home, extra = {}) {
   }
 }
 
+function findExecutable(name) {
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    if (!dir) continue
+    const candidate = path.join(dir, name)
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK)
+      return candidate
+    } catch {
+      // Keep searching PATH.
+    }
+  }
+  return null
+}
+
+function linkManifestRuntime(binDir) {
+  const nodePath = process.versions.bun ? findExecutable("node") : process.execPath
+  if (nodePath) {
+    fs.symlinkSync(nodePath, path.join(binDir, "node"))
+  } else {
+    fs.symlinkSync(process.execPath, path.join(binDir, "bun"))
+  }
+}
+
+function linkCommand(binDir, name) {
+  const commandPath = findExecutable(name)
+  assert.ok(commandPath, `expected ${name} to be available on PATH`)
+  fs.symlinkSync(commandPath, path.join(binDir, name))
+}
+
 function makeBootstrapRepo(installShContent = fs.readFileSync(path.join(repoRoot, "scripts", "install.sh"), "utf8")) {
   const repo = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-bootstrap-source-"))
   fs.mkdirSync(path.join(repo, "scripts"), { recursive: true })
@@ -795,6 +824,113 @@ test("install.sh uninstall removes tracked third-party tools", { timeout: 120000
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("install.sh uninstall removes manifest-only third-party tools", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-manifest-uninstall-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-manifest-uninstall-bin-"))
+  const pipLog = path.join(home, "pip-uninstall")
+  const npxLog = path.join(home, "npx-uninstall")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".local", "bin"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", ".xpowers-manifest"), "# .xpowers-manifest\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "br"), "br\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "bv"), "bv\n", "utf8")
+  fs.writeFileSync(
+    path.join(home, ".xpowers", "manifest.json"),
+    JSON.stringify({
+      version: "test",
+      installedAt: "2026-05-05T00:00:00.000Z",
+      hosts: {},
+      features: {
+        br: { installed: true },
+        bv: { installed: true },
+        graphify: { installed: true },
+        "claude-mem": { installed: true },
+      },
+    }) + "\n",
+    "utf8",
+  )
+  fs.writeFileSync(path.join(tmpBinDir, "python3"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$PIP_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_LOG\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+  linkManifestRuntime(tmpBinDir)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}/usr/bin:/bin`,
+      PIP_LOG: pipLog,
+      NPX_LOG: npxLog,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), false)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), false)
+  assert.match(fs.readFileSync(pipLog, "utf8"), /pip uninstall -y graphifyy/)
+  assert.match(fs.readFileSync(npxLog, "utf8"), /claude-mem uninstall/)
+  assert.equal(fs.existsSync(path.join(home, ".xpowers", "third-party-tools")), false)
+  const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
+  assert.equal(manifest.features.br.installed, false)
+  assert.equal(manifest.features.bv.installed, false)
+  assert.equal(manifest.features.graphify.installed, false)
+  assert.equal(manifest.features["claude-mem"].installed, false)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh manifest fallback reads pretty manifest without js or python runtimes", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-manifest-awk-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-manifest-awk-bin-"))
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".local", "bin"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", ".xpowers-manifest"), "# .xpowers-manifest\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "br"), "br\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "bv"), "bv\n", "utf8")
+  fs.writeFileSync(
+    path.join(home, ".xpowers", "manifest.json"),
+    JSON.stringify(
+      {
+        version: "test",
+        installedAt: "2026-05-05T00:00:00.000Z",
+        hosts: {},
+        features: {
+          br: { installed: true },
+          bv: { installed: true },
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf8",
+  )
+  for (const command of ["awk", "basename", "bash", "dirname", "grep", "rm", "rmdir", "tr"]) {
+    linkCommand(tmpBinDir, command)
+  }
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: tmpBinDir,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), false)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), false)
+  assert.match(output, /Could not update third-party entries/)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("install.sh uninstall preserves third-party state when cleanup fails", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-uninstall-fail-home-"))
   const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-uninstall-fail-bin-"))
@@ -820,7 +956,7 @@ test("install.sh uninstall preserves third-party state when cleanup fails", { ti
   assert.equal(result.status, 0, output)
   assert.match(fs.readFileSync(pipLog, "utf8"), /pip uninstall -y graphifyy/)
   assert.equal(fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"), "graphify\n")
-  assert.match(output, /Keeping third-party state file for retry/)
+  assert.match(output, /Keeping third-party tracking for retry/)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
@@ -902,6 +1038,63 @@ test("install.sh partial uninstall preserves tracked third-party tools", { timeo
   assert.equal(fs.existsSync(pipLog), false)
   assert.equal(fs.existsSync(npxLog), false)
   assert.equal(fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"), "br\nbv\ngraphify\nclaude-mem\n")
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh partial uninstall compares selected and detected host sets before third-party cleanup", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-mismatched-host-uninstall-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-mismatched-host-uninstall-bin-"))
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".local", "bin"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".xpowers", "third-party-tools"), "br\nbv\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "br"), "br\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "bv"), "bv\n", "utf8")
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "gemini", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}/usr/bin:/bin`,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), true)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), true)
+  assert.equal(fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"), "br\nbv\n")
+  assert.doesNotMatch(output, /Removing tracked third-party tool bundle/)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh explicit purge cleans shared tools when no hosts are detected", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-no-detected-host-uninstall-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-no-detected-host-uninstall-bin-"))
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".local", "bin"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".xpowers", "third-party-tools"), "br\nbv\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "br"), "br\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "bv"), "bv\n", "utf8")
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--uninstall", "--yes", "--purge"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}/usr/bin:/bin`,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), false)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), false)
+  assert.equal(fs.existsSync(path.join(home, ".xpowers", "third-party-tools")), false)
+  assert.match(output, /Removing tracked third-party tool bundle/)
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -1083,6 +1083,54 @@ test("install.sh uninstall removes manifest-only third-party tools", { timeout: 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("install.sh manifest probes fall back when node runtime fails", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-manifest-node-fail-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-manifest-node-fail-bin-"))
+  const nodeLog = path.join(home, "node-probe")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".xpowers"), { recursive: true })
+  fs.mkdirSync(path.join(home, ".local", "bin"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", ".xpowers-manifest"), "# .xpowers-manifest\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "br"), "br\n", "utf8")
+  fs.writeFileSync(path.join(home, ".local", "bin", "bv"), "bv\n", "utf8")
+  fs.writeFileSync(
+    path.join(home, ".xpowers", "manifest.json"),
+    JSON.stringify({
+      version: "test",
+      installedAt: "2026-05-05T00:00:00.000Z",
+      hosts: {},
+      features: {
+        br: { installed: true },
+        bv: { installed: true },
+      },
+    }) + "\n",
+    "utf8",
+  )
+  fs.writeFileSync(path.join(tmpBinDir, "node"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NODE_LOG\"\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "node"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      NODE_LOG: nodeLog,
+      PATH: `${tmpBinDir}${path.delimiter}/usr/bin:/bin`,
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.match(fs.readFileSync(nodeLog, "utf8"), /manifest\.features/)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "br")), false)
+  assert.equal(fs.existsSync(path.join(home, ".local", "bin", "bv")), false)
+  const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
+  assert.equal(manifest.features.br.installed, false)
+  assert.equal(manifest.features.bv.installed, false)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("install.sh manifest fallback reads pretty manifest without js or python runtimes", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-manifest-awk-home-"))
   const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-manifest-awk-bin-"))

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -679,6 +679,82 @@ test("install.sh does not run third-party tool bundle without --yes", { timeout:
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })
 
+test("install.sh skips third-party tool bundle when all selected hosts fail", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-all-hosts-fail-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-all-hosts-fail-bin-"))
+  const markerPath = path.join(home, "third-party-called")
+
+  for (const name of ["curl", "python3", "npx"]) {
+    fs.writeFileSync(
+      path.join(tmpBinDir, name),
+      "#!/usr/bin/env bash\nprintf '%s\\n' \"${0##*/} $*\" >> \"$THIRD_PARTY_MARKER\"\nexit 0\n",
+      "utf8",
+    )
+    fs.chmodSync(path.join(tmpBinDir, name), 0o755)
+  }
+  fs.writeFileSync(path.join(tmpBinDir, "npm"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npm"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "gemini"), "#!/usr/bin/env bash\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "gemini"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "gemini", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      THIRD_PARTY_MARKER: markerPath,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 1, output)
+  assert.match(output, /Skipping third-party tool bundle because no selected agents installed successfully/)
+  assert.equal(fs.existsSync(markerPath), false, "third-party installer shims should not run after all host installs fail")
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh runs claude-mem only for successfully installed selected hosts", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-successful-hosts-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-successful-hosts-bin-"))
+  const npxMarker = path.join(home, "npx-called")
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.writeFileSync(path.join(home, ".claude", "settings.json"), JSON.stringify({ statusline: "existing" }) + "\n", "utf8")
+
+  fs.writeFileSync(path.join(tmpBinDir, "curl"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "curl"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "python3"), "#!/usr/bin/env bash\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "npm"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npm"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "gemini"), "#!/usr/bin/env bash\nexit 9\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "gemini"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_MARKER\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "claude,gemini", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      NPX_MARKER: npxMarker,
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 1, output)
+  const npxCalls = fs.readFileSync(npxMarker, "utf8").trim().split("\n")
+  assert.equal(npxCalls.length, 1)
+  assert.match(npxCalls[0], /claude-mem install$/)
+  assert.doesNotMatch(npxCalls[0], /gemini-cli/)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
 test("install.sh uninstall removes tracked third-party tools", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-uninstall-home-"))
   const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-third-party-uninstall-bin-"))

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -223,10 +223,11 @@ test("install.sh mixed claude+pi install reports both agents in summary", { time
   assert.match(output, /Pi Agent/)
 })
 
-test("install.sh mixed claude+pi install does not replay host-independent third-party tools", { timeout: 120000 }, () => {
+test("install.sh mixed claude+pi install keeps br/bv delegated but installs graphify for non-Pi hosts", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-mixed-pi-third-party-home-"))
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-mixed-pi-third-party-bin-"))
   const hostIndependentMarker = path.join(home, "host-independent-third-party-called")
+  const graphifyMarker = path.join(home, "graphify-called")
   const npxMarker = path.join(home, "npx-called")
   fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
 
@@ -244,7 +245,7 @@ test("install.sh mixed claude+pi install does not replay host-independent third-
     [
       "#!/usr/bin/env bash",
       "case \"$*\" in",
-      "  *'pip install --user graphifyy'*) printf '%s\\n' \"$0 $*\" >> \"$HOST_INDEPENDENT_MARKER\" ;;",
+      "  *'pip install --user graphifyy'*) printf '%s\\n' \"$0 $*\" >> \"$GRAPHIFY_MARKER\" ;;",
       "esac",
       "exit 0",
       "",
@@ -252,6 +253,8 @@ test("install.sh mixed claude+pi install does not replay host-independent third-
     "utf8",
   )
   fs.chmodSync(path.join(binDir, "python3"), 0o755)
+  fs.writeFileSync(path.join(binDir, "graphify"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$GRAPHIFY_MARKER\"\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(binDir, "graphify"), 0o755)
   fs.writeFileSync(path.join(binDir, "npx"), "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$NPX_MARKER\"\nexit 0\n", "utf8")
   fs.chmodSync(path.join(binDir, "npx"), 0o755)
 
@@ -260,6 +263,7 @@ test("install.sh mixed claude+pi install does not replay host-independent third-
     encoding: "utf8",
     env: installEnv(home, {
       HOST_INDEPENDENT_MARKER: hostIndependentMarker,
+      GRAPHIFY_MARKER: graphifyMarker,
       NPX_MARKER: npxMarker,
       PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
       XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
@@ -269,7 +273,10 @@ test("install.sh mixed claude+pi install does not replay host-independent third-
 
   const output = combinedOutput(result)
   assert.equal(result.status, 0, output)
-  assert.equal(fs.existsSync(hostIndependentMarker), false, "Pi delegation should own br/bv/graphify for mixed installs")
+  assert.equal(fs.existsSync(hostIndependentMarker), false, "Pi delegation should own br/bv for mixed installs")
+  const graphifyCalls = fs.readFileSync(graphifyMarker, "utf8")
+  assert.match(graphifyCalls, /pip install --user graphifyy/)
+  assert.match(graphifyCalls, /^install$/m)
   assert.match(fs.readFileSync(npxMarker, "utf8"), /claude-mem install/)
   assert.equal(
     fs.readFileSync(path.join(home, ".xpowers", "third-party-tools"), "utf8"),
@@ -517,6 +524,24 @@ test("bun installer omits claude-mem for unsupported hosts by default", { timeou
   assert.equal(Object.hasOwn(payload.features, "claude-mem"), false, "claude-mem should not be selected for Kimi-only installs")
 })
 
+test("bun installer omits graphify for unsupported hosts by default", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-unsupported-graphify-"))
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".config", "agents"), { recursive: true })
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "kimi", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const payload = JSON.parse(result.stdout.trim())
+  assert.equal(Object.hasOwn(payload.features, "graphify"), false, "graphify should not be selected for hosts without upstream platform support")
+})
+
 test("bun installer skips default features when selected hosts are invalid", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-invalid-host-default-features-"))
   const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-invalid-host-default-features-bin-"))
@@ -554,6 +579,61 @@ test("bun installer skips default features when selected hosts are invalid", { t
   assert.deepEqual(manifest.features, {})
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("bun installer runs graphify platform setup for each supported selected host", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-graphify-platforms-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-graphify-platforms-bin-"))
+  const graphifyLog = path.join(home, "graphify-calls")
+  const pythonLog = path.join(home, "python-calls")
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true })
+  fs.symlinkSync("/bin/bash", path.join(tmpBinDir, "bash"))
+  fs.writeFileSync(
+    path.join(tmpBinDir, "python3"),
+    [
+      "#!/usr/bin/env bash",
+      "printf '%s\\n' \"$*\" >> \"$PYTHON_LOG\"",
+      "exit 0",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+  fs.writeFileSync(
+    path.join(tmpBinDir, "graphify"),
+    [
+      "#!/usr/bin/env bash",
+      "printf '%s\\n' \"$*\" >> \"$GRAPHIFY_LOG\"",
+      "exit 0",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  fs.chmodSync(path.join(tmpBinDir, "graphify"), 0o755)
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "claude,opencode,gemini,pi", "--features", "graphify", "--yes", "--json", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      GRAPHIFY_LOG: graphifyLog,
+      PYTHON_LOG: pythonLog,
+      PATH: tmpBinDir,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 1, output)
+  assert.match(fs.readFileSync(pythonLog, "utf8"), /pip install --user graphifyy --quiet/)
+  const graphifyCalls = fs.readFileSync(graphifyLog, "utf8").trim().split("\n")
+  assert.deepEqual(graphifyCalls, [
+    "install",
+    "install --platform opencode",
+    "install --platform gemini",
+    "install --platform pi",
+  ])
 })
 
 test("bun installer reports claude-mem skipped before requiring npx for unsupported hosts", { timeout: 120000 }, () => {
@@ -781,6 +861,60 @@ test("install.sh runs claude-mem only for successfully installed selected hosts"
   assert.equal(npxCalls.length, 1)
   assert.match(npxCalls[0], /claude-mem install$/)
   assert.doesNotMatch(npxCalls[0], /gemini-cli/)
+
+  fs.rmSync(tmpBinDir, { recursive: true, force: true })
+})
+
+test("install.sh runs graphify Codex platform setup for Codex installs", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-graphify-codex-home-"))
+  const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-graphify-codex-bin-"))
+  const graphifyLog = path.join(home, "graphify-calls")
+  const pythonLog = path.join(home, "python-calls")
+  fs.mkdirSync(path.join(home, ".codex"), { recursive: true })
+
+  fs.writeFileSync(path.join(tmpBinDir, "curl"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "curl"), 0o755)
+  fs.writeFileSync(
+    path.join(tmpBinDir, "python3"),
+    [
+      "#!/usr/bin/env bash",
+      "printf '%s\\n' \"$*\" >> \"$PYTHON_LOG\"",
+      "exit 0",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  fs.chmodSync(path.join(tmpBinDir, "python3"), 0o755)
+  fs.writeFileSync(
+    path.join(tmpBinDir, "graphify"),
+    [
+      "#!/usr/bin/env bash",
+      "printf '%s\\n' \"$*\" >> \"$GRAPHIFY_LOG\"",
+      "exit 0",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  fs.chmodSync(path.join(tmpBinDir, "graphify"), 0o755)
+  fs.writeFileSync(path.join(tmpBinDir, "npx"), "#!/usr/bin/env bash\nexit 0\n", "utf8")
+  fs.chmodSync(path.join(tmpBinDir, "npx"), 0o755)
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--hosts", "codex", "--yes", "--allow-conflicts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home, {
+      GRAPHIFY_LOG: graphifyLog,
+      PYTHON_LOG: pythonLog,
+      PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      XPOWERS_SKIP_THIRD_PARTY_FEATURES: "0",
+    }),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  assert.match(fs.readFileSync(pythonLog, "utf8"), /pip install --user graphifyy/)
+  assert.deepEqual(fs.readFileSync(graphifyLog, "utf8").trim().split("\n"), ["install --platform codex"])
 
   fs.rmSync(tmpBinDir, { recursive: true, force: true })
 })


### PR DESCRIPTION
## Summary

- Adds `br`, `bv`, `graphify`, and `claude-mem` to the Bun installer feature model.
- Mirrors the third-party tool bundle in `scripts/install.sh`.
- Documents and tests `XPOWERS_SKIP_THIRD_PARTY_FEATURES=1` so CI and host-only installs avoid external downloads.

## Validation

- `bash -n scripts/install.sh`
- `bun scripts/install.ts --help`
- `node --test --test-name-pattern "third-party" tests/install-script.test.js`
- `npm test`

## Notes

This branch was recreated after reverting the accidental direct push to `main`, so the PR diff is based on the reverted `main` state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional third‑party tool bundle during install (adds br, bv, graphify, claude‑mem, supermemory), with tracked installs, targeted uninstall, host-aware delegation to avoid duplicate installs, and dry‑run reporting.

* **Documentation**
  * README updated with feature IDs, note that --yes enables third‑party installs, and how to perform a host‑only install via XPOWERS_SKIP_THIRD_PARTY_FEATURES.

* **Tests**
  * Expanded tests for bundle behavior, delegation/skip logic, manifest state preservation, retry/partial‑failure handling, and uninstall cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->