### PR TITLE
Add execute-ralph-cc: ScheduleWakeup-based autonomous loop for Claude Code

### DIFF
--- a/.kimi/skills/codex-agent-autonomous-reviewer/SKILL.md
+++ b/.kimi/skills/codex-agent-autonomous-reviewer/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/autonomous-reviewer.md` for Codex Skill
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: autonomous-reviewer
 description: Machine-facing reviewer for automated pipelines. Returns structured verdicts (PASS/NEEDS_FIX/APPROVED/GAPS_FOUND) with actionable fix instructions for orchestrators to act on. Can research unclear patterns via web search. Use during continuous execution (ralph, execute-ralph). Contrast with code-reviewer (human-facing, narrative explanations) and review-implementation (spec-focused, requirements checklist).
@@ -151,4 +151,4 @@ Research: [Supporting research for these findings]
 - Tests failing or missing for new code
 - Security vulnerabilities
 - Breaking changes to existing functionality
-```
+````

--- a/.kimi/skills/codex-agent-code-reviewer/SKILL.md
+++ b/.kimi/skills/codex-agent-code-reviewer/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/code-reviewer.md` for Codex Skills comp
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 
 name: code-reviewer
@@ -75,4 +75,4 @@ When reviewing completed work, you will:
    - Always acknowledge what was done well before highlighting issues
 
 Your output should be structured, actionable, and focused on helping maintain high code quality while ensuring project goals are met. Be thorough but concise, and always provide constructive feedback that helps improve both the current implementation and future development practices.
-```
+````

--- a/.kimi/skills/codex-agent-codebase-investigator/SKILL.md
+++ b/.kimi/skills/codex-agent-codebase-investigator/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/codebase-investigator.md` for Codex Ski
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 
 name: codebase-investigator
@@ -127,4 +127,4 @@ When investigating a codebase, you will:
    - LARGE: Architecture overview, key locations, areas requiring follow-up
 
 Your goal is to provide accurate, verified information about codebase state so that planning and design decisions are grounded in reality, not assumptions. Be thorough in investigation, honest about what you can't find, and concise in reporting.
-```
+````

--- a/.kimi/skills/codex-agent-devops/SKILL.md
+++ b/.kimi/skills/codex-agent-devops/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/devops.md` for Codex Skills compatibili
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: devops
 description: DevOps reviewer - analyzes CI/CD pipelines, pre-commit hooks, build configurations, and diagnoses pipeline failures. Returns PASS or ISSUES_FOUND.
@@ -169,4 +169,4 @@ Recent CI: 3/5 last runs passed. Failures in workflow 'test' (run #456, #458).
 3. **Safety first**: Only run read-only diagnostic commands
 4. **Actionable**: Every finding includes a concrete suggested fix
 5. **Context-aware**: Check recent CI history to identify patterns, not just config
-```
+````

--- a/.kimi/skills/codex-agent-internet-researcher/SKILL.md
+++ b/.kimi/skills/codex-agent-internet-researcher/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/internet-researcher.md` for Codex Skill
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 
 name: internet-researcher
@@ -92,4 +92,4 @@ When conducting internet research, you will:
    - Always note which tier your sources fall into
 
 Your goal is to provide accurate, current, well-sourced information from the internet so that planning and design decisions are based on real-world knowledge, not outdated assumptions. Be thorough in research, transparent about source quality, and concise in reporting.
-```
+````

--- a/.kimi/skills/codex-agent-knowledge-aggregator/SKILL.md
+++ b/.kimi/skills/codex-agent-knowledge-aggregator/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/knowledge-aggregator.md` for Codex Skil
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 
 name: knowledge-aggregator
@@ -183,4 +183,4 @@ This is critical — your value scales with available sources but you must ALWAY
 3. **Graceful degradation**: Always produce output, regardless of source availability
 4. **Context over code**: Your value is finding information that ISN'T in the code
 5. **Honest gaps**: Reporting what you couldn't find is as valuable as what you found
-```
+````

--- a/.kimi/skills/codex-agent-planner/SKILL.md
+++ b/.kimi/skills/codex-agent-planner/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/planner.md` for Codex Skills compatibil
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 
 name: planner
@@ -168,4 +168,4 @@ Task 3: [title] (depends on Task 1) - Risk: LOW
 4. **Dependency-aware**: Tasks in the right order, with clear reasons for ordering.
 5. **Risk-transparent**: Every task has an honest risk assessment.
 6. **Implementable**: A developer should be able to execute any task without asking clarifying questions.
-```
+````

--- a/.kimi/skills/codex-agent-ralph/SKILL.md
+++ b/.kimi/skills/codex-agent-ralph/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/ralph.md` for Codex Skills compatibilit
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 
 name: ralph
@@ -165,4 +165,4 @@ You invoke:
 - `test-effectiveness-analyst` agent (end-of-epic test effectiveness review)
 
 You are the hands-off execution mode for users who trust autonomous operation.
-```
+````

--- a/.kimi/skills/codex-agent-review-documentation/SKILL.md
+++ b/.kimi/skills/codex-agent-review-documentation/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/review-documentation.md` for Codex Skil
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: review-documentation
 description: Documentation reviewer - checks if docs need updates for API changes, new features, config changes. Returns PASS or ISSUES_FOUND.
@@ -94,4 +94,4 @@ Files to Update:
 - Self-explanatory code
 - Test files
 - Obvious patterns following existing conventions
-```
+````

--- a/.kimi/skills/codex-agent-review-implementation/SKILL.md
+++ b/.kimi/skills/codex-agent-review-implementation/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/review-implementation.md` for Codex Ski
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: review-implementation
 description: Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
@@ -91,4 +91,4 @@ Missing Implementation:
 - Test coverage (other agent handles this)
 - Documentation (other agent handles this)
 - Over-engineering (other agent handles this)
-```
+````

--- a/.kimi/skills/codex-agent-review-quality/SKILL.md
+++ b/.kimi/skills/codex-agent-review-quality/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/review-quality.md` for Codex Skills com
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: review-quality
 description: Quality reviewer - finds bugs, race conditions, error handling gaps, resource leaks. Returns PASS or ISSUES_FOUND with severity.
@@ -85,4 +85,4 @@ Recommendations:
 - Performance unless it's a clear problem
 - Documentation gaps (review-documentation handles this)
 - Security vulnerabilities (security-scanner handles OWASP, secrets, CVEs)
-```
+````

--- a/.kimi/skills/codex-agent-review-simplification/SKILL.md
+++ b/.kimi/skills/codex-agent-review-simplification/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/review-simplification.md` for Codex Ski
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: review-simplification
 description: Simplification reviewer - detects over-engineering, unnecessary complexity, premature abstractions. Returns PASS or ISSUES_FOUND.
@@ -93,4 +93,4 @@ Dead Code:
 - Abstractions with multiple consumers
 - Code that follows established project patterns
 - Defensive coding for known edge cases
-```
+````

--- a/.kimi/skills/codex-agent-review-testing/SKILL.md
+++ b/.kimi/skills/codex-agent-review-testing/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/review-testing.md` for Codex Skills com
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: review-testing
 description: Testing reviewer - evaluates test coverage, test quality, and testing gaps. Returns PASS or ISSUES_FOUND.
@@ -91,4 +91,4 @@ Recommended Tests:
 - Existing untested code (only new/changed code)
 - Test style preferences
 - Over-testing (testing implementation details)
-```
+````

--- a/.kimi/skills/codex-agent-security-scanner/SKILL.md
+++ b/.kimi/skills/codex-agent-security-scanner/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/security-scanner.md` for Codex Skills c
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: security-scanner
 description: Security scanner - performs OWASP Top 10 scanning, secrets detection, and dependency vulnerability checks. Returns PASS or ISSUES_FOUND with severity.
@@ -150,4 +150,4 @@ Scope: [number] files scanned, [number] dependency checks performed.
 3. **Read-only**: You scan and report. You never modify code.
 4. **Graceful degradation**: If WebFetch fails for CVE checks, note it and continue
 5. **Scope clarity**: Always report how many files were scanned
-```
+````

--- a/.kimi/skills/codex-agent-test-effectiveness-analyst/SKILL.md
+++ b/.kimi/skills/codex-agent-test-effectiveness-analyst/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/test-effectiveness-analyst.md` for Code
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 
 name: test-effectiveness-analyst
@@ -399,4 +399,4 @@ Target: 80%+ mutation score for critical modules
 - Rush categorization without reading production code first
 
 **Fight these temptations.** Junior engineers write plausible-looking tests. Your job is to be the skeptic who verifies they actually work.
-```
+````

--- a/.kimi/skills/codex-agent-test-runner/SKILL.md
+++ b/.kimi/skills/codex-agent-test-runner/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `agents/test-runner.md` for Codex Skills compat
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 
 name: test-runner
@@ -377,4 +377,4 @@ If tests hang, note that you're still waiting after reasonable time.
 **DO NOT truncate or summarize failures.** The user needs complete information to debug and fix issues.
 
 Your goal is to provide clean, actionable results without polluting the requestor's context with successful output or verbose formatting changes, while ensuring complete failure details for effective debugging.
-```
+````

--- a/.kimi/skills/codex-command-analyze-tests/SKILL.md
+++ b/.kimi/skills/codex-command-analyze-tests/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `commands/analyze-tests.md` for Codex Skills co
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Audit test quality - identify tautological tests, coverage gaming, missing corner cases
 ---
@@ -25,4 +25,4 @@ Use the xpowers:analyzing-test-effectiveness skill exactly as written.
 Scope: $ARGUMENTS
 
 If no scope is provided, analyze test quality across the repository.
-```
+````

--- a/.kimi/skills/codex-command-brainstorm/SKILL.md
+++ b/.kimi/skills/codex-command-brainstorm/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `commands/brainstorm.md` for Codex Skills compa
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Interactive design refinement using Socratic method
 ---
@@ -25,4 +25,4 @@ Use the xpowers:brainstorming skill exactly as written.
 Topic: $ARGUMENTS
 
 If no topic is provided, ask the user for the topic with a single question before proceeding.
-```
+````

--- a/.kimi/skills/codex-command-execute-plan/SKILL.md
+++ b/.kimi/skills/codex-command-execute-plan/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `commands/execute-plan.md` for Codex Skills com
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Execute plan in batches with review checkpoints
 ---
@@ -34,4 +34,4 @@ If no context is provided, resume from current bd state.
 4. Repeat until epic complete
 
 **Checkpoints:** Each task execution ends with a STOP checkpoint. User must run this command again to continue.
-```
+````

--- a/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
@@ -24,7 +24,7 @@ type: flow
 
 # Usage
 
-```
+```text
 /xpowers:execute-ralph-cc [--reviewer-model=opus|sonnet]
 ```
 

--- a/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
@@ -39,10 +39,10 @@ type: flow
 Executes a complete bd epic autonomously using Claude Code's native `ScheduleWakeup` tool instead of stop hooks. Each turn processes exactly one task, then schedules a wake-up for the next:
 
 1. **Phase 0 - State Recovery:** Every wake-up starts here. Reads all state from bd/tm (epic, tasks, criteria). Fully idempotent -- any wake-up reconstructs context from bd/tm alone.
-2. **Phase 1 - Get Task & Refine:** Uses `bv --robot-next` for triage. Claims or auto-creates the next task. Runs SRE refinement.
+2. **Phase 1 - Get Task & Refine:** Uses `bv --robot-triage` output from Phase 0 to determine next task. Claims or auto-creates the next task. Runs SRE refinement.
 3. **Phase 2 - Dispatch Subagent:** Records `PRE_SHA`, dispatches Agent tool with subagent-driven-development protocol. Verifies SHA drift and task status.
 4. **Phase 3 - Post-Task Check:** Quick review. Re-reads epic criteria. If criteria unmet, calls `ScheduleWakeup(60s)` and ends turn. If criteria met, proceeds to Phase 4.
-5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). Both must APPROVED. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
+5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). Both must return APPROVED. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
 6. **Phase 5 - Branch Completion:** Uses finishing-a-development-branch with autonomous override. Presents summary. No ScheduleWakeup -- loop ends naturally.
 
 ## ScheduleWakeup Loop Contract
@@ -76,7 +76,7 @@ The loop uses Claude Code's native `ScheduleWakeup` tool for continuation:
 
 ## Review and Remediation Contract
 
-Reviews happen ONCE at end of epic (not per-task):
+Specialized reviews happen ONCE at end of epic (a lightweight per-task review occurs in Phase 3, but the full review suite runs only after all criteria are met):
 
 - 3 specialized agents dispatched in parallel after all epic criteria are met:
   - review-quality (bugs, race conditions, error handling)

--- a/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
@@ -49,7 +49,7 @@ Executes a complete bd epic autonomously using Claude Code's native `ScheduleWak
 
 The loop uses Claude Code's native `ScheduleWakeup` tool for continuation:
 
-- **Continuation**: At end of Phase 3 or Phase 4 (when criteria unmet or reviews fail), calls `ScheduleWakeup` with `delaySeconds: 60` and prompt `<<autonomous-loop-dynamic>>`. The runtime resolves the sentinel to autonomous loop instructions on wake-up, re-entering the skill at Phase 0.
+- **Continuation**: At end of Phase 3 or Phase 4 (when criteria unmet or reviews fail), calls `ScheduleWakeup` with `delaySeconds: 60` and a concrete Phase 0 re-entry prompt. The prompt contains explicit instructions to load the skill and start at Phase 0, ensuring re-entry regardless of runtime sentinel support.
 - **Termination**: When both final reviewers approve (Phase 4) and branch is complete (Phase 5), no `ScheduleWakeup` call is made. The loop ends naturally.
 - **Idempotent state**: All state comes from bd/tm. No session-scoped variables or custom state files. Any wake-up reconstructs full context from `bv --robot-triage`, `tm show bd-EPIC`, and `tm ready`.
 - **No sentinel dependency**: This variant does NOT emit or depend on `RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED` sentinels. The loop is entirely managed by `ScheduleWakeup`.

--- a/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: codex-command-execute-ralph-cc
+description: "Use when task intent matches command 'execute-ralph-cc'. Do not use for unrelated workflows."
+---
+
+# Codex Command Wrapper
+
+This skill wraps the source file `commands/execute-ralph-cc.md` for Codex Skills compatibility.
+
+## Usage
+
+- Use this skill when the request matches the intent of `commands/execute-ralph-cc.md`.
+- Follow the source instructions exactly.
+- Do not use this skill for unrelated tasks.
+
+## Source Content
+
+```markdown
+---
+name: execute-ralph-cc
+description: "Execute entire bd epic autonomously via ScheduleWakeup task-per-turn loop. Claude Code only. No stop hooks."
+type: flow
+---
+
+# Usage
+
+```
+/xpowers:execute-ralph-cc [--reviewer-model=opus|sonnet]
+```
+
+## Arguments
+
+- `--reviewer-model`: Model for autonomous-reviewer (optional)
+  - `opus` (default): Highest capability, thorough review
+  - `sonnet`: Faster, balanced quality
+
+## What This Does
+
+Executes a complete bd epic autonomously using Claude Code's native `ScheduleWakeup` tool instead of stop hooks. Each turn processes exactly one task, then schedules a wake-up for the next:
+
+1. **Phase 0 - State Recovery:** Every wake-up starts here. Reads all state from bd/tm (epic, tasks, criteria). Fully idempotent -- any wake-up reconstructs context from bd/tm alone.
+2. **Phase 1 - Get Task & Refine:** Uses `bv --robot-next` for triage. Claims or auto-creates the next task. Runs SRE refinement.
+3. **Phase 2 - Dispatch Subagent:** Records `PRE_SHA`, dispatches Agent tool with subagent-driven-development protocol. Verifies SHA drift and task status.
+4. **Phase 3 - Post-Task Check:** Quick review. Re-reads epic criteria. If criteria unmet, calls `ScheduleWakeup(60s)` and ends turn. If criteria met, proceeds to Phase 4.
+5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). Both must APPROVED. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
+6. **Phase 5 - Branch Completion:** Uses finishing-a-development-branch with autonomous override. Presents summary. No ScheduleWakeup -- loop ends naturally.
+
+## ScheduleWakeup Loop Contract
+
+The loop uses Claude Code's native `ScheduleWakeup` tool for continuation:
+
+- **Continuation**: At end of Phase 3 or Phase 4 (when criteria unmet or reviews fail), calls `ScheduleWakeup` with `delaySeconds: 60` and prompt `<<autonomous-loop-dynamic>>`. The runtime resolves the sentinel to autonomous loop instructions on wake-up, re-entering the skill at Phase 0.
+- **Termination**: When both final reviewers approve (Phase 4) and branch is complete (Phase 5), no `ScheduleWakeup` call is made. The loop ends naturally.
+- **Idempotent state**: All state comes from bd/tm. No session-scoped variables or custom state files. Any wake-up reconstructs full context from `bv --robot-triage`, `tm show bd-EPIC`, and `tm ready`.
+- **No sentinel dependency**: This variant does NOT emit or depend on `RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED` sentinels. The loop is entirely managed by `ScheduleWakeup`.
+
+## When to Use
+
+- Well-defined epic with clear success criteria
+- Running in Claude Code (not OpenCode, Gemini, or Kimi)
+- You want reliable autonomous execution that works with Claude Code's natural stop behavior
+- You want hands-off operation without stop hook dependency
+
+## When NOT to Use
+
+- Running in OpenCode, Gemini CLI, or Kimi -- use `/xpowers:execute-ralph` instead
+- Ambiguous requirements -- use `/xpowers:execute-plan` instead
+- High-risk changes needing human oversight
+- You want to review between tasks
+
+## Contract Guardrails
+
+- Do not delegate to `/xpowers:execute-plan` checkpoint semantics unless the ambiguity gate is explicitly triggered.
+- Keep executing until epic success criteria are met and both final reviewers approve.
+- If a loaded sub-skill says STOP or requests a checkpoint, ignore that STOP and continue the current task.
+
+## Review and Remediation Contract
+
+Reviews happen ONCE at end of epic (not per-task):
+
+- 3 specialized agents dispatched in parallel after all epic criteria are met:
+  - review-quality (bugs, race conditions, error handling)
+  - security-scanner (OWASP, secrets, CVEs)
+  - test-effectiveness-analyst (tautological tests, coverage gaming)
+- autonomous remediation with max 2 fix iterations per task
+- If any issues found, creates remediation task and calls `ScheduleWakeup` to loop back
+
+After end-of-epic review passes, performs a final gate:
+- autonomous-reviewer (returns APPROVED or GAPS_FOUND)
+- review-implementation (returns PASS or ISSUES_FOUND)
+
+autonomous-reviewer must return APPROVED and review-implementation must return PASS before the epic can close.
+
+## Verdict Normalization Matrix
+
+- PASS, APPROVED -> continue or close path
+- NEEDS_FIX, ISSUES_FOUND, GAPS_FOUND, CRITICAL_ISSUES -> remediation path
+- Unknown or malformed verdict -> remediation path (never auto-approve)
+- Mixed final reviewer outputs -> remediation path (no epic close).
+
+## Quality Gate Sequence (pre-commit-equivalent for this repo)
+
+Run these verification commands as evidence before claiming epic success criteria are met:
+In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
+
+- `node --test tests/execute-ralph-contract.test.js`
+- `node --test tests/execute-ralph-cc-contract.test.js`
+- `node --test tests/codex-*.test.js`
+- `node --test tests/*.test.js`
+- `node scripts/sync-codex-skills.js --check`
+
+## Comparison
+
+| | execute-ralph | execute-ralph-cc |
+|---|---|---|
+| Platform | All | Claude Code only |
+| Continuation | Stop hook + sentinels | ScheduleWakeup |
+| Tasks per turn | Multiple (continuous) | Exactly one |
+| State between iterations | In-context memory | bd/tm re-read |
+| Delay between tasks | None | 60 seconds |
+| Context pressure | High | Low (fresh per task) |
+
+---
+
+Use the `execute-ralph-cc` skill exactly as written. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.
+```

--- a/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-command-execute-ralph-cc/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `commands/execute-ralph-cc.md` for Codex Skills
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: execute-ralph-cc
 description: "Execute entire bd epic autonomously via ScheduleWakeup task-per-turn loop. Claude Code only. No stop hooks."
@@ -42,7 +42,7 @@ Executes a complete bd epic autonomously using Claude Code's native `ScheduleWak
 2. **Phase 1 - Get Task & Refine:** Uses `bv --robot-triage` output from Phase 0 to determine next task. Claims or auto-creates the next task. Runs SRE refinement.
 3. **Phase 2 - Dispatch Subagent:** Records `PRE_SHA`, dispatches Agent tool with subagent-driven-development protocol. Verifies SHA drift and task status.
 4. **Phase 3 - Post-Task Check:** Quick review. Re-reads epic criteria. If criteria unmet, calls `ScheduleWakeup(60s)` and ends turn. If criteria met, proceeds to Phase 4.
-5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). Both must return APPROVED. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
+5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). `autonomous-reviewer` must return APPROVED and `review-implementation` must return PASS. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
 6. **Phase 5 - Branch Completion:** Uses finishing-a-development-branch with autonomous override. Presents summary. No ScheduleWakeup -- loop ends naturally.
 
 ## ScheduleWakeup Loop Contract
@@ -123,4 +123,4 @@ In guarded environments, direct .git/hooks/pre-commit execution may be blocked b
 ---
 
 Use the `execute-ralph-cc` skill exactly as written. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.
-```
+````

--- a/.kimi/skills/codex-command-execute-ralph/SKILL.md
+++ b/.kimi/skills/codex-command-execute-ralph/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `commands/execute-ralph.md` for Codex Skills co
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 name: execute-ralph
 description: Execute entire epic autonomously with continuous review. No user checkpoints.
@@ -144,4 +144,4 @@ In guarded environments, direct .git/hooks/pre-commit execution may be blocked b
 ---
 
 Use the `execute-ralph` skill exactly as written. If Platform Routing directed you to `execute-ralph-cc`, load that skill instead. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.
-```
+````

--- a/.kimi/skills/codex-command-execute-ralph/SKILL.md
+++ b/.kimi/skills/codex-command-execute-ralph/SKILL.md
@@ -21,6 +21,12 @@ name: execute-ralph
 description: Execute entire epic autonomously with continuous review. No user checkpoints.
 ---
 
+## Platform Routing
+
+**Before loading any skill**, determine which platform you are running on:
+- **Claude Code** (you see "You are Claude Code" in your system prompt): Load the `execute-ralph-cc` skill instead. It uses ScheduleWakeup for reliable autonomous looping in Claude Code.
+- **All other platforms** (OpenCode, Gemini CLI, Kimi, etc.): Continue with the `execute-ralph` skill below. It uses stop hooks for continuation.
+
 # Usage
 
 ```
@@ -137,5 +143,5 @@ In guarded environments, direct .git/hooks/pre-commit execution may be blocked b
 
 ---
 
-Use the `execute-ralph` skill exactly as written. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.
+Use the `execute-ralph` skill exactly as written. If Platform Routing directed you to `execute-ralph-cc`, load that skill instead. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.
 ```

--- a/.kimi/skills/codex-command-recall/SKILL.md
+++ b/.kimi/skills/codex-command-recall/SKILL.md
@@ -15,10 +15,10 @@ This skill wraps the source file `commands/recall.md` for Codex Skills compatibi
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Search long-term memory from previous sessions
 ---
 
 Use the xpowers:recall skill exactly as written
-```
+````

--- a/.kimi/skills/codex-command-refactor-design/SKILL.md
+++ b/.kimi/skills/codex-command-refactor-design/SKILL.md
@@ -15,10 +15,10 @@ This skill wraps the source file `commands/refactor-design.md` for Codex Skills 
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Design a refactor with composition, DI, and test strategy
 ---
 
 Use the xpowers:refactoring-design skill exactly as written
-```
+````

--- a/.kimi/skills/codex-command-refactor-diagnose/SKILL.md
+++ b/.kimi/skills/codex-command-refactor-diagnose/SKILL.md
@@ -15,10 +15,10 @@ This skill wraps the source file `commands/refactor-diagnose.md` for Codex Skill
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Diagnose code/design smells and refactor targets
 ---
 
 Use the xpowers:refactoring-diagnosis skill exactly as written
-```
+````

--- a/.kimi/skills/codex-command-refactor-execute/SKILL.md
+++ b/.kimi/skills/codex-command-refactor-execute/SKILL.md
@@ -15,10 +15,10 @@ This skill wraps the source file `commands/refactor-execute.md` for Codex Skills
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Execute a refactor safely with tests staying green
 ---
 
 Use the xpowers:refactoring-safely skill exactly as written
-```
+````

--- a/.kimi/skills/codex-command-review-implementation/SKILL.md
+++ b/.kimi/skills/codex-command-review-implementation/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `commands/review-implementation.md` for Codex S
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Review implementation was faithfully executed
 ---
@@ -25,4 +25,4 @@ Use the xpowers:review-implementation skill exactly as written.
 Scope: $ARGUMENTS
 
 If no scope is provided, review the current branch against its plan/epic.
-```
+````

--- a/.kimi/skills/codex-command-routing-settings/SKILL.md
+++ b/.kimi/skills/codex-command-routing-settings/SKILL.md
@@ -15,10 +15,10 @@ This skill wraps the source file `commands/routing-settings.md` for Codex Skills
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Configure which AI model each XPowers agent uses
 ---
 
 Use the xpowers:routing-settings skill exactly as written
-```
+````

--- a/.kimi/skills/codex-command-write-plan/SKILL.md
+++ b/.kimi/skills/codex-command-write-plan/SKILL.md
@@ -15,7 +15,7 @@ This skill wraps the source file `commands/write-plan.md` for Codex Skills compa
 
 ## Source Content
 
-```markdown
+````markdown
 ---
 description: Create detailed implementation plan with bite-sized tasks
 ---
@@ -25,4 +25,4 @@ Use the xpowers:writing-plans skill exactly as written.
 Planning topic: $ARGUMENTS
 
 If no topic is provided, ask the user for the feature or goal to plan before proceeding.
-```
+````

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -367,11 +367,12 @@ Unknown or malformed verdict must create a remediation task and continue the loo
 
 Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
 ```bash
-# Increment cycle counter (reset phase4 since we're leaving Phase 4)
+# Increment cycle counter (keep phase4 since remediation will re-enter Phase 4)
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=0"
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
 ```
 ```text
 ScheduleWakeup({

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -431,7 +431,8 @@ Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdo
 Only close epic when BOTH final reviewers approve.
 
 → **CONTINUATION (both APPROVED):** Proceed to Phase 5 (Branch Completion).
-→ **CONTINUATION (non-approval):** Call ScheduleWakeup(60s). END TURN.
+→ **CONTINUATION (non-approval, cap NOT reached):** Call ScheduleWakeup(60s). END TURN.
+→ **CONTINUATION (non-approval, cap reached):** STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates.
 
 ---
 

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -246,7 +246,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+  - If retry also fails, clean worktree (`git checkout . && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
     ```bash
     WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
     CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
@@ -279,7 +279,7 @@ Dispatch `autonomous-reviewer` agent for the completed task.
 
 **Remediation Path**:
 If the review finds **Critical** or **High** issues:
-- Create remediation task: `tm create "Remediation: [Findings]" --parent bd-EPIC`.
+- Create remediation task: `tm create "Remediation: [Findings]"` then `tm dep add bd-REM bd-EPIC --type parent-child`.
 - **Increment watchdog counter** (review failure is a no-progress cycle):
 ```bash
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
@@ -356,7 +356,8 @@ Dispatch specialized reviews **in parallel** via Agent tool:
 
 If any issues found, create remediation task and check watchdog counters:
 ```bash
-tm create "Remediation: Phase 4 specialized review findings" --parent bd-EPIC
+REMEDIATION_ID=$(tm create "Remediation: Phase 4 specialized review findings" | grep -o 'bd-[0-9]*' | head -1)
+tm dep add $REMEDIATION_ID bd-EPIC --type parent-child
 # Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
@@ -402,7 +403,8 @@ Unknown or malformed verdict must create a remediation task and continue the loo
 
 Non-approval --> create remediation task, increment watchdog counter, check cap, call ScheduleWakeup:
 ```bash
-tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" --parent bd-EPIC
+REMEDIATION_ID=$(tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" | grep -o 'bd-[0-9]*' | head -1)
+tm dep add $REMEDIATION_ID bd-EPIC --type parent-child
 # Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
@@ -455,7 +457,8 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
-tm create "Remediation: Phase 5 quality gate failure" --parent bd-EPIC
+REMEDIATION_ID=$(tm create "Remediation: Phase 5 quality gate failure" | grep -o 'bd-[0-9]*' | head -1)
+tm dep add $REMEDIATION_ID bd-EPIC --type parent-child
 ```
 ```text
 ScheduleWakeup({
@@ -635,7 +638,8 @@ Phase 5:
 <code>
 Phase 0 (wake-up):
   bv --robot-triage bd-42 → criteria NOT met, no ready task
-  tm create "Auto-task: remaining criteria" --parent bd-42
+  tm create "Auto-task: remaining criteria"
+  tm dep add bd-NEW bd-42 --type parent-child
   LOOP-WATCHDOG task found: cycles=48 phase4=0
   cycles < 50 → continue
 

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -246,7 +246,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git checkout . && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+  - If retry also fails, clean worktree (`git reset --hard HEAD && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
     ```bash
     WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
     CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -20,7 +20,7 @@ flowchart TD
     SW2 --> W
     P4 -->|both APPROVED| P5[Phase 5: Branch Completion]
     P5 --> E([Done - no ScheduleWakeup])
-```text
+```
 
 <skill_overview>
 Execute a complete epic autonomously using Claude Code's native ScheduleWakeup tool. Each turn processes exactly one task via Agent subagent dispatch. After each task, if epic criteria remain unmet, calls ScheduleWakeup(60s) to schedule the next wake-up. On wake-up, re-enters Phase 0 which reconstructs all state from bd/tm. End-of-epic: 3 specialized reviews in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch. No stop hooks or sentinel protocol.
@@ -69,7 +69,7 @@ ScheduleWakeup({
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```text
+```
 
 The `prompt` parameter `<<autonomous-loop-dynamic>>` is resolved by the runtime to autonomous loop instructions on wake-up, causing re-entry into this skill's Phase 0.
 
@@ -93,23 +93,23 @@ This phase runs at the start of EVERY turn. It reconstructs all context from bd/
 
 ```bash
 bv --robot-triage || (tm ready && tm list)
-```text
+```
 **Health gate:** If dependency cycles exist, alert user and stop. Do NOT call ScheduleWakeup.
 
 ```bash
 tm list --type epic --status open
-```text
+```
 Identify the active epic. If no epic exists, alert user and stop.
 
 ```bash
 tm show bd-EPIC
-```text
+```
 Load epic requirements, success criteria (immutable), and anti-patterns.
 
 ```bash
 tm list --status in_progress
 tm ready
-```text
+```
 
 Determine the path:
 - **A) In-progress task exists** -- resume it, proceed to Phase 1.
@@ -120,22 +120,22 @@ Determine the path:
 **Branch check:**
 ```bash
 git branch --show-current
-```text
+```
 If on main/default branch, create feature branch:
 ```bash
 BRANCH_NAME=$(echo "[epic-title]" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-')
 git checkout -b "feature/${BRANCH_NAME}"
-```text
+```
 If already on a feature branch, continue.
 
 **Watchdog counter recovery:**
 ```bash
 tm list --type chore | grep "LOOP-WATCHDOG: bd-EPIC"
-```text
+```
 If a watchdog task exists, read its no-progress counter from the title:
 ```bash
 tm show bd-WATCHDOG --json | jq -r .title
-```text
+```
 Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
 - `cycles` = total no-progress remediation cycles (max 50)
 - `phase4` = consecutive Phase 4 re-entries (max 2)
@@ -147,7 +147,7 @@ If no watchdog task exists, create one as deferred so it is never picked up by `
 tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
 tm dep add bd-WATCHDOG bd-EPIC --type parent-child
 tm update bd-WATCHDOG --status deferred
-```text
+```
 
 → **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
 
@@ -165,7 +165,7 @@ If arriving from Phase 0 path A (in-progress task):
 If arriving from Phase 0 path B (ready task):
 ```bash
 tm update bd-N --status in_progress
-```text
+```
 
 If arriving from Phase 0 path D (auto-create):
 ```bash
@@ -173,13 +173,13 @@ tm create "Task: [criterion gap]" --type feature --priority 1 \
   --design "## Goal\n[Close unmet criterion]\n## Success Criteria\n- [ ] Gap closed"
 tm dep add bd-NEW bd-EPIC --type parent-child
 tm update bd-NEW --status in_progress
-```text
+```
 
 ### Refinement
 
 ```bash
 tm show bd-N
-```text
+```
 
 Run SRE refinement on the selected task:
 Use Skill tool: `xpowers:sre-task-refinement` (prefer Opus 4.1 model)
@@ -196,12 +196,12 @@ Load full task context:
 ```bash
 tm show bd-EPIC    # epic requirements
 tm show bd-N       # task design
-```text
+```
 
 **Before dispatching**, record current HEAD:
 ```bash
 PRE_SHA=$(git rev-parse HEAD)
-```text
+```
 
 **Launch Agent tool** using the canonical 'Dispatch Protocol' from `subagent-driven-development`.
 
@@ -216,7 +216,7 @@ Use the **Subagent Prompt Template** from `subagent-driven-development` skill, p
 POST_SHA=$(git rev-parse HEAD)
 TASK_TYPE=$(tm show bd-N --json | jq -r .type)
 STATUS=$(tm show bd-N --json | jq -r .status)
-```text
+```
 
 - **Success**:
   - Require `STATUS == "closed"`.
@@ -224,7 +224,15 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   - **Analytical Tasks**: Accepted as success even if `POST_SHA == PRE_SHA` as long as status is `closed`.
   - Proceed to Phase 3.
 - **Turn Limit Hit (Open/In-Progress but Changed)**:
-  - If `STATUS` is not `"closed"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. This is OK -- the next wake-up will find it as in-progress and resume from Phase 0. Proceed to Phase 3 criteria check.
+  - If `STATUS` is not `"closed"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. Skip the Phase 3 review -- the task is not complete, so running `autonomous-reviewer` against unfinished work could create spurious remediation tasks. Instead, call ScheduleWakeup directly:
+  ```text
+  ScheduleWakeup({
+    delaySeconds: 60,
+    reason: "Task bd-N partial progress (turn limit hit), resuming in Phase 0",
+    prompt: "<<autonomous-loop-dynamic>>"
+  })
+  ```
+  END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
   - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and proceed to Phase 3 criteria check.
@@ -258,7 +266,7 @@ END TURN. The remediation task must be completed before entering Phase 4.
 
 ```bash
 tm show bd-EPIC   # re-read success criteria
-```text
+```
 
 **This is the loop decision point.**
 
@@ -271,7 +279,7 @@ ScheduleWakeup({
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```text
+```
 Then END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 **C) Critical blocker** --> Alert user with findings. Do NOT call ScheduleWakeup. Loop terminates.
@@ -286,7 +294,7 @@ If the task completed successfully (STATUS == "closed" with SHA drift), reset th
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
-```text
+```
 
 **Watchdog increment (remediation only -- retry or review failure):**
 Only increment the cycles counter when a task did NOT make progress (retry path, hallucinated completion, or review found Critical/High issues). Do NOT increment after successful task completions even if criteria remain unmet.
@@ -296,7 +304,7 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
-```text
+```
 
 → **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.
 → **CONTINUATION (criteria met):** Proceed to Phase 4 (End-of-Epic Review).
@@ -327,7 +335,7 @@ else
   tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
   # Only call ScheduleWakeup when NOT capped
 fi
-```text
+```
 
 If Phase 4 cap NOT reached, call ScheduleWakeup:
 ```text
@@ -336,7 +344,7 @@ ScheduleWakeup({
   reason: "End-of-epic review found issues, remediation task created for epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```text
+```
 
 If Phase 4 cap reached (phase4 >= 2): STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter.
 
@@ -364,14 +372,14 @@ WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=0"
-```text
+```
 ```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Final gate non-approval for epic bd-EPIC, remediation task created",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```text
+```
 Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
 
 Only close epic when BOTH final reviewers approve.
@@ -391,7 +399,7 @@ node --test tests/execute-ralph-cc-contract.test.js
 node --test tests/codex-*.test.js
 node --test tests/*.test.js
 node scripts/sync-codex-skills.js --check
-```text
+```
 
 If any verification fails, create remediation task and call ScheduleWakeup to return to task loop.
 
@@ -399,7 +407,7 @@ In guarded environments, direct .git/hooks/pre-commit execution may be blocked b
 
 ```text
 Use Skill tool: xpowers:finishing-a-development-branch
-```text
+```
 
 **Autonomous override:** When the skill presents integration options, auto-select **option 2 (Push and create Pull Request)** without waiting for user input. This is autonomous execution -- do not present options or wait.
 

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -502,3 +502,118 @@ NO. This variant does NOT use sentinels. Use ScheduleWakeup for continuation. Ne
 - User must trust autonomous execution
 
 </integration>
+
+<examples>
+
+<example>
+<scenario>Typical autonomous epic execution from start to finish</scenario>
+
+<code>
+User: "run ralph on epic bd-42"
+
+Phase 0 (first wake-up):
+  EPIC_ID=bd-42
+  bv --robot-triage bd-42  # finds 3 open tasks, first is bd-43
+  tm ready                  # bd-43 is ready
+  No in-progress task → Path B (new task)
+
+Phase 1:
+  tm update bd-43 --status in_progress
+  # SRE refinement on bd-43
+  Agent(subagent-driven-development, task=bd-43)
+
+Phase 2:
+  Agent returns: task bd-43 completed, committed
+
+Phase 3:
+  POST_SHA != PRE_SHA → genuine progress
+  bv --robot-triage bd-42 → criteria NOT all met
+  ScheduleWakeup(60s, "<<autonomous-loop-dynamic>>")
+
+[... 2 more task cycles for bd-44, bd-45 ...]
+
+Phase 0 (wake-up after bd-45):
+  bv --robot-triage bd-42 → ALL criteria met → Path C
+
+Phase 4:
+  Agent(review-quality) + Agent(security-scanner) + Agent(test-effectiveness-analyst)
+  All return PASS → proceed to final gate
+  Agent(autonomous-reviewer) → APPROVED
+  Agent(review-implementation) → PASS
+
+Phase 5:
+  xpowers:finishing-a-development-branch
+  No ScheduleWakeup — epic complete
+</code>
+</example>
+
+<example>
+<scenario>Watchdog counter prevents infinite loop on stuck epic</scenario>
+
+<code>
+Phase 0 (wake-up):
+  bv --robot-triage bd-42 → criteria NOT met, no ready task
+  tm create "Auto-task: remaining criteria" --parent bd-42
+  LOOP-WATCHDOG task found: cycles=48 phase4=0
+  cycles < 50 → continue
+
+Phase 1-3:
+  Task bd-48 dispatched, completes
+  ScheduleWakeup(60s)
+
+[... bd-49 also completes but criteria still unmet ...]
+
+Phase 0 (wake-up):
+  LOOP-WATCHDOG: cycles=49 phase4=0
+  Still < 50 → continue
+
+Phase 1-3:
+  Task bd-50 dispatched, NO progress (SHA unchanged)
+  cycles incremented to 50
+
+Phase 0 (wake-up):
+  LOOP-WATCHDOG: cycles=50 phase4=0
+  cycles >= 50 → STOP, alert user:
+  "Epic bd-42 stuck: 50 no-progress cycles. Manual intervention needed."
+</code>
+</example>
+
+<example>
+<scenario>Phase 4 remediation with cap enforcement</scenario>
+
+<code>
+Phase 4 (first entry):
+  3 reviews pass → final gate
+  Agent(autonomous-reviewer) → GAPS_FOUND
+  phase4 counter: 0 → 1
+  Create remediation task bd-51
+  ScheduleWakeup(60s)
+
+[... bd-51 completes, criteria still met, re-enter Phase 4 ...]
+
+Phase 4 (second entry):
+  3 reviews pass → final gate
+  Agent(review-implementation) → ISSUES_FOUND
+  phase4 counter: 1 → 2
+  NEW_PHASE4 >= 2 → STOP, alert user:
+  "Phase 4 re-entry limit (2) reached. Final gate keeps failing. Manual review needed."
+</code>
+</example>
+
+</examples>
+
+<verification_checklist>
+
+Before claiming epic execution is complete:
+- [ ] Phase 0 reconstructs full state from bd/tm on every wake-up (no session variables)
+- [ ] Exactly one task processed per turn via Agent subagent dispatch
+- [ ] ScheduleWakeup used for continuation (never stop hooks or sentinels)
+- [ ] Watchdog task created with deferred status (never selected by tm ready)
+- [ ] No-progress counter only increments on zero SHA drift, resets to 0 on genuine progress
+- [ ] Phase 4 cap (max 2 consecutive re-entries) enforced, stops and alerts user when exceeded
+- [ ] Quick-review Critical/High findings block Phase 4 entry and route back to task loop
+- [ ] Partial-progress tasks (non-closed with SHA drift) skip Phase 3 review
+- [ ] Dual final gate requires both APPROVED (autonomous-reviewer + review-implementation)
+- [ ] Phase 5 calls finishing-a-development-branch, no ScheduleWakeup after completion
+
+</verification_checklist>

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -130,7 +130,7 @@ If already on a feature branch, continue.
 
 **Watchdog counter recovery:**
 ```bash
-tm list --type chore --status open | grep "LOOP-WATCHDOG: bd-EPIC"
+tm list --type chore | grep "LOOP-WATCHDOG: bd-EPIC"
 ```
 If a watchdog task exists, read its no-progress counter from the title:
 ```bash
@@ -142,10 +142,11 @@ Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
 
 If `cycles >= 50` or `phase4 >= 2` (and entering Phase 4 again): STOP and alert user. Do NOT call ScheduleWakeup.
 
-If no watchdog task exists, create one:
+If no watchdog task exists, create one as deferred so it is never picked up by `tm ready` or `bv --robot-next`:
 ```bash
 tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
 tm dep add bd-WATCHDOG bd-EPIC --type parent-child
+tm update bd-WATCHDOG --status deferred
 ```
 
 → **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
@@ -294,7 +295,7 @@ Dispatch specialized reviews **in parallel** via Agent tool:
 2. **security-scanner** -- OWASP, secrets, CVEs
 3. **test-effectiveness-analyst** -- tautological tests, coverage gaming
 
-If any issues found, create remediation task, increment watchdog counters, and call ScheduleWakeup:
+If any issues found, create remediation task and check watchdog counters:
 ```bash
 # Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
@@ -305,12 +306,14 @@ NEW_PHASE4=$((PHASE4 + 1))
 # Enforce phase4 cap
 if [ "$NEW_PHASE4" -ge 2 ]; then
   echo "Phase 4 re-entry limit reached. STOP and alert user."
-  # Do NOT call ScheduleWakeup
+  # Do NOT call ScheduleWakeup -- STOP here
 else
   tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
-  # Call ScheduleWakeup below
+  # Only call ScheduleWakeup when NOT capped
 fi
 ```
+
+If Phase 4 cap NOT reached, call ScheduleWakeup:
 ```
 ScheduleWakeup({
   delaySeconds: 60,
@@ -318,7 +321,10 @@ ScheduleWakeup({
   prompt: "<<autonomous-loop-dynamic>>"
 })
 ```
-Then END TURN. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter; after 2 rounds with unresolved issues, STOP and alert user. Do NOT call ScheduleWakeup.
+
+If Phase 4 cap reached (phase4 >= 2): STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter.
+
+Then END TURN.
 
 **Final gate** -- dispatch in parallel:
 - **autonomous-reviewer**: return APPROVED or GAPS_FOUND

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -246,7 +246,14 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+    ```bash
+    WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+    CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+    NEW_CYCLES=$((CYCLES + 1))
+    PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+    tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
+    ```
     ```text
     ScheduleWakeup({
       delaySeconds: 60,
@@ -301,7 +308,14 @@ tm show bd-EPIC   # re-read success criteria
 
 **A) ALL criteria are met** --> EXIT TASK LOOP. Proceed to Phase 4 (End-of-Epic Review).
 
-**B) Criteria remain unmet AND tasks exist (ready or can be created)** --> CONTINUE LOOP. Call ScheduleWakeup:
+**B) Criteria remain unmet AND tasks exist (ready or can be created)** --> CONTINUE LOOP.
+First, if the task completed successfully (STATUS == "closed" with SHA drift), reset the no-progress counter since genuine progress was made:
+```bash
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
+```
+Then call ScheduleWakeup:
 ```text
 ScheduleWakeup({
   delaySeconds: 60,
@@ -309,21 +323,13 @@ ScheduleWakeup({
   prompt: "<<autonomous-loop-dynamic>>"
 })
 ```
-Then END TURN. The next wake-up will enter Phase 0 and process the next task.
+END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 **C) Critical blocker** --> Alert user with findings. Do NOT call ScheduleWakeup. Loop terminates.
 
 **CRITICAL: Task list exhaustion alone is NEVER a stop condition.** If no ready or in-progress tasks exist and criteria are still unmet, Phase 0 will auto-create the next task on the next wake-up.
 
 Track max 50 no-progress remediation cycles across all phases. After 50, STOP and alert user. Do NOT call ScheduleWakeup.
-
-**Watchdog reset on verified task progress:**
-If the task completed successfully (STATUS == "closed" with SHA drift), reset the no-progress counter since genuine progress was made:
-```bash
-WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
-PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
-```
 
 **Watchdog increment (remediation only -- retry or review failure):**
 Only increment the cycles counter when a task did NOT make progress (retry path, hallucinated completion, or review found Critical/High issues). Do NOT increment after successful task completions even if criteria remain unmet.

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -246,7 +246,15 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and proceed to Phase 3 criteria check.
+  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+    ```text
+    ScheduleWakeup({
+      delaySeconds: 60,
+      reason: "Task bd-N deferred after retry exhaustion, returning to Phase 0 for next task",
+      prompt: "<<autonomous-loop-dynamic>>"
+    })
+    ```
+    END TURN. Phase 0 will select a different ready task or check epic completion.
 - **Failure (Closed but no SHA drift on implementation task)**:
   - If `STATUS == "closed"` and `POST_SHA == PRE_SHA` for an implementation task (feature/bug/task/chore type), flag as hallucinated completion and STOP. Do NOT call ScheduleWakeup.
 
@@ -257,6 +265,8 @@ STATUS=$(tm show bd-N --json | jq -r .status)
 ## Phase 3: Post-Task Verification & Criteria Check
 
 ### Quick review
+
+Only run if the task from Phase 2 was successfully closed (`STATUS == "closed"`). If the task was deferred or left in-progress, skip directly to criteria check below.
 
 Dispatch `autonomous-reviewer` agent for the completed task.
 

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -96,10 +96,23 @@ bv --robot-triage || (tm ready && tm list)
 ```
 **Health gate:** If dependency cycles exist, alert user and stop. Do NOT call ScheduleWakeup.
 
+**Epic recovery (watchdog-first):**
+Recover the active epic ID from the watchdog task BEFORE listing epics. This prevents picking the wrong epic when multiple are open:
+```bash
+tm list --type chore | grep "LOOP-WATCHDOG:"
+```
+If a watchdog task exists, extract the epic ID from its title:
+```bash
+# Title format: LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N
+# Extract bd-EPIC from the title to identify the active epic
+```
+Set `bd-EPIC` to the epic ID from the watchdog title. This is the authoritative anchor for which epic this loop is executing.
+
+If NO watchdog task exists (first run), list epics and select:
 ```bash
 tm list --type epic --status open
 ```
-Identify the active epic. If no epic exists, alert user and stop.
+Identify the active epic. If no epic exists, alert user and stop. If multiple epics exist, select the one matching the current feature branch.
 
 ```bash
 tm show bd-EPIC
@@ -129,10 +142,7 @@ git checkout -b "feature/${BRANCH_NAME}"
 If already on a feature branch, continue.
 
 **Watchdog counter recovery:**
-```bash
-tm list --type chore | grep "LOOP-WATCHDOG: bd-EPIC"
-```
-If a watchdog task exists, read its no-progress counter from the title:
+If watchdog was found above, read its counters (already extracted epic ID):
 ```bash
 tm show bd-WATCHDOG --json | jq -r .title
 ```
@@ -142,7 +152,7 @@ Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
 
 If `cycles >= 50` or `phase4 >= 2` (and entering Phase 4 again): STOP and alert user. Do NOT call ScheduleWakeup.
 
-If no watchdog task exists, create one as deferred so it is never picked up by `tm ready` or `bv --robot-next`:
+If no watchdog task exists (first run, after epic selection above), create one as deferred so it is never picked up by `tm ready` or `bv --robot-next`:
 ```bash
 tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
 tm dep add bd-WATCHDOG bd-EPIC --type parent-child

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -1,0 +1,420 @@
+---
+name: codex-skill-execute-ralph-cc
+description: "Use when the original skill 'execute-ralph-cc' applies. Execute entire bd epic autonomously via ScheduleWakeup task-per-turn loop. Claude Code only. No stop hooks. One task per turn, state recovered from bd/tm on each wake-up."
+---
+
+<!-- Generated from skills/execute-ralph-cc/SKILL.md -->
+
+```mermaid
+flowchart TD
+    W([ScheduleWakeup fires]) --> P0[Phase 0: State Recovery]
+    P0 -->|in-progress or ready task| P1[Phase 1: Get Task + Refine]
+    P0 -->|all criteria met| P4[Phase 4: End-of-Epic Review]
+    P0 -->|no task, criteria unmet| P1
+    P1 --> P2[Phase 2: Dispatch Subagent]
+    P2 --> P3[Phase 3: Verify + Criteria Check]
+    P3 -->|criteria unmet| SW1[ScheduleWakeup 60s]
+    SW1 --> W
+    P3 -->|all criteria met| P4
+    P4 -->|issues found| SW2[ScheduleWakeup 60s]
+    SW2 --> W
+    P4 -->|both APPROVED| P5[Phase 5: Branch Completion]
+    P5 --> E([Done - no ScheduleWakeup])
+```
+
+<skill_overview>
+Execute a complete epic autonomously using Claude Code's native ScheduleWakeup tool. Each turn processes exactly one task via Agent subagent dispatch. After each task, if epic criteria remain unmet, calls ScheduleWakeup(60s) to schedule the next wake-up. On wake-up, re-enters Phase 0 which reconstructs all state from bd/tm. End-of-epic: 3 specialized reviews in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch. No stop hooks or sentinel protocol.
+</skill_overview>
+
+<rigidity_level>
+STRICT - Follow the five-phase flow exactly. Epic requirements are immutable. Never ask the user for confirmation. Use ScheduleWakeup for continuation, never stop hooks.
+</rigidity_level>
+
+<quick_reference>
+
+| Phase | Action | Outcome |
+|-------|--------|---------|
+| **0. State Recovery** | Read bd/tm state, determine path | Ready to work |
+| **1. Get Task** | Claim ready / resume in-progress / auto-create | Task identified |
+| **2. Dispatch Subagent** | Agent tool runs task end-to-end | Task done or retried |
+| **3. Post-Task Check** | Verify + criteria check | ScheduleWakeup or Phase 4 |
+| **4. End-of-Epic Review** | 3 reviews + final gate (both must APPROVED) | Epic validated or remediation |
+| **5. Branch Completion** | finishing-a-development-branch | Epic closed |
+
+</quick_reference>
+
+## ScheduleWakeup Loop Contract
+
+This skill uses `ScheduleWakeup` for continuation instead of stop hooks or sentinels.
+
+**Continuation points** (call ScheduleWakeup):
+
+| Location | Condition | delaySeconds |
+|----------|-----------|-------------|
+| End of Phase 3 | Task completed, criteria still unmet | 60 |
+| End of Phase 4 | Reviews found issues, remediation needed | 60 |
+| End of Phase 4 | Final gate non-approval | 60 |
+
+**Termination** (do NOT call ScheduleWakeup):
+
+| Location | Condition |
+|----------|-----------|
+| After Phase 4 | Both reviewers APPROVED, proceed to Phase 5 |
+| After Phase 5 | Branch complete, present summary |
+
+**Call template:**
+```
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+
+The `prompt` parameter `<<autonomous-loop-dynamic>>` is resolved by the runtime to autonomous loop instructions on wake-up, causing re-entry into this skill's Phase 0.
+
+**This variant does NOT use or depend on RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED sentinels.** The loop is entirely managed by ScheduleWakeup. Do not emit sentinel markers.
+
+<when_to_use>
+
+**Use when:** Running in Claude Code, epic is well-defined, user trusts autonomous execution, tasks are implementation work.
+**Do NOT use when:** Running in OpenCode/Gemini/Kimi (use execute-ralph instead), ambiguous requirements (use execute-plan), needs human oversight per task, exploratory work.
+
+</when_to_use>
+
+<the_process>
+
+**CRITICAL: TUI Dashboard Updates (If Supported)**
+If the `update_ralph_state` tool is available in your environment, use it to keep the live TUI dashboard updated during this turn. If NOT available (e.g. running in Claude Code without the Pi extension), ignore this requirement.
+
+## Phase 0: State Recovery (every wake-up entry point)
+
+This phase runs at the start of EVERY turn. It reconstructs all context from bd/tm.
+
+```bash
+bv --robot-triage || (tm ready && tm list)
+```
+**Health gate:** If dependency cycles exist, alert user and stop. Do NOT call ScheduleWakeup.
+
+```bash
+tm list --type epic --status open
+```
+Identify the active epic. If no epic exists, alert user and stop.
+
+```bash
+tm show bd-EPIC
+```
+Load epic requirements, success criteria (immutable), and anti-patterns.
+
+```bash
+tm list --status in_progress
+tm ready
+```
+
+Determine the path:
+- **A) In-progress task exists** -- resume it, proceed to Phase 1.
+- **B) Ready task exists** -- claim it: `tm update bd-N --status in_progress`, proceed to Phase 1.
+- **C) All criteria met and no in-progress tasks** -- proceed to Phase 4 (end-of-epic review).
+- **D) No tasks, criteria unmet** -- auto-create next task (see Phase 1), proceed to Phase 1.
+
+**Branch check:**
+```bash
+git branch --show-current
+```
+If on main/default branch, create feature branch:
+```bash
+BRANCH_NAME=$(echo "[epic-title]" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-')
+git checkout -b "feature/${BRANCH_NAME}"
+```
+If already on a feature branch, continue.
+
+→ **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
+
+---
+
+## Phase 1: Get Task & Refine
+
+This phase handles task selection, claiming, and refinement.
+
+### Task selection
+
+If arriving from Phase 0 path A (in-progress task):
+- The task is already claimed. Proceed to refinement.
+
+If arriving from Phase 0 path B (ready task):
+```bash
+tm update bd-N --status in_progress
+```
+
+If arriving from Phase 0 path D (auto-create):
+```bash
+tm create "Task: [criterion gap]" --type feature --priority 1 \
+  --design "## Goal\n[Close unmet criterion]\n## Success Criteria\n- [ ] Gap closed"
+tm dep add bd-NEW bd-EPIC --type parent-child
+tm update bd-NEW --status in_progress
+```
+
+### Refinement
+
+```bash
+tm show bd-N
+```
+
+Run SRE refinement on the selected task:
+Use Skill tool: `xpowers:sre-task-refinement` (prefer Opus 4.1 model)
+
+AFTER SRE REFINEMENT RETURNS: You are in execute-ralph-cc Phase 1. Proceed to Phase 2 (Dispatch Subagent). Do NOT stop. Do NOT present checkpoint.
+
+→ **CONTINUATION:** Phase 1 complete. Task identified and refined. Proceed to Phase 2.
+
+---
+
+## Phase 2: Dispatch Subagent
+
+Load full task context:
+```bash
+tm show bd-EPIC    # epic requirements
+tm show bd-N       # task design
+```
+
+**Before dispatching**, record current HEAD:
+```bash
+PRE_SHA=$(git rev-parse HEAD)
+```
+
+**Launch Agent tool** using the canonical 'Dispatch Protocol' from `subagent-driven-development`.
+
+### Subagent Prompt
+Use the **Subagent Prompt Template** from `subagent-driven-development` skill, populating:
+- **Immutable Epic Requirements**: from `tm show bd-EPIC` wrapped in `<epic_contract>` tags.
+- **Task Specification (bd-N)**: from `tm show bd-N` wrapped in `<task_spec>` tags.
+- **Mandatory Workflow**: Ensure `sre-task-refinement` and TDD are mandated.
+
+**After Agent returns**, verify progress:
+```bash
+POST_SHA=$(git rev-parse HEAD)
+TASK_TYPE=$(tm show bd-N --json | jq -r .type)
+STATUS=$(tm show bd-N --json | jq -r .status)
+```
+
+- **Success**:
+  - Require `STATUS == "closed"`.
+  - **Implementation Tasks** (feature, bug, task, chore): MUST have `POST_SHA != PRE_SHA`.
+  - **Analytical Tasks**: Accepted as success even if `POST_SHA == PRE_SHA` as long as status is `closed`.
+  - Proceed to Phase 3.
+- **Turn Limit Hit (Open but Changed)**:
+  - If `STATUS == "open"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. This is OK -- the next wake-up will find it as in-progress and resume from Phase 0. Proceed to Phase 3 criteria check.
+- **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
+  - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
+  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and proceed to Phase 3 criteria check.
+- **Failure (Closed but no SHA drift on implementation task)**:
+  - If `STATUS == "closed"` and `POST_SHA == PRE_SHA` for an implementation task (feature/bug/task/chore type), flag as hallucinated completion and STOP. Do NOT call ScheduleWakeup.
+
+→ **CONTINUATION:** Phase 2 complete. Subagent dispatched and verified. Proceed to Phase 3.
+
+---
+
+## Phase 3: Post-Task Verification & Criteria Check
+
+### Quick review
+
+Dispatch `autonomous-reviewer` agent for the completed task.
+
+**Remediation Path**:
+If the review finds **Critical** or **High** issues:
+- Create remediation task: `tm create "Remediation: [Findings]" --parent bd-EPIC`.
+- This will be picked up on the next wake-up cycle.
+
+### Criteria check
+
+```bash
+tm show bd-EPIC   # re-read success criteria
+```
+
+**This is the loop decision point.**
+
+**A) ALL criteria are met** --> EXIT TASK LOOP. Proceed to Phase 4 (End-of-Epic Review).
+
+**B) Criteria remain unmet AND tasks exist (ready or can be created)** --> CONTINUE LOOP. Call ScheduleWakeup:
+```
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+Then END TURN. The next wake-up will enter Phase 0 and process the next task.
+
+**C) Critical blocker** --> Alert user with findings. Do NOT call ScheduleWakeup. Loop terminates.
+
+**CRITICAL: Task list exhaustion alone is NEVER a stop condition.** If no ready or in-progress tasks exist and criteria are still unmet, Phase 0 will auto-create the next task on the next wake-up.
+
+Track max 50 no-progress remediation cycles across all phases. After 50, STOP and alert user. Do NOT call ScheduleWakeup.
+
+→ **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.
+→ **CONTINUATION (criteria met):** Proceed to Phase 4 (End-of-Epic Review).
+
+---
+
+## Phase 4: End-of-Epic Review (single turn)
+
+Dispatch specialized reviews **in parallel** via Agent tool:
+
+1. **review-quality** -- bugs, race conditions, error handling
+2. **security-scanner** -- OWASP, secrets, CVEs
+3. **test-effectiveness-analyst** -- tautological tests, coverage gaming
+
+If any issues found, create remediation task and call ScheduleWakeup:
+```
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "End-of-epic review found issues, remediation task created for epic bd-EPIC",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+Then END TURN. Max 2 consecutive Phase 4 re-entries; after 2 rounds with unresolved issues, STOP and alert user. Do NOT call ScheduleWakeup.
+
+**Final gate** -- dispatch in parallel:
+- **autonomous-reviewer**: return APPROVED or GAPS_FOUND
+- **review-implementation**: return PASS or ISSUES_FOUND
+
+### Verdict Normalization Matrix
+
+- PASS, APPROVED -> continue or close path
+- NEEDS_FIX, ISSUES_FOUND, GAPS_FOUND, CRITICAL_ISSUES -> remediation path
+- Unknown or malformed verdict -> remediation path (never auto-approve)
+- Mixed final reviewer outputs -> remediation path (no epic close).
+
+Mixed final reviewer outputs are non-approval.
+Do not close the epic unless both final reviewers return an approval verdict.
+Unknown or malformed verdict must create a remediation task and continue the loop.
+
+Non-approval --> create remediation task, call ScheduleWakeup:
+```
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Final gate non-approval for epic bd-EPIC, remediation task created",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+Then END TURN. Max 50 overall no-progress remediation cycles across all phases.
+
+Only close epic when BOTH final reviewers approve.
+
+→ **CONTINUATION (both APPROVED):** Proceed to Phase 5 (Branch Completion).
+→ **CONTINUATION (non-approval):** Call ScheduleWakeup(60s). END TURN.
+
+---
+
+## Phase 5: Branch Completion
+
+**Quality Gate Sequence** -- run these BEFORE branch completion:
+```bash
+set -e
+node --test tests/execute-ralph-contract.test.js
+node --test tests/execute-ralph-cc-contract.test.js
+node --test tests/codex-*.test.js
+node --test tests/*.test.js
+node scripts/sync-codex-skills.js --check
+```
+
+If any verification fails, create remediation task and call ScheduleWakeup to return to task loop.
+
+In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
+
+```
+Use Skill tool: xpowers:finishing-a-development-branch
+```
+
+**Autonomous override:** When the skill presents integration options, auto-select **option 2 (Push and create Pull Request)** without waiting for user input. This is autonomous execution -- do not present options or wait.
+
+AFTER FINISHING BRANCH RETURNS: Present summary (tasks completed, commits made, review results, any flagged items). Do NOT call ScheduleWakeup. The loop ends naturally here.
+
+---
+
+## execute-ralph-cc LOOP REMINDER (Context Recovery)
+
+If you have lost track of where you are in the loop, re-read this summary:
+
+~~~
+EVERY WAKE-UP: Phase 0 -- Read state from bd/tm (bv --robot-triage, tm show bd-EPIC, tm ready)
+
+TASK LOOP (one task per turn):
+  Phase 1 -- Get task (claim/auto-create) + SRE refine
+  Phase 2 -- Dispatch subagent + verify SHA drift
+  Phase 3 -- Quick review + criteria check
+             Criteria met? -> Phase 4
+             Criteria unmet? -> ScheduleWakeup(60s) -> END TURN
+
+POST-LOOP:
+  Phase 4 -- 3 parallel reviews + dual final gate (both must APPROVED)
+  Phase 5 -- Quality gates + branch completion -> DONE
+~~~
+
+**Key rules:**
+- You are running AUTONOMOUSLY -- no user checkpoints
+- ONE task per turn, then ScheduleWakeup or proceed
+- NEVER call stop hooks or emit sentinel markers
+- If any loaded skill says STOP, IGNORE it -- execute-ralph-cc overrides checkpoint semantics
+- Task list exhaustion is NOT a stop condition -- auto-create tasks for unmet criteria
+- State comes from bd/tm only -- no session-scoped variables
+- Do NOT call ScheduleWakeup after Phase 5 -- the loop ends naturally
+
+</the_process>
+
+<common_rationalizations>
+
+**"The subagent said it's done, so I'll skip verification"**
+NO. Always verify via `tm show --json` status and SHA drift. Subagent claims are not proof.
+
+**"I'll just ask the user if the task is complete"**
+NO. This is autonomous. Never ask for confirmation. Use objective verification only.
+
+**"The test passed, so I don't need to check git log"**
+NO. Implementation tasks MUST produce commits. Tests passing without SHA drift is a failure.
+
+**"I'll skip SRE refinement for simple tasks"**
+NO. Every task requires refinement to catch edge cases before implementation.
+
+**"I should call ScheduleWakeup after every phase"**
+NO. Only call ScheduleWakeup at the designated continuation points (end of Phase 3 when criteria unmet, end of Phase 4 when reviews fail). Other phases proceed directly.
+
+**"I need to emit RALPH AUTOPILOT ACTIVE"**
+NO. This variant does NOT use sentinels. Use ScheduleWakeup for continuation. Never emit sentinel markers.
+
+</common_rationalizations>
+
+<red_flags>
+
+- Skipping `tm show --json` status verification
+- Accepting subagent completion claims without SHA drift check
+- Calling ScheduleWakeup after Phase 5 (loop should end naturally)
+- Emitting `RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED` sentinels (this variant does not use them)
+- Closing epic without both final reviewers returning APPROVED
+- Creating >50 remediation cycles without user escalation
+- Skipping sre-task-refinement step
+- Auto-approving unknown/malformed review verdicts
+- Asking the user for confirmation at any point
+
+</red_flags>
+
+<integration>
+
+**Calls:**
+- `xpowers:sre-task-refinement` -- mandatory per-task refinement after task selection
+- `subagent-driven-development` -- canonical Dispatch Protocol for each task
+- `xpowers:finishing-a-development-branch` -- final branch completion
+- Agent tool with specialized reviewers: review-quality, security-scanner, test-effectiveness-analyst, autonomous-reviewer, review-implementation
+
+**Called by:**
+- User when epic is well-defined and autonomous execution is desired IN CLAUDE CODE
+- Should not be called for OpenCode/Gemini/Kimi (use execute-ralph instead)
+- Should not be called for ambiguous requirements (use execute-plans instead)
+
+**Prerequisites:**
+- Running in Claude Code
+- Epic must have clear success criteria
+- Tasks should be implementation-focused
+- User must trust autonomous execution
+
+</integration>

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -272,14 +272,22 @@ Then END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 Track max 50 no-progress remediation cycles across all phases. After 50, STOP and alert user. Do NOT call ScheduleWakeup.
 
-**Watchdog increment (criteria unmet, looping back):**
+**Watchdog reset on verified task progress:**
+If the task completed successfully (STATUS == "closed" with SHA drift), reset the no-progress counter since genuine progress was made:
 ```bash
-# Read current counter
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
+```
+
+**Watchdog increment (remediation only -- retry or review failure):**
+Only increment the cycles counter when a task did NOT make progress (retry path, hallucinated completion, or review found Critical/High issues). Do NOT increment after successful task completions even if criteria remain unmet.
+```bash
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
-# Update watchdog task title
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)"
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
 ```
 
 → **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -101,14 +101,15 @@ Recover the active epic ID from the watchdog task BEFORE listing epics. This pre
 ```bash
 tm list --type chore | grep "LOOP-WATCHDOG:"
 ```
-If a watchdog task exists, extract the epic ID from its title:
+If a watchdog task exists, extract the epic ID from its title and verify the epic is still open:
 ```bash
 # Title format: LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N
 # Extract bd-EPIC from the title to identify the active epic
+tm show bd-EPIC --json | jq -r .status
 ```
-Set `bd-EPIC` to the epic ID from the watchdog title. This is the authoritative anchor for which epic this loop is executing.
+If the epic is still open (not closed/done), set `bd-EPIC` from the watchdog. If the epic is closed (stale watchdog from a previous run), ignore it and fall through to epic listing.
 
-If NO watchdog task exists (first run), list epics and select:
+If NO watchdog task exists (or watchdog is stale), list epics and select:
 ```bash
 tm list --type epic --status open
 ```
@@ -432,6 +433,11 @@ Use Skill tool: xpowers:finishing-a-development-branch
 
 AFTER FINISHING BRANCH RETURNS: Present summary (tasks completed, commits made, review results, any flagged items). Do NOT call ScheduleWakeup. The loop ends naturally here.
 
+**Watchdog cleanup:** Close the watchdog task so stale state never confuses future runs:
+```bash
+tm close bd-WATCHDOG --reason="Epic bd-EPIC completed successfully"
+```
+
 ---
 
 ## execute-ralph-cc LOOP REMINDER (Context Recovery)
@@ -463,6 +469,20 @@ POST-LOOP:
 - Do NOT call ScheduleWakeup after Phase 5 -- the loop ends naturally
 
 </the_process>
+
+<critical_rules>
+
+- Never use stop hooks or sentinel markers in this variant. Use ScheduleWakeup only.
+- Never ask for user confirmation or checkpoints during autonomous loop execution.
+- Process exactly one task per turn, then either ScheduleWakeup or proceed by phase contract.
+- Reconstruct all state from bd/tm on every wake-up. Do not rely on session memory.
+- Do not close the epic unless autonomous-reviewer=APPROVED and review-implementation=PASS.
+- Verify task completion via SHA drift (`git rev-parse HEAD`), never trust subagent claims alone.
+- Every task requires SRE refinement before implementation. No exceptions for "simple" tasks.
+- Max 50 no-progress remediation cycles (watchdog) and max 2 consecutive Phase 4 re-entries.
+- Close the watchdog task on successful epic completion to prevent stale state in future runs.
+
+</critical_rules>
 
 <common_rationalizations>
 

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -38,7 +38,7 @@ STRICT - Follow the six-phase flow exactly. Epic requirements are immutable. Nev
 | **1. Get Task** | Claim ready / resume in-progress / auto-create | Task identified |
 | **2. Dispatch Subagent** | Agent tool runs task end-to-end | Task done or retried |
 | **3. Post-Task Check** | Verify + criteria check | ScheduleWakeup or Phase 4 |
-| **4. End-of-Epic Review** | 3 reviews + final gate (both must return APPROVED) | Epic validated or remediation |
+| **4. End-of-Epic Review** | 3 reviews + final gate (autonomous-reviewer=APPROVED + review-implementation=PASS) | Epic validated or remediation |
 | **5. Branch Completion** | finishing-a-development-branch | Epic closed |
 
 </quick_reference>
@@ -107,13 +107,13 @@ tm show bd-EPIC
 Load epic requirements, success criteria (immutable), and anti-patterns.
 
 ```bash
-tm list --status in_progress
-tm ready
+tm list --status in_progress --parent bd-EPIC
+tm dep tree bd-EPIC  # show ready tasks scoped to this epic
 ```
 
 Determine the path:
-- **A) In-progress task exists** -- resume it, proceed to Phase 1.
-- **B) Ready task exists** -- claim it: `tm update bd-N --status in_progress`, proceed to Phase 1.
+- **A) In-progress task exists (child of bd-EPIC)** -- resume it, proceed to Phase 1.
+- **B) Ready task exists (child of bd-EPIC)** -- claim it: `tm update bd-N --status in_progress`, proceed to Phase 1.
 - **C) All criteria met and no in-progress tasks** -- proceed to Phase 4 (end-of-epic review).
 - **D) No tasks, criteria unmet** -- auto-create next task (see Phase 1), proceed to Phase 1.
 
@@ -252,6 +252,14 @@ Dispatch `autonomous-reviewer` agent for the completed task.
 **Remediation Path**:
 If the review finds **Critical** or **High** issues:
 - Create remediation task: `tm create "Remediation: [Findings]" --parent bd-EPIC`.
+- **Increment watchdog counter** (review failure is a no-progress cycle):
+```bash
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
+```
 - **Do NOT proceed to Phase 4 even if criteria appear met.** Call ScheduleWakeup to return to Phase 0, which will pick up the new remediation task:
 ```text
 ScheduleWakeup({
@@ -519,7 +527,7 @@ Phase 0 (first wake-up):
 
 Phase 1:
   tm update bd-43 --status in_progress
-  # SRE refinement on bd-43
+  \# SRE refinement on bd-43
   Agent(subagent-driven-development, task=bd-43)
 
 Phase 2:
@@ -613,7 +621,7 @@ Before claiming epic execution is complete:
 - [ ] Phase 4 cap (max 2 consecutive re-entries) enforced, stops and alerts user when exceeded
 - [ ] Quick-review Critical/High findings block Phase 4 entry and route back to task loop
 - [ ] Partial-progress tasks (non-closed with SHA drift) skip Phase 3 review
-- [ ] Dual final gate requires both APPROVED (autonomous-reviewer + review-implementation)
+- [ ] Dual final gate requires autonomous-reviewer=APPROVED and review-implementation=PASS
 - [ ] Phase 5 calls finishing-a-development-branch, no ScheduleWakeup after completion
 
 </verification_checklist>

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -246,7 +246,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git reset --hard HEAD && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+  - If retry also fails, clean worktree (`git reset HEAD && git checkout . && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
     ```bash
     WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
     CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -402,6 +402,7 @@ Unknown or malformed verdict must create a remediation task and continue the loo
 
 Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
 ```bash
+tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" --parent bd-EPIC
 # Increment cycle counter (keep phase4 since remediation will re-enter Phase 4)
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -66,12 +66,12 @@ This skill uses `ScheduleWakeup` for continuation instead of stop hooks or senti
 ```text
 ScheduleWakeup({
   delaySeconds: 60,
-  reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
-  prompt: "<<autonomous-loop-dynamic>>"
+  reason: "<descriptive reason referencing bd-EPIC and current phase>",
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 
-The `prompt` parameter `<<autonomous-loop-dynamic>>` is resolved by the runtime to autonomous loop instructions on wake-up, causing re-entry into this skill's Phase 0.
+The `prompt` parameter contains concrete Phase 0 re-entry instructions so the wake-up always knows how to resume regardless of runtime sentinel support.
 
 **This variant does NOT use or depend on RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED sentinels.** The loop is entirely managed by ScheduleWakeup. Do not emit sentinel markers.
 
@@ -240,7 +240,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   ScheduleWakeup({
     delaySeconds: 60,
     reason: "Task bd-N partial progress (turn limit hit), resuming in Phase 0",
-    prompt: "<<autonomous-loop-dynamic>>"
+    prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
   })
   ```
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
@@ -258,7 +258,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
     ScheduleWakeup({
       delaySeconds: 60,
       reason: "Task bd-N deferred after retry exhaustion, returning to Phase 0 for next task",
-      prompt: "<<autonomous-loop-dynamic>>"
+      prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
     })
     ```
     END TURN. Phase 0 will select a different ready task or check epic completion.
@@ -293,7 +293,7 @@ tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Quick review found Critical/High issues, remediation task created for epic bd-EPIC",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 END TURN. The remediation task must be completed before entering Phase 4.
@@ -320,7 +320,7 @@ Then call ScheduleWakeup:
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 END TURN. The next wake-up will enter Phase 0 and process the next task.
@@ -377,7 +377,7 @@ If Phase 4 cap NOT reached, call ScheduleWakeup:
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "End-of-epic review found issues, remediation task created for epic bd-EPIC",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 
@@ -413,7 +413,7 @@ tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Final gate non-approval for epic bd-EPIC, remediation task created",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
@@ -450,7 +450,7 @@ tm create "Remediation: Phase 5 quality gate failure" --parent bd-EPIC
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Phase 5 quality gate failed for epic bd-EPIC, remediation task created",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 END TURN. Do NOT proceed to branch completion with failing verification.
@@ -599,7 +599,7 @@ Phase 2:
 Phase 3:
   POST_SHA != PRE_SHA → genuine progress
   bv --robot-triage bd-42 → criteria NOT all met
-  ScheduleWakeup(60s, "<<autonomous-loop-dynamic>>")
+  ScheduleWakeup(60s, "Continue execute-ralph-cc. Phase 0: run bv --robot-triage, find active epic, read tasks from bd/tm.")
 
 [... 2 more task cycles for bd-44, bd-45 ...]
 

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -27,7 +27,7 @@ Execute a complete epic autonomously using Claude Code's native ScheduleWakeup t
 </skill_overview>
 
 <rigidity_level>
-STRICT - Follow the five-phase flow exactly. Epic requirements are immutable. Never ask the user for confirmation. Use ScheduleWakeup for continuation, never stop hooks.
+STRICT - Follow the six-phase flow exactly. Epic requirements are immutable. Never ask the user for confirmation. Use ScheduleWakeup for continuation, never stop hooks.
 </rigidity_level>
 
 <quick_reference>
@@ -38,7 +38,7 @@ STRICT - Follow the five-phase flow exactly. Epic requirements are immutable. Ne
 | **1. Get Task** | Claim ready / resume in-progress / auto-create | Task identified |
 | **2. Dispatch Subagent** | Agent tool runs task end-to-end | Task done or retried |
 | **3. Post-Task Check** | Verify + criteria check | ScheduleWakeup or Phase 4 |
-| **4. End-of-Epic Review** | 3 reviews + final gate (both must APPROVED) | Epic validated or remediation |
+| **4. End-of-Epic Review** | 3 reviews + final gate (both must return APPROVED) | Epic validated or remediation |
 | **5. Branch Completion** | finishing-a-development-branch | Epic closed |
 
 </quick_reference>
@@ -128,6 +128,26 @@ git checkout -b "feature/${BRANCH_NAME}"
 ```
 If already on a feature branch, continue.
 
+**Watchdog counter recovery:**
+```bash
+tm list --type chore --status open | grep "LOOP-WATCHDOG: bd-EPIC"
+```
+If a watchdog task exists, read its no-progress counter from the title:
+```bash
+tm show bd-WATCHDOG --json | jq -r .title
+```
+Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
+- `cycles` = total no-progress remediation cycles (max 50)
+- `phase4` = consecutive Phase 4 re-entries (max 2)
+
+If `cycles >= 50` or `phase4 >= 2` (and entering Phase 4 again): STOP and alert user. Do NOT call ScheduleWakeup.
+
+If no watchdog task exists, create one:
+```bash
+tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
+tm dep add bd-WATCHDOG bd-EPIC --type parent-child
+```
+
 → **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
 
 ---
@@ -202,8 +222,8 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   - **Implementation Tasks** (feature, bug, task, chore): MUST have `POST_SHA != PRE_SHA`.
   - **Analytical Tasks**: Accepted as success even if `POST_SHA == PRE_SHA` as long as status is `closed`.
   - Proceed to Phase 3.
-- **Turn Limit Hit (Open but Changed)**:
-  - If `STATUS == "open"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. This is OK -- the next wake-up will find it as in-progress and resume from Phase 0. Proceed to Phase 3 criteria check.
+- **Turn Limit Hit (Open/In-Progress but Changed)**:
+  - If `STATUS` is not `"closed"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. This is OK -- the next wake-up will find it as in-progress and resume from Phase 0. Proceed to Phase 3 criteria check.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
   - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and proceed to Phase 3 criteria check.
@@ -251,6 +271,16 @@ Then END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 Track max 50 no-progress remediation cycles across all phases. After 50, STOP and alert user. Do NOT call ScheduleWakeup.
 
+**Watchdog increment (criteria unmet, looping back):**
+```bash
+# Read current counter
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+# Update watchdog task title
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)"
+```
+
 → **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.
 → **CONTINUATION (criteria met):** Proceed to Phase 4 (End-of-Epic Review).
 
@@ -264,7 +294,23 @@ Dispatch specialized reviews **in parallel** via Agent tool:
 2. **security-scanner** -- OWASP, secrets, CVEs
 3. **test-effectiveness-analyst** -- tautological tests, coverage gaming
 
-If any issues found, create remediation task and call ScheduleWakeup:
+If any issues found, create remediation task, increment watchdog counters, and call ScheduleWakeup:
+```bash
+# Increment both cycle and phase4 counters
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+NEW_PHASE4=$((PHASE4 + 1))
+# Enforce phase4 cap
+if [ "$NEW_PHASE4" -ge 2 ]; then
+  echo "Phase 4 re-entry limit reached. STOP and alert user."
+  # Do NOT call ScheduleWakeup
+else
+  tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
+  # Call ScheduleWakeup below
+fi
+```
 ```
 ScheduleWakeup({
   delaySeconds: 60,
@@ -272,7 +318,7 @@ ScheduleWakeup({
   prompt: "<<autonomous-loop-dynamic>>"
 })
 ```
-Then END TURN. Max 2 consecutive Phase 4 re-entries; after 2 rounds with unresolved issues, STOP and alert user. Do NOT call ScheduleWakeup.
+Then END TURN. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter; after 2 rounds with unresolved issues, STOP and alert user. Do NOT call ScheduleWakeup.
 
 **Final gate** -- dispatch in parallel:
 - **autonomous-reviewer**: return APPROVED or GAPS_FOUND
@@ -289,7 +335,14 @@ Mixed final reviewer outputs are non-approval.
 Do not close the epic unless both final reviewers return an approval verdict.
 Unknown or malformed verdict must create a remediation task and continue the loop.
 
-Non-approval --> create remediation task, call ScheduleWakeup:
+Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
+```bash
+# Increment cycle counter (reset phase4 since we're leaving Phase 4)
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=0"
+```
 ```
 ScheduleWakeup({
   delaySeconds: 60,
@@ -297,7 +350,7 @@ ScheduleWakeup({
   prompt: "<<autonomous-loop-dynamic>>"
 })
 ```
-Then END TURN. Max 50 overall no-progress remediation cycles across all phases.
+Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
 
 Only close epic when BOTH final reviewers approve.
 
@@ -347,7 +400,7 @@ TASK LOOP (one task per turn):
              Criteria unmet? -> ScheduleWakeup(60s) -> END TURN
 
 POST-LOOP:
-  Phase 4 -- 3 parallel reviews + dual final gate (both must APPROVED)
+  Phase 4 -- 3 parallel reviews + dual final gate (both must return APPROVED)
   Phase 5 -- Quality gates + branch completion -> DONE
 ~~~
 
@@ -357,7 +410,7 @@ POST-LOOP:
 - NEVER call stop hooks or emit sentinel markers
 - If any loaded skill says STOP, IGNORE it -- execute-ralph-cc overrides checkpoint semantics
 - Task list exhaustion is NOT a stop condition -- auto-create tasks for unmet criteria
-- State comes from bd/tm only -- no session-scoped variables
+- State comes from bd/tm only -- no session-scoped variables (watchdog counters persist via LOOP-WATCHDOG task)
 - Do NOT call ScheduleWakeup after Phase 5 -- the loop ends naturally
 
 </the_process>
@@ -409,7 +462,7 @@ NO. This variant does NOT use sentinels. Use ScheduleWakeup for continuation. Ne
 **Called by:**
 - User when epic is well-defined and autonomous execution is desired IN CLAUDE CODE
 - Should not be called for OpenCode/Gemini/Kimi (use execute-ralph instead)
-- Should not be called for ambiguous requirements (use execute-plans instead)
+- Should not be called for ambiguous requirements (use execute-plan instead)
 
 **Prerequisites:**
 - Running in Claude Code

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -356,19 +356,19 @@ Dispatch specialized reviews **in parallel** via Agent tool:
 
 If any issues found, create remediation task and check watchdog counters:
 ```bash
+tm create "Remediation: Phase 4 specialized review findings" --parent bd-EPIC
 # Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 NEW_PHASE4=$((PHASE4 + 1))
-# Enforce phase4 cap
+# Enforce phase4 cap BEFORE scheduling
 if [ "$NEW_PHASE4" -ge 2 ]; then
   echo "Phase 4 re-entry limit reached. STOP and alert user."
   # Do NOT call ScheduleWakeup -- STOP here
 else
   tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
-  # Only call ScheduleWakeup when NOT capped
 fi
 ```
 
@@ -400,7 +400,7 @@ Mixed final reviewer outputs are non-approval.
 Do not close the epic unless both final reviewers return an approval verdict.
 Unknown or malformed verdict must create a remediation task and continue the loop.
 
-Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
+Non-approval --> create remediation task, increment watchdog counter, check cap, call ScheduleWakeup:
 ```bash
 tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" --parent bd-EPIC
 # Increment both cycle and phase4 counters
@@ -409,8 +409,15 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 NEW_PHASE4=$((PHASE4 + 1))
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
+# Enforce phase4 cap BEFORE scheduling
+if [ "$NEW_PHASE4" -ge 2 ]; then
+  echo "Phase 4 re-entry limit reached. STOP and alert user."
+  # Do NOT call ScheduleWakeup -- STOP here
+else
+  tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
+fi
 ```
+If Phase 4 cap NOT reached:
 ```text
 ScheduleWakeup({
   delaySeconds: 60,
@@ -418,6 +425,7 @@ ScheduleWakeup({
   prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
+If Phase 4 cap reached (phase4 >= 2): STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates.
 Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
 
 Only close epic when BOTH final reviewers approve.

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -20,7 +20,7 @@ flowchart TD
     SW2 --> W
     P4 -->|both APPROVED| P5[Phase 5: Branch Completion]
     P5 --> E([Done - no ScheduleWakeup])
-```
+```text
 
 <skill_overview>
 Execute a complete epic autonomously using Claude Code's native ScheduleWakeup tool. Each turn processes exactly one task via Agent subagent dispatch. After each task, if epic criteria remain unmet, calls ScheduleWakeup(60s) to schedule the next wake-up. On wake-up, re-enters Phase 0 which reconstructs all state from bd/tm. End-of-epic: 3 specialized reviews in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch. No stop hooks or sentinel protocol.
@@ -63,13 +63,13 @@ This skill uses `ScheduleWakeup` for continuation instead of stop hooks or senti
 | After Phase 5 | Branch complete, present summary |
 
 **Call template:**
-```
+```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```
+```text
 
 The `prompt` parameter `<<autonomous-loop-dynamic>>` is resolved by the runtime to autonomous loop instructions on wake-up, causing re-entry into this skill's Phase 0.
 
@@ -93,23 +93,23 @@ This phase runs at the start of EVERY turn. It reconstructs all context from bd/
 
 ```bash
 bv --robot-triage || (tm ready && tm list)
-```
+```text
 **Health gate:** If dependency cycles exist, alert user and stop. Do NOT call ScheduleWakeup.
 
 ```bash
 tm list --type epic --status open
-```
+```text
 Identify the active epic. If no epic exists, alert user and stop.
 
 ```bash
 tm show bd-EPIC
-```
+```text
 Load epic requirements, success criteria (immutable), and anti-patterns.
 
 ```bash
 tm list --status in_progress
 tm ready
-```
+```text
 
 Determine the path:
 - **A) In-progress task exists** -- resume it, proceed to Phase 1.
@@ -120,22 +120,22 @@ Determine the path:
 **Branch check:**
 ```bash
 git branch --show-current
-```
+```text
 If on main/default branch, create feature branch:
 ```bash
 BRANCH_NAME=$(echo "[epic-title]" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-')
 git checkout -b "feature/${BRANCH_NAME}"
-```
+```text
 If already on a feature branch, continue.
 
 **Watchdog counter recovery:**
 ```bash
 tm list --type chore | grep "LOOP-WATCHDOG: bd-EPIC"
-```
+```text
 If a watchdog task exists, read its no-progress counter from the title:
 ```bash
 tm show bd-WATCHDOG --json | jq -r .title
-```
+```text
 Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
 - `cycles` = total no-progress remediation cycles (max 50)
 - `phase4` = consecutive Phase 4 re-entries (max 2)
@@ -147,7 +147,7 @@ If no watchdog task exists, create one as deferred so it is never picked up by `
 tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
 tm dep add bd-WATCHDOG bd-EPIC --type parent-child
 tm update bd-WATCHDOG --status deferred
-```
+```text
 
 → **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
 
@@ -165,7 +165,7 @@ If arriving from Phase 0 path A (in-progress task):
 If arriving from Phase 0 path B (ready task):
 ```bash
 tm update bd-N --status in_progress
-```
+```text
 
 If arriving from Phase 0 path D (auto-create):
 ```bash
@@ -173,13 +173,13 @@ tm create "Task: [criterion gap]" --type feature --priority 1 \
   --design "## Goal\n[Close unmet criterion]\n## Success Criteria\n- [ ] Gap closed"
 tm dep add bd-NEW bd-EPIC --type parent-child
 tm update bd-NEW --status in_progress
-```
+```text
 
 ### Refinement
 
 ```bash
 tm show bd-N
-```
+```text
 
 Run SRE refinement on the selected task:
 Use Skill tool: `xpowers:sre-task-refinement` (prefer Opus 4.1 model)
@@ -196,12 +196,12 @@ Load full task context:
 ```bash
 tm show bd-EPIC    # epic requirements
 tm show bd-N       # task design
-```
+```text
 
 **Before dispatching**, record current HEAD:
 ```bash
 PRE_SHA=$(git rev-parse HEAD)
-```
+```text
 
 **Launch Agent tool** using the canonical 'Dispatch Protocol' from `subagent-driven-development`.
 
@@ -216,7 +216,7 @@ Use the **Subagent Prompt Template** from `subagent-driven-development` skill, p
 POST_SHA=$(git rev-parse HEAD)
 TASK_TYPE=$(tm show bd-N --json | jq -r .type)
 STATUS=$(tm show bd-N --json | jq -r .status)
-```
+```text
 
 - **Success**:
   - Require `STATUS == "closed"`.
@@ -244,26 +244,34 @@ Dispatch `autonomous-reviewer` agent for the completed task.
 **Remediation Path**:
 If the review finds **Critical** or **High** issues:
 - Create remediation task: `tm create "Remediation: [Findings]" --parent bd-EPIC`.
-- This will be picked up on the next wake-up cycle.
+- **Do NOT proceed to Phase 4 even if criteria appear met.** Call ScheduleWakeup to return to Phase 0, which will pick up the new remediation task:
+```text
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Quick review found Critical/High issues, remediation task created for epic bd-EPIC",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+END TURN. The remediation task must be completed before entering Phase 4.
 
 ### Criteria check
 
 ```bash
 tm show bd-EPIC   # re-read success criteria
-```
+```text
 
 **This is the loop decision point.**
 
 **A) ALL criteria are met** --> EXIT TASK LOOP. Proceed to Phase 4 (End-of-Epic Review).
 
 **B) Criteria remain unmet AND tasks exist (ready or can be created)** --> CONTINUE LOOP. Call ScheduleWakeup:
-```
+```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```
+```text
 Then END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 **C) Critical blocker** --> Alert user with findings. Do NOT call ScheduleWakeup. Loop terminates.
@@ -278,7 +286,7 @@ If the task completed successfully (STATUS == "closed" with SHA drift), reset th
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
-```
+```text
 
 **Watchdog increment (remediation only -- retry or review failure):**
 Only increment the cycles counter when a task did NOT make progress (retry path, hallucinated completion, or review found Critical/High issues). Do NOT increment after successful task completions even if criteria remain unmet.
@@ -288,7 +296,7 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
-```
+```text
 
 → **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.
 → **CONTINUATION (criteria met):** Proceed to Phase 4 (End-of-Epic Review).
@@ -319,16 +327,16 @@ else
   tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
   # Only call ScheduleWakeup when NOT capped
 fi
-```
+```text
 
 If Phase 4 cap NOT reached, call ScheduleWakeup:
-```
+```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "End-of-epic review found issues, remediation task created for epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```
+```text
 
 If Phase 4 cap reached (phase4 >= 2): STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter.
 
@@ -356,14 +364,14 @@ WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=0"
-```
-```
+```text
+```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Final gate non-approval for epic bd-EPIC, remediation task created",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```
+```text
 Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
 
 Only close epic when BOTH final reviewers approve.
@@ -383,15 +391,15 @@ node --test tests/execute-ralph-cc-contract.test.js
 node --test tests/codex-*.test.js
 node --test tests/*.test.js
 node scripts/sync-codex-skills.js --check
-```
+```text
 
 If any verification fails, create remediation task and call ScheduleWakeup to return to task loop.
 
 In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
 
-```
+```text
 Use Skill tool: xpowers:finishing-a-development-branch
-```
+```text
 
 **Autonomous override:** When the skill presents integration options, auto-select **option 2 (Push and create Pull Request)** without waiting for user input. This is autonomous execution -- do not present options or wait.
 
@@ -403,7 +411,7 @@ AFTER FINISHING BRANCH RETURNS: Present summary (tasks completed, commits made, 
 
 If you have lost track of where you are in the loop, re-read this summary:
 
-~~~
+```text
 EVERY WAKE-UP: Phase 0 -- Read state from bd/tm (bv --robot-triage, tm show bd-EPIC, tm ready)
 
 TASK LOOP (one task per turn):
@@ -416,7 +424,7 @@ TASK LOOP (one task per turn):
 POST-LOOP:
   Phase 4 -- 3 parallel reviews + dual final gate (both must return APPROVED)
   Phase 5 -- Quality gates + branch completion -> DONE
-~~~
+```
 
 **Key rules:**
 - You are running AUTONOMOUSLY -- no user checkpoints

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -431,7 +431,23 @@ node --test tests/*.test.js
 node scripts/sync-codex-skills.js --check
 ```
 
-If any verification fails, create remediation task and call ScheduleWakeup to return to task loop.
+If any verification fails, create remediation task, increment watchdog counter, and call ScheduleWakeup to return to task loop:
+```bash
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
+tm create "Remediation: Phase 5 quality gate failure" --parent bd-EPIC
+```
+```text
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Phase 5 quality gate failed for epic bd-EPIC, remediation task created",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+END TURN. Do NOT proceed to branch completion with failing verification.
 
 In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
 

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -363,12 +363,12 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 NEW_PHASE4=$((PHASE4 + 1))
+# Always persist counters BEFORE checking cap (durable across resumes)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 # Enforce phase4 cap BEFORE scheduling
 if [ "$NEW_PHASE4" -ge 2 ]; then
   echo "Phase 4 re-entry limit reached. STOP and alert user."
   # Do NOT call ScheduleWakeup -- STOP here
-else
-  tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 fi
 ```
 
@@ -409,12 +409,12 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 NEW_PHASE4=$((PHASE4 + 1))
+# Always persist counters BEFORE checking cap (durable across resumes)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 # Enforce phase4 cap BEFORE scheduling
 if [ "$NEW_PHASE4" -ge 2 ]; then
   echo "Phase 4 re-entry limit reached. STOP and alert user."
   # Do NOT call ScheduleWakeup -- STOP here
-else
-  tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 fi
 ```
 If Phase 4 cap NOT reached:

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -403,12 +403,13 @@ Unknown or malformed verdict must create a remediation task and continue the loo
 Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
 ```bash
 tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" --parent bd-EPIC
-# Increment cycle counter (keep phase4 since remediation will re-enter Phase 4)
+# Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
+NEW_PHASE4=$((PHASE4 + 1))
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 ```
 ```text
 ScheduleWakeup({

--- a/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph-cc/SKILL.md
@@ -451,6 +451,12 @@ END TURN. Do NOT proceed to branch completion with failing verification.
 
 In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
 
+**Watchdog cleanup:** Close the watchdog task BEFORE branch completion so the cleanup is included in the final commit/push:
+```bash
+tm close bd-WATCHDOG --reason="Epic bd-EPIC completed successfully"
+git add .beads/ && git commit -m "chore: close watchdog for completed epic bd-EPIC"
+```
+
 ```text
 Use Skill tool: xpowers:finishing-a-development-branch
 ```
@@ -458,11 +464,6 @@ Use Skill tool: xpowers:finishing-a-development-branch
 **Autonomous override:** When the skill presents integration options, auto-select **option 2 (Push and create Pull Request)** without waiting for user input. This is autonomous execution -- do not present options or wait.
 
 AFTER FINISHING BRANCH RETURNS: Present summary (tasks completed, commits made, review results, any flagged items). Do NOT call ScheduleWakeup. The loop ends naturally here.
-
-**Watchdog cleanup:** Close the watchdog task so stale state never confuses future runs:
-```bash
-tm close bd-WATCHDOG --reason="Epic bd-EPIC completed successfully"
-```
 
 ---
 

--- a/.kimi/skills/codex-skill-execute-ralph/SKILL.md
+++ b/.kimi/skills/codex-skill-execute-ralph/SKILL.md
@@ -20,7 +20,7 @@ flowchart TD
 ```
 
 <skill_overview>
-Execute a complete epic autonomously by dispatching one Agent subagent per task. Each subagent handles SRE refinement, TDD, test-runner, commit, and task closure in its own context. The main loop only tracks git log progress and epic criteria. End-of-epic: 3 specialized reviews (review-quality, security-scanner, test-effectiveness-analyst) in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch.
+Execute a complete epic autonomously by dispatching one Agent subagent per task. **Platform routing:** If running in Claude Code (you see "You are Claude Code" in your system prompt), stop now and load the `execute-ralph-cc` skill instead -- it uses ScheduleWakeup for reliable autonomous looping in Claude Code. Continue with this skill only on other platforms (OpenCode, Gemini CLI, Kimi). Each subagent handles SRE refinement, TDD, test-runner, commit, and task closure in its own context. The main loop only tracks git log progress and epic criteria. End-of-epic: 3 specialized reviews (review-quality, security-scanner, test-effectiveness-analyst) in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch.
 </skill_overview>
 
 <rigidity_level>

--- a/commands/execute-ralph-cc.md
+++ b/commands/execute-ralph-cc.md
@@ -24,7 +24,7 @@ Executes a complete bd epic autonomously using Claude Code's native `ScheduleWak
 2. **Phase 1 - Get Task & Refine:** Uses `bv --robot-triage` output from Phase 0 to determine next task. Claims or auto-creates the next task. Runs SRE refinement.
 3. **Phase 2 - Dispatch Subagent:** Records `PRE_SHA`, dispatches Agent tool with subagent-driven-development protocol. Verifies SHA drift and task status.
 4. **Phase 3 - Post-Task Check:** Quick review. Re-reads epic criteria. If criteria unmet, calls `ScheduleWakeup(60s)` and ends turn. If criteria met, proceeds to Phase 4.
-5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). Both must return APPROVED. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
+5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). `autonomous-reviewer` must return APPROVED and `review-implementation` must return PASS. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
 6. **Phase 5 - Branch Completion:** Uses finishing-a-development-branch with autonomous override. Presents summary. No ScheduleWakeup -- loop ends naturally.
 
 ## ScheduleWakeup Loop Contract

--- a/commands/execute-ralph-cc.md
+++ b/commands/execute-ralph-cc.md
@@ -6,7 +6,7 @@ type: flow
 
 # Usage
 
-```
+```text
 /xpowers:execute-ralph-cc [--reviewer-model=opus|sonnet]
 ```
 

--- a/commands/execute-ralph-cc.md
+++ b/commands/execute-ralph-cc.md
@@ -21,10 +21,10 @@ type: flow
 Executes a complete bd epic autonomously using Claude Code's native `ScheduleWakeup` tool instead of stop hooks. Each turn processes exactly one task, then schedules a wake-up for the next:
 
 1. **Phase 0 - State Recovery:** Every wake-up starts here. Reads all state from bd/tm (epic, tasks, criteria). Fully idempotent -- any wake-up reconstructs context from bd/tm alone.
-2. **Phase 1 - Get Task & Refine:** Uses `bv --robot-next` for triage. Claims or auto-creates the next task. Runs SRE refinement.
+2. **Phase 1 - Get Task & Refine:** Uses `bv --robot-triage` output from Phase 0 to determine next task. Claims or auto-creates the next task. Runs SRE refinement.
 3. **Phase 2 - Dispatch Subagent:** Records `PRE_SHA`, dispatches Agent tool with subagent-driven-development protocol. Verifies SHA drift and task status.
 4. **Phase 3 - Post-Task Check:** Quick review. Re-reads epic criteria. If criteria unmet, calls `ScheduleWakeup(60s)` and ends turn. If criteria met, proceeds to Phase 4.
-5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). Both must APPROVED. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
+5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). Both must return APPROVED. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
 6. **Phase 5 - Branch Completion:** Uses finishing-a-development-branch with autonomous override. Presents summary. No ScheduleWakeup -- loop ends naturally.
 
 ## ScheduleWakeup Loop Contract
@@ -58,7 +58,7 @@ The loop uses Claude Code's native `ScheduleWakeup` tool for continuation:
 
 ## Review and Remediation Contract
 
-Reviews happen ONCE at end of epic (not per-task):
+Specialized reviews happen ONCE at end of epic (a lightweight per-task review occurs in Phase 3, but the full review suite runs only after all criteria are met):
 
 - 3 specialized agents dispatched in parallel after all epic criteria are met:
   - review-quality (bugs, race conditions, error handling)

--- a/commands/execute-ralph-cc.md
+++ b/commands/execute-ralph-cc.md
@@ -1,0 +1,107 @@
+---
+name: execute-ralph-cc
+description: "Execute entire bd epic autonomously via ScheduleWakeup task-per-turn loop. Claude Code only. No stop hooks."
+type: flow
+---
+
+# Usage
+
+```
+/xpowers:execute-ralph-cc [--reviewer-model=opus|sonnet]
+```
+
+## Arguments
+
+- `--reviewer-model`: Model for autonomous-reviewer (optional)
+  - `opus` (default): Highest capability, thorough review
+  - `sonnet`: Faster, balanced quality
+
+## What This Does
+
+Executes a complete bd epic autonomously using Claude Code's native `ScheduleWakeup` tool instead of stop hooks. Each turn processes exactly one task, then schedules a wake-up for the next:
+
+1. **Phase 0 - State Recovery:** Every wake-up starts here. Reads all state from bd/tm (epic, tasks, criteria). Fully idempotent -- any wake-up reconstructs context from bd/tm alone.
+2. **Phase 1 - Get Task & Refine:** Uses `bv --robot-next` for triage. Claims or auto-creates the next task. Runs SRE refinement.
+3. **Phase 2 - Dispatch Subagent:** Records `PRE_SHA`, dispatches Agent tool with subagent-driven-development protocol. Verifies SHA drift and task status.
+4. **Phase 3 - Post-Task Check:** Quick review. Re-reads epic criteria. If criteria unmet, calls `ScheduleWakeup(60s)` and ends turn. If criteria met, proceeds to Phase 4.
+5. **Phase 4 - End-of-Epic Review:** Dispatches 3 specialized agents in parallel (review-quality, security-scanner, test-effectiveness-analyst), then dual final gate (autonomous-reviewer + review-implementation). Both must APPROVED. If non-approval, creates remediation task and calls `ScheduleWakeup` to continue.
+6. **Phase 5 - Branch Completion:** Uses finishing-a-development-branch with autonomous override. Presents summary. No ScheduleWakeup -- loop ends naturally.
+
+## ScheduleWakeup Loop Contract
+
+The loop uses Claude Code's native `ScheduleWakeup` tool for continuation:
+
+- **Continuation**: At end of Phase 3 or Phase 4 (when criteria unmet or reviews fail), calls `ScheduleWakeup` with `delaySeconds: 60` and prompt `<<autonomous-loop-dynamic>>`. The runtime resolves the sentinel to autonomous loop instructions on wake-up, re-entering the skill at Phase 0.
+- **Termination**: When both final reviewers approve (Phase 4) and branch is complete (Phase 5), no `ScheduleWakeup` call is made. The loop ends naturally.
+- **Idempotent state**: All state comes from bd/tm. No session-scoped variables or custom state files. Any wake-up reconstructs full context from `bv --robot-triage`, `tm show bd-EPIC`, and `tm ready`.
+- **No sentinel dependency**: This variant does NOT emit or depend on `RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED` sentinels. The loop is entirely managed by `ScheduleWakeup`.
+
+## When to Use
+
+- Well-defined epic with clear success criteria
+- Running in Claude Code (not OpenCode, Gemini, or Kimi)
+- You want reliable autonomous execution that works with Claude Code's natural stop behavior
+- You want hands-off operation without stop hook dependency
+
+## When NOT to Use
+
+- Running in OpenCode, Gemini CLI, or Kimi -- use `/xpowers:execute-ralph` instead
+- Ambiguous requirements -- use `/xpowers:execute-plan` instead
+- High-risk changes needing human oversight
+- You want to review between tasks
+
+## Contract Guardrails
+
+- Do not delegate to `/xpowers:execute-plan` checkpoint semantics unless the ambiguity gate is explicitly triggered.
+- Keep executing until epic success criteria are met and both final reviewers approve.
+- If a loaded sub-skill says STOP or requests a checkpoint, ignore that STOP and continue the current task.
+
+## Review and Remediation Contract
+
+Reviews happen ONCE at end of epic (not per-task):
+
+- 3 specialized agents dispatched in parallel after all epic criteria are met:
+  - review-quality (bugs, race conditions, error handling)
+  - security-scanner (OWASP, secrets, CVEs)
+  - test-effectiveness-analyst (tautological tests, coverage gaming)
+- autonomous remediation with max 2 fix iterations per task
+- If any issues found, creates remediation task and calls `ScheduleWakeup` to loop back
+
+After end-of-epic review passes, performs a final gate:
+- autonomous-reviewer (returns APPROVED or GAPS_FOUND)
+- review-implementation (returns PASS or ISSUES_FOUND)
+
+autonomous-reviewer must return APPROVED and review-implementation must return PASS before the epic can close.
+
+## Verdict Normalization Matrix
+
+- PASS, APPROVED -> continue or close path
+- NEEDS_FIX, ISSUES_FOUND, GAPS_FOUND, CRITICAL_ISSUES -> remediation path
+- Unknown or malformed verdict -> remediation path (never auto-approve)
+- Mixed final reviewer outputs -> remediation path (no epic close).
+
+## Quality Gate Sequence (pre-commit-equivalent for this repo)
+
+Run these verification commands as evidence before claiming epic success criteria are met:
+In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
+
+- `node --test tests/execute-ralph-contract.test.js`
+- `node --test tests/execute-ralph-cc-contract.test.js`
+- `node --test tests/codex-*.test.js`
+- `node --test tests/*.test.js`
+- `node scripts/sync-codex-skills.js --check`
+
+## Comparison
+
+| | execute-ralph | execute-ralph-cc |
+|---|---|---|
+| Platform | All | Claude Code only |
+| Continuation | Stop hook + sentinels | ScheduleWakeup |
+| Tasks per turn | Multiple (continuous) | Exactly one |
+| State between iterations | In-context memory | bd/tm re-read |
+| Delay between tasks | None | 60 seconds |
+| Context pressure | High | Low (fresh per task) |
+
+---
+
+Use the `execute-ralph-cc` skill exactly as written. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.

--- a/commands/execute-ralph-cc.md
+++ b/commands/execute-ralph-cc.md
@@ -31,7 +31,7 @@ Executes a complete bd epic autonomously using Claude Code's native `ScheduleWak
 
 The loop uses Claude Code's native `ScheduleWakeup` tool for continuation:
 
-- **Continuation**: At end of Phase 3 or Phase 4 (when criteria unmet or reviews fail), calls `ScheduleWakeup` with `delaySeconds: 60` and prompt `<<autonomous-loop-dynamic>>`. The runtime resolves the sentinel to autonomous loop instructions on wake-up, re-entering the skill at Phase 0.
+- **Continuation**: At end of Phase 3 or Phase 4 (when criteria unmet or reviews fail), calls `ScheduleWakeup` with `delaySeconds: 60` and a concrete Phase 0 re-entry prompt. The prompt contains explicit instructions to load the skill and start at Phase 0, ensuring re-entry regardless of runtime sentinel support.
 - **Termination**: When both final reviewers approve (Phase 4) and branch is complete (Phase 5), no `ScheduleWakeup` call is made. The loop ends naturally.
 - **Idempotent state**: All state comes from bd/tm. No session-scoped variables or custom state files. Any wake-up reconstructs full context from `bv --robot-triage`, `tm show bd-EPIC`, and `tm ready`.
 - **No sentinel dependency**: This variant does NOT emit or depend on `RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED` sentinels. The loop is entirely managed by `ScheduleWakeup`.

--- a/commands/execute-ralph.md
+++ b/commands/execute-ralph.md
@@ -6,7 +6,7 @@ description: Execute entire epic autonomously with continuous review. No user ch
 ## Platform Routing
 
 **Before loading any skill**, determine which platform you are running on:
-- **Claude Code** (you see "You are Claude Code" in your system prompt, or environment has `CLAUDECODE=1`): Load the `execute-ralph-cc` skill instead. It uses ScheduleWakeup for reliable autonomous looping in Claude Code.
+- **Claude Code** (you see "You are Claude Code" in your system prompt): Load the `execute-ralph-cc` skill instead. It uses ScheduleWakeup for reliable autonomous looping in Claude Code.
 - **All other platforms** (OpenCode, Gemini CLI, Kimi, etc.): Continue with the `execute-ralph` skill below. It uses stop hooks for continuation.
 
 # Usage
@@ -125,4 +125,4 @@ In guarded environments, direct .git/hooks/pre-commit execution may be blocked b
 
 ---
 
-Use the appropriate skill based on the Platform Routing section above. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.
+Use the `execute-ralph` skill exactly as written. If Platform Routing directed you to `execute-ralph-cc`, load that skill instead. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.

--- a/commands/execute-ralph.md
+++ b/commands/execute-ralph.md
@@ -3,6 +3,12 @@ name: execute-ralph
 description: Execute entire epic autonomously with continuous review. No user checkpoints.
 ---
 
+## Platform Routing
+
+**Before loading any skill**, determine which platform you are running on:
+- **Claude Code** (you see "You are Claude Code" in your system prompt, or environment has `CLAUDECODE=1`): Load the `execute-ralph-cc` skill instead. It uses ScheduleWakeup for reliable autonomous looping in Claude Code.
+- **All other platforms** (OpenCode, Gemini CLI, Kimi, etc.): Continue with the `execute-ralph` skill below. It uses stop hooks for continuation.
+
 # Usage
 
 ```
@@ -119,4 +125,4 @@ In guarded environments, direct .git/hooks/pre-commit execution may be blocked b
 
 ---
 
-Use the `execute-ralph` skill exactly as written. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.
+Use the appropriate skill based on the Platform Routing section above. Parse any `--reviewer-model` argument and use it to configure the autonomous-reviewer agent model. Default to opus if not specified.

--- a/hooks/skill-rules.json
+++ b/hooks/skill-rules.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Skill and agent activation rules for xpowers plugin - 19 skills + 1 agent = 20 total",
+  "_comment": "Skill and agent activation rules for xpowers plugin - 20 skills + 1 agent = 21 total",
   "_schema": {
     "description": "Each skill/agent has type, enforcement, priority, and triggers",
     "type": "process|domain|workflow|agent",
@@ -135,6 +135,19 @@
         "(execute|run|start).*?(ralph|execute-ralph)",
         "(autonomous|hands-off).*(epic|execution|workflow)",
         "(complete|finish).*?(epic).*(without|no).*(checkpoint|stop)"
+      ]
+    }
+  },
+  "execute-ralph-cc": {
+    "type": "workflow",
+    "enforcement": "suggest",
+    "priority": "critical",
+    "promptTriggers": {
+      "keywords": ["execute-ralph-cc", "ralph-cc", "autonomous loop claude code", "schedule wakeup epic", "run full epic claude code"],
+      "intentPatterns": [
+        "(execute|run|start).*?(ralph-cc|execute-ralph-cc)",
+        "(autonomous|hands-off).*(epic|execution).*?(claude.?code|cc)",
+        "(schedule.*?wakeup|loop).*?(epic|ralph)"
       ]
     }
   },

--- a/hooks/skill-rules.json
+++ b/hooks/skill-rules.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Skill and agent activation rules for xpowers plugin - 20 skills + 1 agent = 21 total",
+  "_comment": "Skill and agent activation rules for xpowers plugin - 21 skills + 1 agent = 22 total",
   "_schema": {
     "description": "Each skill/agent has type, enforcement, priority, and triggers",
     "type": "process|domain|workflow|agent",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -679,7 +679,7 @@ with open('$tmp', 'w') as f:
     echo "  Uses local ONNX embeddings (no API key needed for embeddings)."
     echo "  Memories stored as plain markdown files in ~/.memsearch/memory/"
     echo ""
-    read -r -p "  Install memsearch? [y/N] " answer
+    read -r -p "  Install memsearch? [y/N] " answer </dev/tty
     if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
       if command -v python3 >/dev/null 2>&1; then
         echo "  Installing memsearch[onnx]..."
@@ -770,7 +770,7 @@ install_opencode() {
     echo "  This runs the interactive routing wizard (you can also run it later"
     echo "  with: bun scripts/opencode-routing-wizard.ts)"
     echo ""
-    read -r -p "  Run routing wizard? [y/N] " answer
+    read -r -p "  Run routing wizard? [y/N] " answer </dev/tty
     if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
       bun "${REPO_ROOT}/scripts/opencode-routing-wizard.ts" || warn "Routing wizard failed"
     fi
@@ -783,7 +783,7 @@ install_opencode() {
     echo "  Uses local ONNX embeddings (no API key needed for embeddings)."
     echo "  Memories stored as plain markdown files in ~/.memsearch/memory/"
     echo ""
-    read -r -p "  Install memsearch? [y/N] " answer
+    read -r -p "  Install memsearch? [y/N] " answer </dev/tty
     if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
       if command -v python3 >/dev/null 2>&1; then
         echo "  Installing memsearch[onnx]..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -679,7 +679,8 @@ with open('$tmp', 'w') as f:
     echo "  Uses local ONNX embeddings (no API key needed for embeddings)."
     echo "  Memories stored as plain markdown files in ~/.memsearch/memory/"
     echo ""
-    read -r -p "  Install memsearch? [y/N] " answer </dev/tty
+    echo -n "  Install memsearch? [y/N] "
+    read -r answer </dev/tty
     if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
       if command -v python3 >/dev/null 2>&1; then
         echo "  Installing memsearch[onnx]..."
@@ -770,7 +771,8 @@ install_opencode() {
     echo "  This runs the interactive routing wizard (you can also run it later"
     echo "  with: bun scripts/opencode-routing-wizard.ts)"
     echo ""
-    read -r -p "  Run routing wizard? [y/N] " answer </dev/tty
+    echo -n "  Run routing wizard? [y/N] "
+    read -r answer </dev/tty
     if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
       bun "${REPO_ROOT}/scripts/opencode-routing-wizard.ts" || warn "Routing wizard failed"
     fi
@@ -783,7 +785,8 @@ install_opencode() {
     echo "  Uses local ONNX embeddings (no API key needed for embeddings)."
     echo "  Memories stored as plain markdown files in ~/.memsearch/memory/"
     echo ""
-    read -r -p "  Install memsearch? [y/N] " answer </dev/tty
+    echo -n "  Install memsearch? [y/N] "
+    read -r answer </dev/tty
     if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
       if command -v python3 >/dev/null 2>&1; then
         echo "  Installing memsearch[onnx]..."

--- a/scripts/sync-codex-skills.js
+++ b/scripts/sync-codex-skills.js
@@ -173,9 +173,9 @@ This skill wraps the source file \`${sourcePath}\` for Codex Skills compatibilit
 
 ## Source Content
 
-\`\`\`markdown
+\`\`\`\`markdown
 ${originalContent.trimEnd()}
-\`\`\`
+\`\`\`\`
 `)
 }
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -402,12 +402,13 @@ Unknown or malformed verdict must create a remediation task and continue the loo
 Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
 ```bash
 tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" --parent bd-EPIC
-# Increment cycle counter (keep phase4 since remediation will re-enter Phase 4)
+# Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
+NEW_PHASE4=$((PHASE4 + 1))
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 ```
 ```text
 ScheduleWakeup({

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -430,7 +430,8 @@ Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdo
 Only close epic when BOTH final reviewers approve.
 
 → **CONTINUATION (both APPROVED):** Proceed to Phase 5 (Branch Completion).
-→ **CONTINUATION (non-approval):** Call ScheduleWakeup(60s). END TURN.
+→ **CONTINUATION (non-approval, cap NOT reached):** Call ScheduleWakeup(60s). END TURN.
+→ **CONTINUATION (non-approval, cap reached):** STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates.
 
 ---
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -245,7 +245,14 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+    ```bash
+    WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+    CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+    NEW_CYCLES=$((CYCLES + 1))
+    PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+    tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
+    ```
     ```text
     ScheduleWakeup({
       delaySeconds: 60,
@@ -300,7 +307,14 @@ tm show bd-EPIC   # re-read success criteria
 
 **A) ALL criteria are met** --> EXIT TASK LOOP. Proceed to Phase 4 (End-of-Epic Review).
 
-**B) Criteria remain unmet AND tasks exist (ready or can be created)** --> CONTINUE LOOP. Call ScheduleWakeup:
+**B) Criteria remain unmet AND tasks exist (ready or can be created)** --> CONTINUE LOOP.
+First, if the task completed successfully (STATUS == "closed" with SHA drift), reset the no-progress counter since genuine progress was made:
+```bash
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
+```
+Then call ScheduleWakeup:
 ```text
 ScheduleWakeup({
   delaySeconds: 60,
@@ -308,21 +322,13 @@ ScheduleWakeup({
   prompt: "<<autonomous-loop-dynamic>>"
 })
 ```
-Then END TURN. The next wake-up will enter Phase 0 and process the next task.
+END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 **C) Critical blocker** --> Alert user with findings. Do NOT call ScheduleWakeup. Loop terminates.
 
 **CRITICAL: Task list exhaustion alone is NEVER a stop condition.** If no ready or in-progress tasks exist and criteria are still unmet, Phase 0 will auto-create the next task on the next wake-up.
 
 Track max 50 no-progress remediation cycles across all phases. After 50, STOP and alert user. Do NOT call ScheduleWakeup.
-
-**Watchdog reset on verified task progress:**
-If the task completed successfully (STATUS == "closed" with SHA drift), reset the no-progress counter since genuine progress was made:
-```bash
-WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
-PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
-```
 
 **Watchdog increment (remediation only -- retry or review failure):**
 Only increment the cycles counter when a task did NOT make progress (retry path, hallucinated completion, or review found Critical/High issues). Do NOT increment after successful task completions even if criteria remain unmet.

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -26,7 +26,7 @@ Execute a complete epic autonomously using Claude Code's native ScheduleWakeup t
 </skill_overview>
 
 <rigidity_level>
-STRICT - Follow the five-phase flow exactly. Epic requirements are immutable. Never ask the user for confirmation. Use ScheduleWakeup for continuation, never stop hooks.
+STRICT - Follow the six-phase flow exactly. Epic requirements are immutable. Never ask the user for confirmation. Use ScheduleWakeup for continuation, never stop hooks.
 </rigidity_level>
 
 <quick_reference>
@@ -37,7 +37,7 @@ STRICT - Follow the five-phase flow exactly. Epic requirements are immutable. Ne
 | **1. Get Task** | Claim ready / resume in-progress / auto-create | Task identified |
 | **2. Dispatch Subagent** | Agent tool runs task end-to-end | Task done or retried |
 | **3. Post-Task Check** | Verify + criteria check | ScheduleWakeup or Phase 4 |
-| **4. End-of-Epic Review** | 3 reviews + final gate (both must APPROVED) | Epic validated or remediation |
+| **4. End-of-Epic Review** | 3 reviews + final gate (both must return APPROVED) | Epic validated or remediation |
 | **5. Branch Completion** | finishing-a-development-branch | Epic closed |
 
 </quick_reference>
@@ -127,6 +127,26 @@ git checkout -b "feature/${BRANCH_NAME}"
 ```
 If already on a feature branch, continue.
 
+**Watchdog counter recovery:**
+```bash
+tm list --type chore --status open | grep "LOOP-WATCHDOG: bd-EPIC"
+```
+If a watchdog task exists, read its no-progress counter from the title:
+```bash
+tm show bd-WATCHDOG --json | jq -r .title
+```
+Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
+- `cycles` = total no-progress remediation cycles (max 50)
+- `phase4` = consecutive Phase 4 re-entries (max 2)
+
+If `cycles >= 50` or `phase4 >= 2` (and entering Phase 4 again): STOP and alert user. Do NOT call ScheduleWakeup.
+
+If no watchdog task exists, create one:
+```bash
+tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
+tm dep add bd-WATCHDOG bd-EPIC --type parent-child
+```
+
 → **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
 
 ---
@@ -201,8 +221,8 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   - **Implementation Tasks** (feature, bug, task, chore): MUST have `POST_SHA != PRE_SHA`.
   - **Analytical Tasks**: Accepted as success even if `POST_SHA == PRE_SHA` as long as status is `closed`.
   - Proceed to Phase 3.
-- **Turn Limit Hit (Open but Changed)**:
-  - If `STATUS == "open"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. This is OK -- the next wake-up will find it as in-progress and resume from Phase 0. Proceed to Phase 3 criteria check.
+- **Turn Limit Hit (Open/In-Progress but Changed)**:
+  - If `STATUS` is not `"closed"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. This is OK -- the next wake-up will find it as in-progress and resume from Phase 0. Proceed to Phase 3 criteria check.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
   - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and proceed to Phase 3 criteria check.
@@ -250,6 +270,16 @@ Then END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 Track max 50 no-progress remediation cycles across all phases. After 50, STOP and alert user. Do NOT call ScheduleWakeup.
 
+**Watchdog increment (criteria unmet, looping back):**
+```bash
+# Read current counter
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+# Update watchdog task title
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)"
+```
+
 → **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.
 → **CONTINUATION (criteria met):** Proceed to Phase 4 (End-of-Epic Review).
 
@@ -263,7 +293,23 @@ Dispatch specialized reviews **in parallel** via Agent tool:
 2. **security-scanner** -- OWASP, secrets, CVEs
 3. **test-effectiveness-analyst** -- tautological tests, coverage gaming
 
-If any issues found, create remediation task and call ScheduleWakeup:
+If any issues found, create remediation task, increment watchdog counters, and call ScheduleWakeup:
+```bash
+# Increment both cycle and phase4 counters
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+NEW_PHASE4=$((PHASE4 + 1))
+# Enforce phase4 cap
+if [ "$NEW_PHASE4" -ge 2 ]; then
+  echo "Phase 4 re-entry limit reached. STOP and alert user."
+  # Do NOT call ScheduleWakeup
+else
+  tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
+  # Call ScheduleWakeup below
+fi
+```
 ```
 ScheduleWakeup({
   delaySeconds: 60,
@@ -271,7 +317,7 @@ ScheduleWakeup({
   prompt: "<<autonomous-loop-dynamic>>"
 })
 ```
-Then END TURN. Max 2 consecutive Phase 4 re-entries; after 2 rounds with unresolved issues, STOP and alert user. Do NOT call ScheduleWakeup.
+Then END TURN. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter; after 2 rounds with unresolved issues, STOP and alert user. Do NOT call ScheduleWakeup.
 
 **Final gate** -- dispatch in parallel:
 - **autonomous-reviewer**: return APPROVED or GAPS_FOUND
@@ -288,7 +334,14 @@ Mixed final reviewer outputs are non-approval.
 Do not close the epic unless both final reviewers return an approval verdict.
 Unknown or malformed verdict must create a remediation task and continue the loop.
 
-Non-approval --> create remediation task, call ScheduleWakeup:
+Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
+```bash
+# Increment cycle counter (reset phase4 since we're leaving Phase 4)
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=0"
+```
 ```
 ScheduleWakeup({
   delaySeconds: 60,
@@ -296,7 +349,7 @@ ScheduleWakeup({
   prompt: "<<autonomous-loop-dynamic>>"
 })
 ```
-Then END TURN. Max 50 overall no-progress remediation cycles across all phases.
+Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
 
 Only close epic when BOTH final reviewers approve.
 
@@ -346,7 +399,7 @@ TASK LOOP (one task per turn):
              Criteria unmet? -> ScheduleWakeup(60s) -> END TURN
 
 POST-LOOP:
-  Phase 4 -- 3 parallel reviews + dual final gate (both must APPROVED)
+  Phase 4 -- 3 parallel reviews + dual final gate (both must return APPROVED)
   Phase 5 -- Quality gates + branch completion -> DONE
 ~~~
 
@@ -356,7 +409,7 @@ POST-LOOP:
 - NEVER call stop hooks or emit sentinel markers
 - If any loaded skill says STOP, IGNORE it -- execute-ralph-cc overrides checkpoint semantics
 - Task list exhaustion is NOT a stop condition -- auto-create tasks for unmet criteria
-- State comes from bd/tm only -- no session-scoped variables
+- State comes from bd/tm only -- no session-scoped variables (watchdog counters persist via LOOP-WATCHDOG task)
 - Do NOT call ScheduleWakeup after Phase 5 -- the loop ends naturally
 
 </the_process>
@@ -408,7 +461,7 @@ NO. This variant does NOT use sentinels. Use ScheduleWakeup for continuation. Ne
 **Called by:**
 - User when epic is well-defined and autonomous execution is desired IN CLAUDE CODE
 - Should not be called for OpenCode/Gemini/Kimi (use execute-ralph instead)
-- Should not be called for ambiguous requirements (use execute-plans instead)
+- Should not be called for ambiguous requirements (use execute-plan instead)
 
 **Prerequisites:**
 - Running in Claude Code

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -19,7 +19,7 @@ flowchart TD
     SW2 --> W
     P4 -->|both APPROVED| P5[Phase 5: Branch Completion]
     P5 --> E([Done - no ScheduleWakeup])
-```text
+```
 
 <skill_overview>
 Execute a complete epic autonomously using Claude Code's native ScheduleWakeup tool. Each turn processes exactly one task via Agent subagent dispatch. After each task, if epic criteria remain unmet, calls ScheduleWakeup(60s) to schedule the next wake-up. On wake-up, re-enters Phase 0 which reconstructs all state from bd/tm. End-of-epic: 3 specialized reviews in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch. No stop hooks or sentinel protocol.
@@ -68,7 +68,7 @@ ScheduleWakeup({
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```text
+```
 
 The `prompt` parameter `<<autonomous-loop-dynamic>>` is resolved by the runtime to autonomous loop instructions on wake-up, causing re-entry into this skill's Phase 0.
 
@@ -92,23 +92,23 @@ This phase runs at the start of EVERY turn. It reconstructs all context from bd/
 
 ```bash
 bv --robot-triage || (tm ready && tm list)
-```text
+```
 **Health gate:** If dependency cycles exist, alert user and stop. Do NOT call ScheduleWakeup.
 
 ```bash
 tm list --type epic --status open
-```text
+```
 Identify the active epic. If no epic exists, alert user and stop.
 
 ```bash
 tm show bd-EPIC
-```text
+```
 Load epic requirements, success criteria (immutable), and anti-patterns.
 
 ```bash
 tm list --status in_progress
 tm ready
-```text
+```
 
 Determine the path:
 - **A) In-progress task exists** -- resume it, proceed to Phase 1.
@@ -119,22 +119,22 @@ Determine the path:
 **Branch check:**
 ```bash
 git branch --show-current
-```text
+```
 If on main/default branch, create feature branch:
 ```bash
 BRANCH_NAME=$(echo "[epic-title]" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-')
 git checkout -b "feature/${BRANCH_NAME}"
-```text
+```
 If already on a feature branch, continue.
 
 **Watchdog counter recovery:**
 ```bash
 tm list --type chore | grep "LOOP-WATCHDOG: bd-EPIC"
-```text
+```
 If a watchdog task exists, read its no-progress counter from the title:
 ```bash
 tm show bd-WATCHDOG --json | jq -r .title
-```text
+```
 Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
 - `cycles` = total no-progress remediation cycles (max 50)
 - `phase4` = consecutive Phase 4 re-entries (max 2)
@@ -146,7 +146,7 @@ If no watchdog task exists, create one as deferred so it is never picked up by `
 tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
 tm dep add bd-WATCHDOG bd-EPIC --type parent-child
 tm update bd-WATCHDOG --status deferred
-```text
+```
 
 → **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
 
@@ -164,7 +164,7 @@ If arriving from Phase 0 path A (in-progress task):
 If arriving from Phase 0 path B (ready task):
 ```bash
 tm update bd-N --status in_progress
-```text
+```
 
 If arriving from Phase 0 path D (auto-create):
 ```bash
@@ -172,13 +172,13 @@ tm create "Task: [criterion gap]" --type feature --priority 1 \
   --design "## Goal\n[Close unmet criterion]\n## Success Criteria\n- [ ] Gap closed"
 tm dep add bd-NEW bd-EPIC --type parent-child
 tm update bd-NEW --status in_progress
-```text
+```
 
 ### Refinement
 
 ```bash
 tm show bd-N
-```text
+```
 
 Run SRE refinement on the selected task:
 Use Skill tool: `xpowers:sre-task-refinement` (prefer Opus 4.1 model)
@@ -195,12 +195,12 @@ Load full task context:
 ```bash
 tm show bd-EPIC    # epic requirements
 tm show bd-N       # task design
-```text
+```
 
 **Before dispatching**, record current HEAD:
 ```bash
 PRE_SHA=$(git rev-parse HEAD)
-```text
+```
 
 **Launch Agent tool** using the canonical 'Dispatch Protocol' from `subagent-driven-development`.
 
@@ -215,7 +215,7 @@ Use the **Subagent Prompt Template** from `subagent-driven-development` skill, p
 POST_SHA=$(git rev-parse HEAD)
 TASK_TYPE=$(tm show bd-N --json | jq -r .type)
 STATUS=$(tm show bd-N --json | jq -r .status)
-```text
+```
 
 - **Success**:
   - Require `STATUS == "closed"`.
@@ -223,7 +223,15 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   - **Analytical Tasks**: Accepted as success even if `POST_SHA == PRE_SHA` as long as status is `closed`.
   - Proceed to Phase 3.
 - **Turn Limit Hit (Open/In-Progress but Changed)**:
-  - If `STATUS` is not `"closed"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. This is OK -- the next wake-up will find it as in-progress and resume from Phase 0. Proceed to Phase 3 criteria check.
+  - If `STATUS` is not `"closed"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. Skip the Phase 3 review -- the task is not complete, so running `autonomous-reviewer` against unfinished work could create spurious remediation tasks. Instead, call ScheduleWakeup directly:
+  ```text
+  ScheduleWakeup({
+    delaySeconds: 60,
+    reason: "Task bd-N partial progress (turn limit hit), resuming in Phase 0",
+    prompt: "<<autonomous-loop-dynamic>>"
+  })
+  ```
+  END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
   - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and proceed to Phase 3 criteria check.
@@ -257,7 +265,7 @@ END TURN. The remediation task must be completed before entering Phase 4.
 
 ```bash
 tm show bd-EPIC   # re-read success criteria
-```text
+```
 
 **This is the loop decision point.**
 
@@ -270,7 +278,7 @@ ScheduleWakeup({
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```text
+```
 Then END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 **C) Critical blocker** --> Alert user with findings. Do NOT call ScheduleWakeup. Loop terminates.
@@ -285,7 +293,7 @@ If the task completed successfully (STATUS == "closed" with SHA drift), reset th
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
-```text
+```
 
 **Watchdog increment (remediation only -- retry or review failure):**
 Only increment the cycles counter when a task did NOT make progress (retry path, hallucinated completion, or review found Critical/High issues). Do NOT increment after successful task completions even if criteria remain unmet.
@@ -295,7 +303,7 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
-```text
+```
 
 → **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.
 → **CONTINUATION (criteria met):** Proceed to Phase 4 (End-of-Epic Review).
@@ -326,7 +334,7 @@ else
   tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
   # Only call ScheduleWakeup when NOT capped
 fi
-```text
+```
 
 If Phase 4 cap NOT reached, call ScheduleWakeup:
 ```text
@@ -335,7 +343,7 @@ ScheduleWakeup({
   reason: "End-of-epic review found issues, remediation task created for epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```text
+```
 
 If Phase 4 cap reached (phase4 >= 2): STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter.
 
@@ -363,14 +371,14 @@ WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=0"
-```text
+```
 ```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Final gate non-approval for epic bd-EPIC, remediation task created",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```text
+```
 Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
 
 Only close epic when BOTH final reviewers approve.
@@ -390,7 +398,7 @@ node --test tests/execute-ralph-cc-contract.test.js
 node --test tests/codex-*.test.js
 node --test tests/*.test.js
 node scripts/sync-codex-skills.js --check
-```text
+```
 
 If any verification fails, create remediation task and call ScheduleWakeup to return to task loop.
 
@@ -398,7 +406,7 @@ In guarded environments, direct .git/hooks/pre-commit execution may be blocked b
 
 ```text
 Use Skill tool: xpowers:finishing-a-development-branch
-```text
+```
 
 **Autonomous override:** When the skill presents integration options, auto-select **option 2 (Push and create Pull Request)** without waiting for user input. This is autonomous execution -- do not present options or wait.
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -271,14 +271,22 @@ Then END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 Track max 50 no-progress remediation cycles across all phases. After 50, STOP and alert user. Do NOT call ScheduleWakeup.
 
-**Watchdog increment (criteria unmet, looping back):**
+**Watchdog reset on verified task progress:**
+If the task completed successfully (STATUS == "closed" with SHA drift), reset the no-progress counter since genuine progress was made:
 ```bash
-# Read current counter
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
+```
+
+**Watchdog increment (remediation only -- retry or review failure):**
+Only increment the cycles counter when a task did NOT make progress (retry path, hallucinated completion, or review found Critical/High issues). Do NOT increment after successful task completions even if criteria remain unmet.
+```bash
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
-# Update watchdog task title
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)"
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
 ```
 
 → **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -430,7 +430,23 @@ node --test tests/*.test.js
 node scripts/sync-codex-skills.js --check
 ```
 
-If any verification fails, create remediation task and call ScheduleWakeup to return to task loop.
+If any verification fails, create remediation task, increment watchdog counter, and call ScheduleWakeup to return to task loop:
+```bash
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
+tm create "Remediation: Phase 5 quality gate failure" --parent bd-EPIC
+```
+```text
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Phase 5 quality gate failed for epic bd-EPIC, remediation task created",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+END TURN. Do NOT proceed to branch completion with failing verification.
 
 In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -37,7 +37,7 @@ STRICT - Follow the six-phase flow exactly. Epic requirements are immutable. Nev
 | **1. Get Task** | Claim ready / resume in-progress / auto-create | Task identified |
 | **2. Dispatch Subagent** | Agent tool runs task end-to-end | Task done or retried |
 | **3. Post-Task Check** | Verify + criteria check | ScheduleWakeup or Phase 4 |
-| **4. End-of-Epic Review** | 3 reviews + final gate (both must return APPROVED) | Epic validated or remediation |
+| **4. End-of-Epic Review** | 3 reviews + final gate (autonomous-reviewer=APPROVED + review-implementation=PASS) | Epic validated or remediation |
 | **5. Branch Completion** | finishing-a-development-branch | Epic closed |
 
 </quick_reference>
@@ -106,13 +106,13 @@ tm show bd-EPIC
 Load epic requirements, success criteria (immutable), and anti-patterns.
 
 ```bash
-tm list --status in_progress
-tm ready
+tm list --status in_progress --parent bd-EPIC
+tm dep tree bd-EPIC  # show ready tasks scoped to this epic
 ```
 
 Determine the path:
-- **A) In-progress task exists** -- resume it, proceed to Phase 1.
-- **B) Ready task exists** -- claim it: `tm update bd-N --status in_progress`, proceed to Phase 1.
+- **A) In-progress task exists (child of bd-EPIC)** -- resume it, proceed to Phase 1.
+- **B) Ready task exists (child of bd-EPIC)** -- claim it: `tm update bd-N --status in_progress`, proceed to Phase 1.
 - **C) All criteria met and no in-progress tasks** -- proceed to Phase 4 (end-of-epic review).
 - **D) No tasks, criteria unmet** -- auto-create next task (see Phase 1), proceed to Phase 1.
 
@@ -251,6 +251,14 @@ Dispatch `autonomous-reviewer` agent for the completed task.
 **Remediation Path**:
 If the review finds **Critical** or **High** issues:
 - Create remediation task: `tm create "Remediation: [Findings]" --parent bd-EPIC`.
+- **Increment watchdog counter** (review failure is a no-progress cycle):
+```bash
+WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
+CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
+NEW_CYCLES=$((CYCLES + 1))
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
+```
 - **Do NOT proceed to Phase 4 even if criteria appear met.** Call ScheduleWakeup to return to Phase 0, which will pick up the new remediation task:
 ```text
 ScheduleWakeup({
@@ -518,7 +526,7 @@ Phase 0 (first wake-up):
 
 Phase 1:
   tm update bd-43 --status in_progress
-  # SRE refinement on bd-43
+  \# SRE refinement on bd-43
   Agent(subagent-driven-development, task=bd-43)
 
 Phase 2:
@@ -612,7 +620,7 @@ Before claiming epic execution is complete:
 - [ ] Phase 4 cap (max 2 consecutive re-entries) enforced, stops and alerts user when exceeded
 - [ ] Quick-review Critical/High findings block Phase 4 entry and route back to task loop
 - [ ] Partial-progress tasks (non-closed with SHA drift) skip Phase 3 review
-- [ ] Dual final gate requires both APPROVED (autonomous-reviewer + review-implementation)
+- [ ] Dual final gate requires autonomous-reviewer=APPROVED and review-implementation=PASS
 - [ ] Phase 5 calls finishing-a-development-branch, no ScheduleWakeup after completion
 
 </verification_checklist>

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -1,0 +1,419 @@
+---
+name: execute-ralph-cc
+description: "Execute entire bd epic autonomously via ScheduleWakeup task-per-turn loop. Claude Code only. No stop hooks. One task per turn, state recovered from bd/tm on each wake-up."
+type: flow
+---
+
+```mermaid
+flowchart TD
+    W([ScheduleWakeup fires]) --> P0[Phase 0: State Recovery]
+    P0 -->|in-progress or ready task| P1[Phase 1: Get Task + Refine]
+    P0 -->|all criteria met| P4[Phase 4: End-of-Epic Review]
+    P0 -->|no task, criteria unmet| P1
+    P1 --> P2[Phase 2: Dispatch Subagent]
+    P2 --> P3[Phase 3: Verify + Criteria Check]
+    P3 -->|criteria unmet| SW1[ScheduleWakeup 60s]
+    SW1 --> W
+    P3 -->|all criteria met| P4
+    P4 -->|issues found| SW2[ScheduleWakeup 60s]
+    SW2 --> W
+    P4 -->|both APPROVED| P5[Phase 5: Branch Completion]
+    P5 --> E([Done - no ScheduleWakeup])
+```
+
+<skill_overview>
+Execute a complete epic autonomously using Claude Code's native ScheduleWakeup tool. Each turn processes exactly one task via Agent subagent dispatch. After each task, if epic criteria remain unmet, calls ScheduleWakeup(60s) to schedule the next wake-up. On wake-up, re-enters Phase 0 which reconstructs all state from bd/tm. End-of-epic: 3 specialized reviews in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch. No stop hooks or sentinel protocol.
+</skill_overview>
+
+<rigidity_level>
+STRICT - Follow the five-phase flow exactly. Epic requirements are immutable. Never ask the user for confirmation. Use ScheduleWakeup for continuation, never stop hooks.
+</rigidity_level>
+
+<quick_reference>
+
+| Phase | Action | Outcome |
+|-------|--------|---------|
+| **0. State Recovery** | Read bd/tm state, determine path | Ready to work |
+| **1. Get Task** | Claim ready / resume in-progress / auto-create | Task identified |
+| **2. Dispatch Subagent** | Agent tool runs task end-to-end | Task done or retried |
+| **3. Post-Task Check** | Verify + criteria check | ScheduleWakeup or Phase 4 |
+| **4. End-of-Epic Review** | 3 reviews + final gate (both must APPROVED) | Epic validated or remediation |
+| **5. Branch Completion** | finishing-a-development-branch | Epic closed |
+
+</quick_reference>
+
+## ScheduleWakeup Loop Contract
+
+This skill uses `ScheduleWakeup` for continuation instead of stop hooks or sentinels.
+
+**Continuation points** (call ScheduleWakeup):
+
+| Location | Condition | delaySeconds |
+|----------|-----------|-------------|
+| End of Phase 3 | Task completed, criteria still unmet | 60 |
+| End of Phase 4 | Reviews found issues, remediation needed | 60 |
+| End of Phase 4 | Final gate non-approval | 60 |
+
+**Termination** (do NOT call ScheduleWakeup):
+
+| Location | Condition |
+|----------|-----------|
+| After Phase 4 | Both reviewers APPROVED, proceed to Phase 5 |
+| After Phase 5 | Branch complete, present summary |
+
+**Call template:**
+```
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+
+The `prompt` parameter `<<autonomous-loop-dynamic>>` is resolved by the runtime to autonomous loop instructions on wake-up, causing re-entry into this skill's Phase 0.
+
+**This variant does NOT use or depend on RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED sentinels.** The loop is entirely managed by ScheduleWakeup. Do not emit sentinel markers.
+
+<when_to_use>
+
+**Use when:** Running in Claude Code, epic is well-defined, user trusts autonomous execution, tasks are implementation work.
+**Do NOT use when:** Running in OpenCode/Gemini/Kimi (use execute-ralph instead), ambiguous requirements (use execute-plan), needs human oversight per task, exploratory work.
+
+</when_to_use>
+
+<the_process>
+
+**CRITICAL: TUI Dashboard Updates (If Supported)**
+If the `update_ralph_state` tool is available in your environment, use it to keep the live TUI dashboard updated during this turn. If NOT available (e.g. running in Claude Code without the Pi extension), ignore this requirement.
+
+## Phase 0: State Recovery (every wake-up entry point)
+
+This phase runs at the start of EVERY turn. It reconstructs all context from bd/tm.
+
+```bash
+bv --robot-triage || (tm ready && tm list)
+```
+**Health gate:** If dependency cycles exist, alert user and stop. Do NOT call ScheduleWakeup.
+
+```bash
+tm list --type epic --status open
+```
+Identify the active epic. If no epic exists, alert user and stop.
+
+```bash
+tm show bd-EPIC
+```
+Load epic requirements, success criteria (immutable), and anti-patterns.
+
+```bash
+tm list --status in_progress
+tm ready
+```
+
+Determine the path:
+- **A) In-progress task exists** -- resume it, proceed to Phase 1.
+- **B) Ready task exists** -- claim it: `tm update bd-N --status in_progress`, proceed to Phase 1.
+- **C) All criteria met and no in-progress tasks** -- proceed to Phase 4 (end-of-epic review).
+- **D) No tasks, criteria unmet** -- auto-create next task (see Phase 1), proceed to Phase 1.
+
+**Branch check:**
+```bash
+git branch --show-current
+```
+If on main/default branch, create feature branch:
+```bash
+BRANCH_NAME=$(echo "[epic-title]" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-')
+git checkout -b "feature/${BRANCH_NAME}"
+```
+If already on a feature branch, continue.
+
+→ **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
+
+---
+
+## Phase 1: Get Task & Refine
+
+This phase handles task selection, claiming, and refinement.
+
+### Task selection
+
+If arriving from Phase 0 path A (in-progress task):
+- The task is already claimed. Proceed to refinement.
+
+If arriving from Phase 0 path B (ready task):
+```bash
+tm update bd-N --status in_progress
+```
+
+If arriving from Phase 0 path D (auto-create):
+```bash
+tm create "Task: [criterion gap]" --type feature --priority 1 \
+  --design "## Goal\n[Close unmet criterion]\n## Success Criteria\n- [ ] Gap closed"
+tm dep add bd-NEW bd-EPIC --type parent-child
+tm update bd-NEW --status in_progress
+```
+
+### Refinement
+
+```bash
+tm show bd-N
+```
+
+Run SRE refinement on the selected task:
+Use Skill tool: `xpowers:sre-task-refinement` (prefer Opus 4.1 model)
+
+AFTER SRE REFINEMENT RETURNS: You are in execute-ralph-cc Phase 1. Proceed to Phase 2 (Dispatch Subagent). Do NOT stop. Do NOT present checkpoint.
+
+→ **CONTINUATION:** Phase 1 complete. Task identified and refined. Proceed to Phase 2.
+
+---
+
+## Phase 2: Dispatch Subagent
+
+Load full task context:
+```bash
+tm show bd-EPIC    # epic requirements
+tm show bd-N       # task design
+```
+
+**Before dispatching**, record current HEAD:
+```bash
+PRE_SHA=$(git rev-parse HEAD)
+```
+
+**Launch Agent tool** using the canonical 'Dispatch Protocol' from `subagent-driven-development`.
+
+### Subagent Prompt
+Use the **Subagent Prompt Template** from `subagent-driven-development` skill, populating:
+- **Immutable Epic Requirements**: from `tm show bd-EPIC` wrapped in `<epic_contract>` tags.
+- **Task Specification (bd-N)**: from `tm show bd-N` wrapped in `<task_spec>` tags.
+- **Mandatory Workflow**: Ensure `sre-task-refinement` and TDD are mandated.
+
+**After Agent returns**, verify progress:
+```bash
+POST_SHA=$(git rev-parse HEAD)
+TASK_TYPE=$(tm show bd-N --json | jq -r .type)
+STATUS=$(tm show bd-N --json | jq -r .status)
+```
+
+- **Success**:
+  - Require `STATUS == "closed"`.
+  - **Implementation Tasks** (feature, bug, task, chore): MUST have `POST_SHA != PRE_SHA`.
+  - **Analytical Tasks**: Accepted as success even if `POST_SHA == PRE_SHA` as long as status is `closed`.
+  - Proceed to Phase 3.
+- **Turn Limit Hit (Open but Changed)**:
+  - If `STATUS == "open"` AND `POST_SHA != PRE_SHA`: The task made progress but didn't finish. This is OK -- the next wake-up will find it as in-progress and resume from Phase 0. Proceed to Phase 3 criteria check.
+- **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
+  - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
+  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and proceed to Phase 3 criteria check.
+- **Failure (Closed but no SHA drift on implementation task)**:
+  - If `STATUS == "closed"` and `POST_SHA == PRE_SHA` for an implementation task (feature/bug/task/chore type), flag as hallucinated completion and STOP. Do NOT call ScheduleWakeup.
+
+→ **CONTINUATION:** Phase 2 complete. Subagent dispatched and verified. Proceed to Phase 3.
+
+---
+
+## Phase 3: Post-Task Verification & Criteria Check
+
+### Quick review
+
+Dispatch `autonomous-reviewer` agent for the completed task.
+
+**Remediation Path**:
+If the review finds **Critical** or **High** issues:
+- Create remediation task: `tm create "Remediation: [Findings]" --parent bd-EPIC`.
+- This will be picked up on the next wake-up cycle.
+
+### Criteria check
+
+```bash
+tm show bd-EPIC   # re-read success criteria
+```
+
+**This is the loop decision point.**
+
+**A) ALL criteria are met** --> EXIT TASK LOOP. Proceed to Phase 4 (End-of-Epic Review).
+
+**B) Criteria remain unmet AND tasks exist (ready or can be created)** --> CONTINUE LOOP. Call ScheduleWakeup:
+```
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+Then END TURN. The next wake-up will enter Phase 0 and process the next task.
+
+**C) Critical blocker** --> Alert user with findings. Do NOT call ScheduleWakeup. Loop terminates.
+
+**CRITICAL: Task list exhaustion alone is NEVER a stop condition.** If no ready or in-progress tasks exist and criteria are still unmet, Phase 0 will auto-create the next task on the next wake-up.
+
+Track max 50 no-progress remediation cycles across all phases. After 50, STOP and alert user. Do NOT call ScheduleWakeup.
+
+→ **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.
+→ **CONTINUATION (criteria met):** Proceed to Phase 4 (End-of-Epic Review).
+
+---
+
+## Phase 4: End-of-Epic Review (single turn)
+
+Dispatch specialized reviews **in parallel** via Agent tool:
+
+1. **review-quality** -- bugs, race conditions, error handling
+2. **security-scanner** -- OWASP, secrets, CVEs
+3. **test-effectiveness-analyst** -- tautological tests, coverage gaming
+
+If any issues found, create remediation task and call ScheduleWakeup:
+```
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "End-of-epic review found issues, remediation task created for epic bd-EPIC",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+Then END TURN. Max 2 consecutive Phase 4 re-entries; after 2 rounds with unresolved issues, STOP and alert user. Do NOT call ScheduleWakeup.
+
+**Final gate** -- dispatch in parallel:
+- **autonomous-reviewer**: return APPROVED or GAPS_FOUND
+- **review-implementation**: return PASS or ISSUES_FOUND
+
+### Verdict Normalization Matrix
+
+- PASS, APPROVED -> continue or close path
+- NEEDS_FIX, ISSUES_FOUND, GAPS_FOUND, CRITICAL_ISSUES -> remediation path
+- Unknown or malformed verdict -> remediation path (never auto-approve)
+- Mixed final reviewer outputs -> remediation path (no epic close).
+
+Mixed final reviewer outputs are non-approval.
+Do not close the epic unless both final reviewers return an approval verdict.
+Unknown or malformed verdict must create a remediation task and continue the loop.
+
+Non-approval --> create remediation task, call ScheduleWakeup:
+```
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Final gate non-approval for epic bd-EPIC, remediation task created",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+Then END TURN. Max 50 overall no-progress remediation cycles across all phases.
+
+Only close epic when BOTH final reviewers approve.
+
+→ **CONTINUATION (both APPROVED):** Proceed to Phase 5 (Branch Completion).
+→ **CONTINUATION (non-approval):** Call ScheduleWakeup(60s). END TURN.
+
+---
+
+## Phase 5: Branch Completion
+
+**Quality Gate Sequence** -- run these BEFORE branch completion:
+```bash
+set -e
+node --test tests/execute-ralph-contract.test.js
+node --test tests/execute-ralph-cc-contract.test.js
+node --test tests/codex-*.test.js
+node --test tests/*.test.js
+node scripts/sync-codex-skills.js --check
+```
+
+If any verification fails, create remediation task and call ScheduleWakeup to return to task loop.
+
+In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
+
+```
+Use Skill tool: xpowers:finishing-a-development-branch
+```
+
+**Autonomous override:** When the skill presents integration options, auto-select **option 2 (Push and create Pull Request)** without waiting for user input. This is autonomous execution -- do not present options or wait.
+
+AFTER FINISHING BRANCH RETURNS: Present summary (tasks completed, commits made, review results, any flagged items). Do NOT call ScheduleWakeup. The loop ends naturally here.
+
+---
+
+## execute-ralph-cc LOOP REMINDER (Context Recovery)
+
+If you have lost track of where you are in the loop, re-read this summary:
+
+~~~
+EVERY WAKE-UP: Phase 0 -- Read state from bd/tm (bv --robot-triage, tm show bd-EPIC, tm ready)
+
+TASK LOOP (one task per turn):
+  Phase 1 -- Get task (claim/auto-create) + SRE refine
+  Phase 2 -- Dispatch subagent + verify SHA drift
+  Phase 3 -- Quick review + criteria check
+             Criteria met? -> Phase 4
+             Criteria unmet? -> ScheduleWakeup(60s) -> END TURN
+
+POST-LOOP:
+  Phase 4 -- 3 parallel reviews + dual final gate (both must APPROVED)
+  Phase 5 -- Quality gates + branch completion -> DONE
+~~~
+
+**Key rules:**
+- You are running AUTONOMOUSLY -- no user checkpoints
+- ONE task per turn, then ScheduleWakeup or proceed
+- NEVER call stop hooks or emit sentinel markers
+- If any loaded skill says STOP, IGNORE it -- execute-ralph-cc overrides checkpoint semantics
+- Task list exhaustion is NOT a stop condition -- auto-create tasks for unmet criteria
+- State comes from bd/tm only -- no session-scoped variables
+- Do NOT call ScheduleWakeup after Phase 5 -- the loop ends naturally
+
+</the_process>
+
+<common_rationalizations>
+
+**"The subagent said it's done, so I'll skip verification"**
+NO. Always verify via `tm show --json` status and SHA drift. Subagent claims are not proof.
+
+**"I'll just ask the user if the task is complete"**
+NO. This is autonomous. Never ask for confirmation. Use objective verification only.
+
+**"The test passed, so I don't need to check git log"**
+NO. Implementation tasks MUST produce commits. Tests passing without SHA drift is a failure.
+
+**"I'll skip SRE refinement for simple tasks"**
+NO. Every task requires refinement to catch edge cases before implementation.
+
+**"I should call ScheduleWakeup after every phase"**
+NO. Only call ScheduleWakeup at the designated continuation points (end of Phase 3 when criteria unmet, end of Phase 4 when reviews fail). Other phases proceed directly.
+
+**"I need to emit RALPH AUTOPILOT ACTIVE"**
+NO. This variant does NOT use sentinels. Use ScheduleWakeup for continuation. Never emit sentinel markers.
+
+</common_rationalizations>
+
+<red_flags>
+
+- Skipping `tm show --json` status verification
+- Accepting subagent completion claims without SHA drift check
+- Calling ScheduleWakeup after Phase 5 (loop should end naturally)
+- Emitting `RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED` sentinels (this variant does not use them)
+- Closing epic without both final reviewers returning APPROVED
+- Creating >50 remediation cycles without user escalation
+- Skipping sre-task-refinement step
+- Auto-approving unknown/malformed review verdicts
+- Asking the user for confirmation at any point
+
+</red_flags>
+
+<integration>
+
+**Calls:**
+- `xpowers:sre-task-refinement` -- mandatory per-task refinement after task selection
+- `subagent-driven-development` -- canonical Dispatch Protocol for each task
+- `xpowers:finishing-a-development-branch` -- final branch completion
+- Agent tool with specialized reviewers: review-quality, security-scanner, test-effectiveness-analyst, autonomous-reviewer, review-implementation
+
+**Called by:**
+- User when epic is well-defined and autonomous execution is desired IN CLAUDE CODE
+- Should not be called for OpenCode/Gemini/Kimi (use execute-ralph instead)
+- Should not be called for ambiguous requirements (use execute-plans instead)
+
+**Prerequisites:**
+- Running in Claude Code
+- Epic must have clear success criteria
+- Tasks should be implementation-focused
+- User must trust autonomous execution
+
+</integration>

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -245,7 +245,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git reset --hard HEAD && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+  - If retry also fails, clean worktree (`git reset HEAD && git checkout . && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
     ```bash
     WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
     CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -362,12 +362,12 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 NEW_PHASE4=$((PHASE4 + 1))
+# Always persist counters BEFORE checking cap (durable across resumes)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 # Enforce phase4 cap BEFORE scheduling
 if [ "$NEW_PHASE4" -ge 2 ]; then
   echo "Phase 4 re-entry limit reached. STOP and alert user."
   # Do NOT call ScheduleWakeup -- STOP here
-else
-  tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 fi
 ```
 
@@ -408,12 +408,12 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 NEW_PHASE4=$((PHASE4 + 1))
+# Always persist counters BEFORE checking cap (durable across resumes)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 # Enforce phase4 cap BEFORE scheduling
 if [ "$NEW_PHASE4" -ge 2 ]; then
   echo "Phase 4 re-entry limit reached. STOP and alert user."
   # Do NOT call ScheduleWakeup -- STOP here
-else
-  tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
 fi
 ```
 If Phase 4 cap NOT reached:

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -245,7 +245,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+  - If retry also fails, clean worktree (`git checkout . && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
     ```bash
     WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
     CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
@@ -278,7 +278,7 @@ Dispatch `autonomous-reviewer` agent for the completed task.
 
 **Remediation Path**:
 If the review finds **Critical** or **High** issues:
-- Create remediation task: `tm create "Remediation: [Findings]" --parent bd-EPIC`.
+- Create remediation task: `tm create "Remediation: [Findings]"` then `tm dep add bd-REM bd-EPIC --type parent-child`.
 - **Increment watchdog counter** (review failure is a no-progress cycle):
 ```bash
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
@@ -355,7 +355,8 @@ Dispatch specialized reviews **in parallel** via Agent tool:
 
 If any issues found, create remediation task and check watchdog counters:
 ```bash
-tm create "Remediation: Phase 4 specialized review findings" --parent bd-EPIC
+REMEDIATION_ID=$(tm create "Remediation: Phase 4 specialized review findings" | grep -o 'bd-[0-9]*' | head -1)
+tm dep add $REMEDIATION_ID bd-EPIC --type parent-child
 # Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
@@ -401,7 +402,8 @@ Unknown or malformed verdict must create a remediation task and continue the loo
 
 Non-approval --> create remediation task, increment watchdog counter, check cap, call ScheduleWakeup:
 ```bash
-tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" --parent bd-EPIC
+REMEDIATION_ID=$(tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" | grep -o 'bd-[0-9]*' | head -1)
+tm dep add $REMEDIATION_ID bd-EPIC --type parent-child
 # Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
@@ -454,7 +456,8 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
-tm create "Remediation: Phase 5 quality gate failure" --parent bd-EPIC
+REMEDIATION_ID=$(tm create "Remediation: Phase 5 quality gate failure" | grep -o 'bd-[0-9]*' | head -1)
+tm dep add $REMEDIATION_ID bd-EPIC --type parent-child
 ```
 ```text
 ScheduleWakeup({
@@ -634,7 +637,8 @@ Phase 5:
 <code>
 Phase 0 (wake-up):
   bv --robot-triage bd-42 → criteria NOT met, no ready task
-  tm create "Auto-task: remaining criteria" --parent bd-42
+  tm create "Auto-task: remaining criteria"
+  tm dep add bd-NEW bd-42 --type parent-child
   LOOP-WATCHDOG task found: cycles=48 phase4=0
   cycles < 50 → continue
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -366,11 +366,12 @@ Unknown or malformed verdict must create a remediation task and continue the loo
 
 Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
 ```bash
-# Increment cycle counter (reset phase4 since we're leaving Phase 4)
+# Increment cycle counter (keep phase4 since remediation will re-enter Phase 4)
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=0"
+PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
+tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
 ```
 ```text
 ScheduleWakeup({

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -245,7 +245,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git checkout . && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+  - If retry also fails, clean worktree (`git reset --hard HEAD && git clean -fd`), defer the task (`tm update bd-N --status deferred`), increment watchdog counter (no-progress cycle), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
     ```bash
     WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
     CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -129,7 +129,7 @@ If already on a feature branch, continue.
 
 **Watchdog counter recovery:**
 ```bash
-tm list --type chore --status open | grep "LOOP-WATCHDOG: bd-EPIC"
+tm list --type chore | grep "LOOP-WATCHDOG: bd-EPIC"
 ```
 If a watchdog task exists, read its no-progress counter from the title:
 ```bash
@@ -141,10 +141,11 @@ Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
 
 If `cycles >= 50` or `phase4 >= 2` (and entering Phase 4 again): STOP and alert user. Do NOT call ScheduleWakeup.
 
-If no watchdog task exists, create one:
+If no watchdog task exists, create one as deferred so it is never picked up by `tm ready` or `bv --robot-next`:
 ```bash
 tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
 tm dep add bd-WATCHDOG bd-EPIC --type parent-child
+tm update bd-WATCHDOG --status deferred
 ```
 
 → **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
@@ -293,7 +294,7 @@ Dispatch specialized reviews **in parallel** via Agent tool:
 2. **security-scanner** -- OWASP, secrets, CVEs
 3. **test-effectiveness-analyst** -- tautological tests, coverage gaming
 
-If any issues found, create remediation task, increment watchdog counters, and call ScheduleWakeup:
+If any issues found, create remediation task and check watchdog counters:
 ```bash
 # Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
@@ -304,12 +305,14 @@ NEW_PHASE4=$((PHASE4 + 1))
 # Enforce phase4 cap
 if [ "$NEW_PHASE4" -ge 2 ]; then
   echo "Phase 4 re-entry limit reached. STOP and alert user."
-  # Do NOT call ScheduleWakeup
+  # Do NOT call ScheduleWakeup -- STOP here
 else
   tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
-  # Call ScheduleWakeup below
+  # Only call ScheduleWakeup when NOT capped
 fi
 ```
+
+If Phase 4 cap NOT reached, call ScheduleWakeup:
 ```
 ScheduleWakeup({
   delaySeconds: 60,
@@ -317,7 +320,10 @@ ScheduleWakeup({
   prompt: "<<autonomous-loop-dynamic>>"
 })
 ```
-Then END TURN. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter; after 2 rounds with unresolved issues, STOP and alert user. Do NOT call ScheduleWakeup.
+
+If Phase 4 cap reached (phase4 >= 2): STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter.
+
+Then END TURN.
 
 **Final gate** -- dispatch in parallel:
 - **autonomous-reviewer**: return APPROVED or GAPS_FOUND

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -501,3 +501,118 @@ NO. This variant does NOT use sentinels. Use ScheduleWakeup for continuation. Ne
 - User must trust autonomous execution
 
 </integration>
+
+<examples>
+
+<example>
+<scenario>Typical autonomous epic execution from start to finish</scenario>
+
+<code>
+User: "run ralph on epic bd-42"
+
+Phase 0 (first wake-up):
+  EPIC_ID=bd-42
+  bv --robot-triage bd-42  # finds 3 open tasks, first is bd-43
+  tm ready                  # bd-43 is ready
+  No in-progress task → Path B (new task)
+
+Phase 1:
+  tm update bd-43 --status in_progress
+  # SRE refinement on bd-43
+  Agent(subagent-driven-development, task=bd-43)
+
+Phase 2:
+  Agent returns: task bd-43 completed, committed
+
+Phase 3:
+  POST_SHA != PRE_SHA → genuine progress
+  bv --robot-triage bd-42 → criteria NOT all met
+  ScheduleWakeup(60s, "<<autonomous-loop-dynamic>>")
+
+[... 2 more task cycles for bd-44, bd-45 ...]
+
+Phase 0 (wake-up after bd-45):
+  bv --robot-triage bd-42 → ALL criteria met → Path C
+
+Phase 4:
+  Agent(review-quality) + Agent(security-scanner) + Agent(test-effectiveness-analyst)
+  All return PASS → proceed to final gate
+  Agent(autonomous-reviewer) → APPROVED
+  Agent(review-implementation) → PASS
+
+Phase 5:
+  xpowers:finishing-a-development-branch
+  No ScheduleWakeup — epic complete
+</code>
+</example>
+
+<example>
+<scenario>Watchdog counter prevents infinite loop on stuck epic</scenario>
+
+<code>
+Phase 0 (wake-up):
+  bv --robot-triage bd-42 → criteria NOT met, no ready task
+  tm create "Auto-task: remaining criteria" --parent bd-42
+  LOOP-WATCHDOG task found: cycles=48 phase4=0
+  cycles < 50 → continue
+
+Phase 1-3:
+  Task bd-48 dispatched, completes
+  ScheduleWakeup(60s)
+
+[... bd-49 also completes but criteria still unmet ...]
+
+Phase 0 (wake-up):
+  LOOP-WATCHDOG: cycles=49 phase4=0
+  Still < 50 → continue
+
+Phase 1-3:
+  Task bd-50 dispatched, NO progress (SHA unchanged)
+  cycles incremented to 50
+
+Phase 0 (wake-up):
+  LOOP-WATCHDOG: cycles=50 phase4=0
+  cycles >= 50 → STOP, alert user:
+  "Epic bd-42 stuck: 50 no-progress cycles. Manual intervention needed."
+</code>
+</example>
+
+<example>
+<scenario>Phase 4 remediation with cap enforcement</scenario>
+
+<code>
+Phase 4 (first entry):
+  3 reviews pass → final gate
+  Agent(autonomous-reviewer) → GAPS_FOUND
+  phase4 counter: 0 → 1
+  Create remediation task bd-51
+  ScheduleWakeup(60s)
+
+[... bd-51 completes, criteria still met, re-enter Phase 4 ...]
+
+Phase 4 (second entry):
+  3 reviews pass → final gate
+  Agent(review-implementation) → ISSUES_FOUND
+  phase4 counter: 1 → 2
+  NEW_PHASE4 >= 2 → STOP, alert user:
+  "Phase 4 re-entry limit (2) reached. Final gate keeps failing. Manual review needed."
+</code>
+</example>
+
+</examples>
+
+<verification_checklist>
+
+Before claiming epic execution is complete:
+- [ ] Phase 0 reconstructs full state from bd/tm on every wake-up (no session variables)
+- [ ] Exactly one task processed per turn via Agent subagent dispatch
+- [ ] ScheduleWakeup used for continuation (never stop hooks or sentinels)
+- [ ] Watchdog task created with deferred status (never selected by tm ready)
+- [ ] No-progress counter only increments on zero SHA drift, resets to 0 on genuine progress
+- [ ] Phase 4 cap (max 2 consecutive re-entries) enforced, stops and alerts user when exceeded
+- [ ] Quick-review Critical/High findings block Phase 4 entry and route back to task loop
+- [ ] Partial-progress tasks (non-closed with SHA drift) skip Phase 3 review
+- [ ] Dual final gate requires both APPROVED (autonomous-reviewer + review-implementation)
+- [ ] Phase 5 calls finishing-a-development-branch, no ScheduleWakeup after completion
+
+</verification_checklist>

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -245,7 +245,15 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
 - **Retry (Not Closed and No Drift)**: If `STATUS != "closed"` AND `POST_SHA == PRE_SHA`:
   - If subagent summary claims success, **retry once** with 'Verification Emphasis' prompt.
-  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and proceed to Phase 3 criteria check.
+  - If retry also fails, clean worktree (`git checkout .`), defer the task (`tm update bd-N --status deferred`), and call ScheduleWakeup to return to Phase 0. Do NOT proceed to Phase 3 quick review -- there is no completed task to review.
+    ```text
+    ScheduleWakeup({
+      delaySeconds: 60,
+      reason: "Task bd-N deferred after retry exhaustion, returning to Phase 0 for next task",
+      prompt: "<<autonomous-loop-dynamic>>"
+    })
+    ```
+    END TURN. Phase 0 will select a different ready task or check epic completion.
 - **Failure (Closed but no SHA drift on implementation task)**:
   - If `STATUS == "closed"` and `POST_SHA == PRE_SHA` for an implementation task (feature/bug/task/chore type), flag as hallucinated completion and STOP. Do NOT call ScheduleWakeup.
 
@@ -256,6 +264,8 @@ STATUS=$(tm show bd-N --json | jq -r .status)
 ## Phase 3: Post-Task Verification & Criteria Check
 
 ### Quick review
+
+Only run if the task from Phase 2 was successfully closed (`STATUS == "closed"`). If the task was deferred or left in-progress, skip directly to criteria check below.
 
 Dispatch `autonomous-reviewer` agent for the completed task.
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -355,19 +355,19 @@ Dispatch specialized reviews **in parallel** via Agent tool:
 
 If any issues found, create remediation task and check watchdog counters:
 ```bash
+tm create "Remediation: Phase 4 specialized review findings" --parent bd-EPIC
 # Increment both cycle and phase4 counters
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 NEW_PHASE4=$((PHASE4 + 1))
-# Enforce phase4 cap
+# Enforce phase4 cap BEFORE scheduling
 if [ "$NEW_PHASE4" -ge 2 ]; then
   echo "Phase 4 re-entry limit reached. STOP and alert user."
   # Do NOT call ScheduleWakeup -- STOP here
 else
   tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
-  # Only call ScheduleWakeup when NOT capped
 fi
 ```
 
@@ -399,7 +399,7 @@ Mixed final reviewer outputs are non-approval.
 Do not close the epic unless both final reviewers return an approval verdict.
 Unknown or malformed verdict must create a remediation task and continue the loop.
 
-Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
+Non-approval --> create remediation task, increment watchdog counter, check cap, call ScheduleWakeup:
 ```bash
 tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" --parent bd-EPIC
 # Increment both cycle and phase4 counters
@@ -408,8 +408,15 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 NEW_PHASE4=$((PHASE4 + 1))
-tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
+# Enforce phase4 cap BEFORE scheduling
+if [ "$NEW_PHASE4" -ge 2 ]; then
+  echo "Phase 4 re-entry limit reached. STOP and alert user."
+  # Do NOT call ScheduleWakeup -- STOP here
+else
+  tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
+fi
 ```
+If Phase 4 cap NOT reached:
 ```text
 ScheduleWakeup({
   delaySeconds: 60,
@@ -417,6 +424,7 @@ ScheduleWakeup({
   prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
+If Phase 4 cap reached (phase4 >= 2): STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates.
 Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
 
 Only close epic when BOTH final reviewers approve.

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -65,12 +65,12 @@ This skill uses `ScheduleWakeup` for continuation instead of stop hooks or senti
 ```text
 ScheduleWakeup({
   delaySeconds: 60,
-  reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
-  prompt: "<<autonomous-loop-dynamic>>"
+  reason: "<descriptive reason referencing bd-EPIC and current phase>",
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 
-The `prompt` parameter `<<autonomous-loop-dynamic>>` is resolved by the runtime to autonomous loop instructions on wake-up, causing re-entry into this skill's Phase 0.
+The `prompt` parameter contains concrete Phase 0 re-entry instructions so the wake-up always knows how to resume regardless of runtime sentinel support.
 
 **This variant does NOT use or depend on RALPH AUTOPILOT ACTIVE/COMPLETE/BLOCKED sentinels.** The loop is entirely managed by ScheduleWakeup. Do not emit sentinel markers.
 
@@ -239,7 +239,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
   ScheduleWakeup({
     delaySeconds: 60,
     reason: "Task bd-N partial progress (turn limit hit), resuming in Phase 0",
-    prompt: "<<autonomous-loop-dynamic>>"
+    prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
   })
   ```
   END TURN. The next wake-up will find the task as in-progress and resume from Phase 0.
@@ -257,7 +257,7 @@ STATUS=$(tm show bd-N --json | jq -r .status)
     ScheduleWakeup({
       delaySeconds: 60,
       reason: "Task bd-N deferred after retry exhaustion, returning to Phase 0 for next task",
-      prompt: "<<autonomous-loop-dynamic>>"
+      prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
     })
     ```
     END TURN. Phase 0 will select a different ready task or check epic completion.
@@ -292,7 +292,7 @@ tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Quick review found Critical/High issues, remediation task created for epic bd-EPIC",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 END TURN. The remediation task must be completed before entering Phase 4.
@@ -319,7 +319,7 @@ Then call ScheduleWakeup:
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 END TURN. The next wake-up will enter Phase 0 and process the next task.
@@ -376,7 +376,7 @@ If Phase 4 cap NOT reached, call ScheduleWakeup:
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "End-of-epic review found issues, remediation task created for epic bd-EPIC",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 
@@ -412,7 +412,7 @@ tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Final gate non-approval for epic bd-EPIC, remediation task created",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
@@ -449,7 +449,7 @@ tm create "Remediation: Phase 5 quality gate failure" --parent bd-EPIC
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Phase 5 quality gate failed for epic bd-EPIC, remediation task created",
-  prompt: "<<autonomous-loop-dynamic>>"
+  prompt: "Continue execute-ralph-cc. Load the skill and start at Phase 0: run bv --robot-triage, find the active epic, read tasks and criteria from bd/tm. All state from bd/tm."
 })
 ```
 END TURN. Do NOT proceed to branch completion with failing verification.
@@ -598,7 +598,7 @@ Phase 2:
 Phase 3:
   POST_SHA != PRE_SHA → genuine progress
   bv --robot-triage bd-42 → criteria NOT all met
-  ScheduleWakeup(60s, "<<autonomous-loop-dynamic>>")
+  ScheduleWakeup(60s, "Continue execute-ralph-cc. Phase 0: run bv --robot-triage, find active epic, read tasks from bd/tm.")
 
 [... 2 more task cycles for bd-44, bd-45 ...]
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -100,14 +100,15 @@ Recover the active epic ID from the watchdog task BEFORE listing epics. This pre
 ```bash
 tm list --type chore | grep "LOOP-WATCHDOG:"
 ```
-If a watchdog task exists, extract the epic ID from its title:
+If a watchdog task exists, extract the epic ID from its title and verify the epic is still open:
 ```bash
 # Title format: LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N
 # Extract bd-EPIC from the title to identify the active epic
+tm show bd-EPIC --json | jq -r .status
 ```
-Set `bd-EPIC` to the epic ID from the watchdog title. This is the authoritative anchor for which epic this loop is executing.
+If the epic is still open (not closed/done), set `bd-EPIC` from the watchdog. If the epic is closed (stale watchdog from a previous run), ignore it and fall through to epic listing.
 
-If NO watchdog task exists (first run), list epics and select:
+If NO watchdog task exists (or watchdog is stale), list epics and select:
 ```bash
 tm list --type epic --status open
 ```
@@ -431,6 +432,11 @@ Use Skill tool: xpowers:finishing-a-development-branch
 
 AFTER FINISHING BRANCH RETURNS: Present summary (tasks completed, commits made, review results, any flagged items). Do NOT call ScheduleWakeup. The loop ends naturally here.
 
+**Watchdog cleanup:** Close the watchdog task so stale state never confuses future runs:
+```bash
+tm close bd-WATCHDOG --reason="Epic bd-EPIC completed successfully"
+```
+
 ---
 
 ## execute-ralph-cc LOOP REMINDER (Context Recovery)
@@ -462,6 +468,20 @@ POST-LOOP:
 - Do NOT call ScheduleWakeup after Phase 5 -- the loop ends naturally
 
 </the_process>
+
+<critical_rules>
+
+- Never use stop hooks or sentinel markers in this variant. Use ScheduleWakeup only.
+- Never ask for user confirmation or checkpoints during autonomous loop execution.
+- Process exactly one task per turn, then either ScheduleWakeup or proceed by phase contract.
+- Reconstruct all state from bd/tm on every wake-up. Do not rely on session memory.
+- Do not close the epic unless autonomous-reviewer=APPROVED and review-implementation=PASS.
+- Verify task completion via SHA drift (`git rev-parse HEAD`), never trust subagent claims alone.
+- Every task requires SRE refinement before implementation. No exceptions for "simple" tasks.
+- Max 50 no-progress remediation cycles (watchdog) and max 2 consecutive Phase 4 re-entries.
+- Close the watchdog task on successful epic completion to prevent stale state in future runs.
+
+</critical_rules>
 
 <common_rationalizations>
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -450,6 +450,12 @@ END TURN. Do NOT proceed to branch completion with failing verification.
 
 In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
 
+**Watchdog cleanup:** Close the watchdog task BEFORE branch completion so the cleanup is included in the final commit/push:
+```bash
+tm close bd-WATCHDOG --reason="Epic bd-EPIC completed successfully"
+git add .beads/ && git commit -m "chore: close watchdog for completed epic bd-EPIC"
+```
+
 ```text
 Use Skill tool: xpowers:finishing-a-development-branch
 ```
@@ -457,11 +463,6 @@ Use Skill tool: xpowers:finishing-a-development-branch
 **Autonomous override:** When the skill presents integration options, auto-select **option 2 (Push and create Pull Request)** without waiting for user input. This is autonomous execution -- do not present options or wait.
 
 AFTER FINISHING BRANCH RETURNS: Present summary (tasks completed, commits made, review results, any flagged items). Do NOT call ScheduleWakeup. The loop ends naturally here.
-
-**Watchdog cleanup:** Close the watchdog task so stale state never confuses future runs:
-```bash
-tm close bd-WATCHDOG --reason="Epic bd-EPIC completed successfully"
-```
 
 ---
 

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -19,7 +19,7 @@ flowchart TD
     SW2 --> W
     P4 -->|both APPROVED| P5[Phase 5: Branch Completion]
     P5 --> E([Done - no ScheduleWakeup])
-```
+```text
 
 <skill_overview>
 Execute a complete epic autonomously using Claude Code's native ScheduleWakeup tool. Each turn processes exactly one task via Agent subagent dispatch. After each task, if epic criteria remain unmet, calls ScheduleWakeup(60s) to schedule the next wake-up. On wake-up, re-enters Phase 0 which reconstructs all state from bd/tm. End-of-epic: 3 specialized reviews in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch. No stop hooks or sentinel protocol.
@@ -62,13 +62,13 @@ This skill uses `ScheduleWakeup` for continuation instead of stop hooks or senti
 | After Phase 5 | Branch complete, present summary |
 
 **Call template:**
-```
+```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```
+```text
 
 The `prompt` parameter `<<autonomous-loop-dynamic>>` is resolved by the runtime to autonomous loop instructions on wake-up, causing re-entry into this skill's Phase 0.
 
@@ -92,23 +92,23 @@ This phase runs at the start of EVERY turn. It reconstructs all context from bd/
 
 ```bash
 bv --robot-triage || (tm ready && tm list)
-```
+```text
 **Health gate:** If dependency cycles exist, alert user and stop. Do NOT call ScheduleWakeup.
 
 ```bash
 tm list --type epic --status open
-```
+```text
 Identify the active epic. If no epic exists, alert user and stop.
 
 ```bash
 tm show bd-EPIC
-```
+```text
 Load epic requirements, success criteria (immutable), and anti-patterns.
 
 ```bash
 tm list --status in_progress
 tm ready
-```
+```text
 
 Determine the path:
 - **A) In-progress task exists** -- resume it, proceed to Phase 1.
@@ -119,22 +119,22 @@ Determine the path:
 **Branch check:**
 ```bash
 git branch --show-current
-```
+```text
 If on main/default branch, create feature branch:
 ```bash
 BRANCH_NAME=$(echo "[epic-title]" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-')
 git checkout -b "feature/${BRANCH_NAME}"
-```
+```text
 If already on a feature branch, continue.
 
 **Watchdog counter recovery:**
 ```bash
 tm list --type chore | grep "LOOP-WATCHDOG: bd-EPIC"
-```
+```text
 If a watchdog task exists, read its no-progress counter from the title:
 ```bash
 tm show bd-WATCHDOG --json | jq -r .title
-```
+```text
 Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
 - `cycles` = total no-progress remediation cycles (max 50)
 - `phase4` = consecutive Phase 4 re-entries (max 2)
@@ -146,7 +146,7 @@ If no watchdog task exists, create one as deferred so it is never picked up by `
 tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
 tm dep add bd-WATCHDOG bd-EPIC --type parent-child
 tm update bd-WATCHDOG --status deferred
-```
+```text
 
 → **CONTINUATION:** Phase 0 complete. State recovered from bd/tm. Proceed to Phase 1 (if tasks remain) or Phase 4 (if all criteria met).
 
@@ -164,7 +164,7 @@ If arriving from Phase 0 path A (in-progress task):
 If arriving from Phase 0 path B (ready task):
 ```bash
 tm update bd-N --status in_progress
-```
+```text
 
 If arriving from Phase 0 path D (auto-create):
 ```bash
@@ -172,13 +172,13 @@ tm create "Task: [criterion gap]" --type feature --priority 1 \
   --design "## Goal\n[Close unmet criterion]\n## Success Criteria\n- [ ] Gap closed"
 tm dep add bd-NEW bd-EPIC --type parent-child
 tm update bd-NEW --status in_progress
-```
+```text
 
 ### Refinement
 
 ```bash
 tm show bd-N
-```
+```text
 
 Run SRE refinement on the selected task:
 Use Skill tool: `xpowers:sre-task-refinement` (prefer Opus 4.1 model)
@@ -195,12 +195,12 @@ Load full task context:
 ```bash
 tm show bd-EPIC    # epic requirements
 tm show bd-N       # task design
-```
+```text
 
 **Before dispatching**, record current HEAD:
 ```bash
 PRE_SHA=$(git rev-parse HEAD)
-```
+```text
 
 **Launch Agent tool** using the canonical 'Dispatch Protocol' from `subagent-driven-development`.
 
@@ -215,7 +215,7 @@ Use the **Subagent Prompt Template** from `subagent-driven-development` skill, p
 POST_SHA=$(git rev-parse HEAD)
 TASK_TYPE=$(tm show bd-N --json | jq -r .type)
 STATUS=$(tm show bd-N --json | jq -r .status)
-```
+```text
 
 - **Success**:
   - Require `STATUS == "closed"`.
@@ -243,26 +243,34 @@ Dispatch `autonomous-reviewer` agent for the completed task.
 **Remediation Path**:
 If the review finds **Critical** or **High** issues:
 - Create remediation task: `tm create "Remediation: [Findings]" --parent bd-EPIC`.
-- This will be picked up on the next wake-up cycle.
+- **Do NOT proceed to Phase 4 even if criteria appear met.** Call ScheduleWakeup to return to Phase 0, which will pick up the new remediation task:
+```text
+ScheduleWakeup({
+  delaySeconds: 60,
+  reason: "Quick review found Critical/High issues, remediation task created for epic bd-EPIC",
+  prompt: "<<autonomous-loop-dynamic>>"
+})
+```
+END TURN. The remediation task must be completed before entering Phase 4.
 
 ### Criteria check
 
 ```bash
 tm show bd-EPIC   # re-read success criteria
-```
+```text
 
 **This is the loop decision point.**
 
 **A) ALL criteria are met** --> EXIT TASK LOOP. Proceed to Phase 4 (End-of-Epic Review).
 
 **B) Criteria remain unmet AND tasks exist (ready or can be created)** --> CONTINUE LOOP. Call ScheduleWakeup:
-```
+```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Continue execute-ralph-cc task loop, next task from epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```
+```text
 Then END TURN. The next wake-up will enter Phase 0 and process the next task.
 
 **C) Critical blocker** --> Alert user with findings. Do NOT call ScheduleWakeup. Loop terminates.
@@ -277,7 +285,7 @@ If the task completed successfully (STATUS == "closed" with SHA drift), reset th
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=${PHASE4}"
-```
+```text
 
 **Watchdog increment (remediation only -- retry or review failure):**
 Only increment the cycles counter when a task did NOT make progress (retry path, hallucinated completion, or review found Critical/High issues). Do NOT increment after successful task completions even if criteria remain unmet.
@@ -287,7 +295,7 @@ CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 PHASE4=$(echo "$WATCHDOG_TITLE" | grep -o 'phase4=[0-9]*' | cut -d= -f2)
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${PHASE4}"
-```
+```text
 
 → **CONTINUATION (criteria unmet):** Call ScheduleWakeup(60s). END TURN.
 → **CONTINUATION (criteria met):** Proceed to Phase 4 (End-of-Epic Review).
@@ -318,16 +326,16 @@ else
   tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=${NEW_PHASE4}"
   # Only call ScheduleWakeup when NOT capped
 fi
-```
+```text
 
 If Phase 4 cap NOT reached, call ScheduleWakeup:
-```
+```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "End-of-epic review found issues, remediation task created for epic bd-EPIC",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```
+```text
 
 If Phase 4 cap reached (phase4 >= 2): STOP and alert user. Do NOT call ScheduleWakeup. Loop terminates. Max 2 consecutive Phase 4 re-entries enforced by watchdog counter.
 
@@ -355,14 +363,14 @@ WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)
 NEW_CYCLES=$((CYCLES + 1))
 tm update bd-WATCHDOG --title "LOOP-WATCHDOG: bd-EPIC cycles=${NEW_CYCLES} phase4=0"
-```
-```
+```text
+```text
 ScheduleWakeup({
   delaySeconds: 60,
   reason: "Final gate non-approval for epic bd-EPIC, remediation task created",
   prompt: "<<autonomous-loop-dynamic>>"
 })
-```
+```text
 Then END TURN. Max 50 overall no-progress remediation cycles enforced by watchdog counter in Phase 0.
 
 Only close epic when BOTH final reviewers approve.
@@ -382,15 +390,15 @@ node --test tests/execute-ralph-cc-contract.test.js
 node --test tests/codex-*.test.js
 node --test tests/*.test.js
 node scripts/sync-codex-skills.js --check
-```
+```text
 
 If any verification fails, create remediation task and call ScheduleWakeup to return to task loop.
 
 In guarded environments, direct .git/hooks/pre-commit execution may be blocked by safety guardrails.
 
-```
+```text
 Use Skill tool: xpowers:finishing-a-development-branch
-```
+```text
 
 **Autonomous override:** When the skill presents integration options, auto-select **option 2 (Push and create Pull Request)** without waiting for user input. This is autonomous execution -- do not present options or wait.
 
@@ -402,7 +410,7 @@ AFTER FINISHING BRANCH RETURNS: Present summary (tasks completed, commits made, 
 
 If you have lost track of where you are in the loop, re-read this summary:
 
-~~~
+```text
 EVERY WAKE-UP: Phase 0 -- Read state from bd/tm (bv --robot-triage, tm show bd-EPIC, tm ready)
 
 TASK LOOP (one task per turn):
@@ -415,7 +423,7 @@ TASK LOOP (one task per turn):
 POST-LOOP:
   Phase 4 -- 3 parallel reviews + dual final gate (both must return APPROVED)
   Phase 5 -- Quality gates + branch completion -> DONE
-~~~
+```
 
 **Key rules:**
 - You are running AUTONOMOUSLY -- no user checkpoints

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -401,6 +401,7 @@ Unknown or malformed verdict must create a remediation task and continue the loo
 
 Non-approval --> create remediation task, increment watchdog counter, call ScheduleWakeup:
 ```bash
+tm create "Remediation: Final gate non-approval (findings from autonomous-reviewer/review-implementation)" --parent bd-EPIC
 # Increment cycle counter (keep phase4 since remediation will re-enter Phase 4)
 WATCHDOG_TITLE=$(tm show bd-WATCHDOG --json | jq -r .title)
 CYCLES=$(echo "$WATCHDOG_TITLE" | grep -o 'cycles=[0-9]*' | cut -d= -f2)

--- a/skills/execute-ralph-cc/SKILL.md
+++ b/skills/execute-ralph-cc/SKILL.md
@@ -95,10 +95,23 @@ bv --robot-triage || (tm ready && tm list)
 ```
 **Health gate:** If dependency cycles exist, alert user and stop. Do NOT call ScheduleWakeup.
 
+**Epic recovery (watchdog-first):**
+Recover the active epic ID from the watchdog task BEFORE listing epics. This prevents picking the wrong epic when multiple are open:
+```bash
+tm list --type chore | grep "LOOP-WATCHDOG:"
+```
+If a watchdog task exists, extract the epic ID from its title:
+```bash
+# Title format: LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N
+# Extract bd-EPIC from the title to identify the active epic
+```
+Set `bd-EPIC` to the epic ID from the watchdog title. This is the authoritative anchor for which epic this loop is executing.
+
+If NO watchdog task exists (first run), list epics and select:
 ```bash
 tm list --type epic --status open
 ```
-Identify the active epic. If no epic exists, alert user and stop.
+Identify the active epic. If no epic exists, alert user and stop. If multiple epics exist, select the one matching the current feature branch.
 
 ```bash
 tm show bd-EPIC
@@ -128,10 +141,7 @@ git checkout -b "feature/${BRANCH_NAME}"
 If already on a feature branch, continue.
 
 **Watchdog counter recovery:**
-```bash
-tm list --type chore | grep "LOOP-WATCHDOG: bd-EPIC"
-```
-If a watchdog task exists, read its no-progress counter from the title:
+If watchdog was found above, read its counters (already extracted epic ID):
 ```bash
 tm show bd-WATCHDOG --json | jq -r .title
 ```
@@ -141,7 +151,7 @@ Title format: `LOOP-WATCHDOG: bd-EPIC cycles=N phase4=N`
 
 If `cycles >= 50` or `phase4 >= 2` (and entering Phase 4 again): STOP and alert user. Do NOT call ScheduleWakeup.
 
-If no watchdog task exists, create one as deferred so it is never picked up by `tm ready` or `bv --robot-next`:
+If no watchdog task exists (first run, after epic selection above), create one as deferred so it is never picked up by `tm ready` or `bv --robot-next`:
 ```bash
 tm create "LOOP-WATCHDOG: bd-EPIC cycles=0 phase4=0" --type chore --priority 4
 tm dep add bd-WATCHDOG bd-EPIC --type parent-child

--- a/skills/execute-ralph/SKILL.md
+++ b/skills/execute-ralph/SKILL.md
@@ -19,7 +19,7 @@ flowchart TD
 ```
 
 <skill_overview>
-Execute a complete epic autonomously by dispatching one Agent subagent per task. Each subagent handles SRE refinement, TDD, test-runner, commit, and task closure in its own context. The main loop only tracks git log progress and epic criteria. End-of-epic: 3 specialized reviews (review-quality, security-scanner, test-effectiveness-analyst) in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch.
+Execute a complete epic autonomously by dispatching one Agent subagent per task. **Platform routing:** If running in Claude Code (you see "You are Claude Code" in your system prompt), stop now and load the `execute-ralph-cc` skill instead -- it uses ScheduleWakeup for reliable autonomous looping in Claude Code. Continue with this skill only on other platforms (OpenCode, Gemini CLI, Kimi). Each subagent handles SRE refinement, TDD, test-runner, commit, and task closure in its own context. The main loop only tracks git log progress and epic criteria. End-of-epic: 3 specialized reviews (review-quality, security-scanner, test-effectiveness-analyst) in parallel, then dual final gate (autonomous-reviewer + review-implementation). Branch completion via finishing-a-development-branch.
 </skill_overview>
 
 <rigidity_level>

--- a/tests/execute-ralph-cc-contract.test.js
+++ b/tests/execute-ralph-cc-contract.test.js
@@ -105,7 +105,6 @@ test("test_execute_ralph_cc_dual_final_gate", () => {
 })
 
 test("test_execute_ralph_cc_max_50_remediation_cycles", () => {
-  const command = read("commands/execute-ralph-cc.md")
   const skill = read("skills/execute-ralph-cc/SKILL.md")
 
   assert.equal(skill.includes("max 50 no-progress remediation cycles"), true)
@@ -179,4 +178,13 @@ test("test_execute_ralph_cc_phase_4_max_2_reentries", () => {
     skill.includes("Max 2 consecutive Phase 4 re-entries"),
     true,
   )
+})
+
+test("test_execute_ralph_cc_watchdog_counters_persist_across_sessions", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(skill.includes("LOOP-WATCHDOG"), true)
+  assert.equal(skill.includes("cycles="), true)
+  assert.equal(skill.includes("phase4="), true)
+  assert.equal(skill.includes("Watchdog counter recovery"), true)
 })

--- a/tests/execute-ralph-cc-contract.test.js
+++ b/tests/execute-ralph-cc-contract.test.js
@@ -1,0 +1,182 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const path = require("node:path")
+
+const repoRoot = path.resolve(__dirname, "..")
+
+const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), "utf8")
+
+test("test_execute_ralph_cc_uses_schedulewakeup_for_continuation", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(skill.includes("ScheduleWakeup"), true)
+  assert.equal(skill.includes("delaySeconds: 60"), true)
+  assert.equal(skill.includes("<<autonomous-loop-dynamic>>"), true)
+})
+
+test("test_execute_ralph_cc_does_not_use_sentinels_as_operational_control", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  // The skill may reference sentinels in comparison/context sections but
+  // must NOT emit them as operational instructions
+  assert.equal(
+    skill.includes("Do not emit sentinel markers"),
+    true,
+  )
+  assert.equal(
+    skill.includes("This variant does NOT use or depend on RALPH AUTOPILOT ACTIVE"),
+    true,
+  )
+})
+
+test("test_execute_ralph_cc_state_recovery_from_bd_tm", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(skill.includes("Phase 0: State Recovery"), true)
+  assert.equal(skill.includes("bv --robot-triage"), true)
+  assert.equal(skill.includes("tm show bd-EPIC"), true)
+  assert.equal(skill.includes("reconstructs all context from bd/tm"), true)
+})
+
+test("test_execute_ralph_cc_one_task_per_turn", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(skill.includes("one task per turn"), true)
+  assert.equal(skill.includes("ONE task per turn"), true)
+})
+
+test("test_execute_ralph_cc_loop_termination_on_success", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(
+    skill.includes("Do NOT call ScheduleWakeup after Phase 5"),
+    true,
+  )
+  assert.equal(
+    skill.includes("loop ends naturally"),
+    true,
+  )
+})
+
+test("test_execute_ralph_cc_verdict_normalization_matrix", () => {
+  const command = read("commands/execute-ralph-cc.md")
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(command.includes("Verdict Normalization Matrix"), true)
+  assert.equal(skill.includes("Verdict Normalization Matrix"), true)
+  assert.equal(skill.includes("PASS, APPROVED -> continue or close path"), true)
+  assert.equal(
+    skill.includes("NEEDS_FIX, ISSUES_FOUND, GAPS_FOUND, CRITICAL_ISSUES -> remediation path"),
+    true,
+  )
+  assert.equal(
+    skill.includes("Unknown or malformed verdict -> remediation path (never auto-approve)"),
+    true,
+  )
+})
+
+test("test_execute_ralph_cc_quality_gate_sequence", () => {
+  const command = read("commands/execute-ralph-cc.md")
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(
+    command.includes("Quality Gate Sequence (pre-commit-equivalent for this repo)"),
+    true,
+  )
+  assert.equal(
+    skill.includes("direct .git/hooks/pre-commit execution may be blocked by safety guardrails"),
+    true,
+  )
+})
+
+test("test_execute_ralph_cc_dual_final_gate", () => {
+  const command = read("commands/execute-ralph-cc.md")
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(
+    command.includes("autonomous-reviewer must return APPROVED and review-implementation must return PASS"),
+    true,
+  )
+  assert.equal(
+    skill.includes("Only close epic when BOTH final reviewers approve"),
+    true,
+  )
+})
+
+test("test_execute_ralph_cc_max_50_remediation_cycles", () => {
+  const command = read("commands/execute-ralph-cc.md")
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(skill.includes("max 50 no-progress remediation cycles"), true)
+  assert.equal(skill.includes("Track max 50 no-progress remediation cycles"), true)
+})
+
+test("test_execute_ralph_cc_auto_creates_tasks_when_criteria_unmet", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(
+    skill.includes("Task list exhaustion alone is NEVER a stop condition"),
+    true,
+  )
+  assert.equal(
+    skill.includes("auto-create the next task"),
+    true,
+  )
+})
+
+test("test_execute_ralph_cc_sre_refinement_required", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(skill.includes("Use Skill tool: `xpowers:sre-task-refinement`"), true)
+})
+
+test("test_execute_ralph_cc_sha_drift_verification", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(skill.includes("PRE_SHA=$(git rev-parse HEAD)"), true)
+  assert.equal(skill.includes("POST_SHA=$(git rev-parse HEAD)"), true)
+})
+
+test("test_execute_ralph_cc_mixed_verdicts_do_not_close_epic", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(skill.includes("Mixed final reviewer outputs are non-approval"), true)
+  assert.equal(
+    skill.includes("Do not close the epic unless both final reviewers return an approval verdict"),
+    true,
+  )
+})
+
+test("test_execute_ralph_cc_unknown_verdict_forces_remediation", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(
+    skill.includes("Unknown or malformed verdict must create a remediation task and continue the loop"),
+    true,
+  )
+})
+
+test("test_execute_ralph_cc_activation_rule_exists", () => {
+  const rules = JSON.parse(read("hooks/skill-rules.json"))
+
+  assert.ok(rules["execute-ralph-cc"])
+  assert.equal(rules["execute-ralph-cc"].priority, "critical")
+  assert.equal(rules["execute-ralph-cc"].type, "workflow")
+})
+
+test("test_execute_ralph_cc_command_references_correct_skill", () => {
+  const command = read("commands/execute-ralph-cc.md")
+
+  assert.equal(command.includes("execute-ralph-cc"), true)
+  assert.equal(command.includes("ScheduleWakeup"), true)
+})
+
+test("test_execute_ralph_cc_phase_4_max_2_reentries", () => {
+  const skill = read("skills/execute-ralph-cc/SKILL.md")
+
+  assert.equal(
+    skill.includes("Max 2 consecutive Phase 4 re-entries"),
+    true,
+  )
+})

--- a/tests/execute-ralph-cc-contract.test.js
+++ b/tests/execute-ralph-cc-contract.test.js
@@ -12,7 +12,7 @@ test("test_execute_ralph_cc_uses_schedulewakeup_for_continuation", () => {
 
   assert.equal(skill.includes("ScheduleWakeup"), true)
   assert.equal(skill.includes("delaySeconds: 60"), true)
-  assert.equal(skill.includes("<<autonomous-loop-dynamic>>"), true)
+  assert.equal(skill.includes("Continue execute-ralph-cc. Load the skill and start at Phase 0"), true)
 })
 
 test("test_execute_ralph_cc_does_not_use_sentinels_as_operational_control", () => {

--- a/tests/execute-ralph-contract.test.js
+++ b/tests/execute-ralph-contract.test.js
@@ -233,6 +233,21 @@ test("test_ralph_autopilot_stop_hook_registered_for_activation_stop_and_subagent
   assert.ok(stopCommands.indexOf(hookCommand) < stopCommands.indexOf(reminderCommand))
 })
 
+test("test_execute_ralph_command_routes_to_cc_for_claude_code", () => {
+  const command = read("commands/execute-ralph.md")
+
+  assert.equal(command.includes("Platform Routing"), true)
+  assert.equal(command.includes("execute-ralph-cc"), true)
+  assert.equal(command.includes("ScheduleWakeup"), true)
+})
+
+test("test_execute_ralph_command_routes_to_original_for_other_platforms", () => {
+  const command = read("commands/execute-ralph.md")
+
+  assert.equal(command.includes("OpenCode"), true)
+  assert.equal(command.includes("`execute-ralph` skill"), true)
+})
+
 test("test_ralph_autopilot_stop_hook_is_executable_node_script", () => {
   const hookPath = path.join(repoRoot, "hooks/stop/30-ralph-autopilot-continue.js")
   const hook = read("hooks/stop/30-ralph-autopilot-continue.js")


### PR DESCRIPTION
## Summary
- New `/xpowers:execute-ralph-cc` skill uses native `ScheduleWakeup` tool for reliable one-task-per-turn autonomous execution in Claude Code
- `/xpowers:execute-ralph` now auto-detects platform: routes to `execute-ralph-cc` in Claude Code, original stop-hook-based skill for other platforms
- Original `execute-ralph` unchanged for OpenCode/Gemini/Kimi (stop hooks work fine there)

## Why
The stop-hook mechanism (`30-ralph-autopilot-continue.js`) is unreliable in Claude Code — context limits, turn limits, and permission prompts cause stops the hook can't prevent. ScheduleWakeup embraces Claude Code's natural stop behavior: complete one task, schedule a 60s wake-up, continue.

## Changes
| File | Action |
|------|--------|
| `commands/execute-ralph-cc.md` | New command entry point |
| `skills/execute-ralph-cc/SKILL.md` | New skill: Phase 0-5 with ScheduleWakeup loop |
| `commands/execute-ralph.md` | Added platform routing section |
| `hooks/skill-rules.json` | Added `execute-ralph-cc` activation rule (critical priority) |
| `tests/execute-ralph-cc-contract.test.js` | 17 contract tests for new skill |
| `tests/execute-ralph-contract.test.js` | 2 new tests for platform routing |

## Key design differences

| Aspect | execute-ralph | execute-ralph-cc |
|--------|--------------|------------------|
| Continuation | Stop hook + sentinels | ScheduleWakeup |
| Tasks per turn | Multiple (continuous) | Exactly one |
| State between iterations | In-context memory | bd/tm re-read |
| Context pressure | High | Low (fresh per task) |

## Test plan
- [x] 17 new contract tests pass (`tests/execute-ralph-cc-contract.test.js`)
- [x] 20 original contract tests pass (no regression, `tests/execute-ralph-contract.test.js`)
- [x] Full suite 463+ tests pass
- [x] Sync script picks up new skill (`node scripts/sync-codex-skills.js --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code–only autonomous execution workflow: scheduled wakeups, six-phase epic loop, iterative remediation, and dual-final-approval closure; optional --reviewer-model (default: opus) and platform routing to this workflow.

* **Documentation**
  * Detailed specs, flowcharts, quality gates, verdict normalization, guardrails, examples, and usage guidance.

* **Tests**
  * Contract tests for workflow semantics, guardrails, routing, and reviewer/gating behaviors.

* **Chores**
  * Routing rule added; installer prompts now read from the terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->