### PR TITLE
fix: remove invalid model: inherit from OpenCode agent files

### DIFF
--- a/.opencode/agents/autonomous-reviewer.md
+++ b/.opencode/agents/autonomous-reviewer.md
@@ -1,13 +1,6 @@
 ---
 name: autonomous-reviewer
 description: Machine-facing reviewer for automated pipelines. Returns structured verdicts (PASS/NEEDS_FIX/APPROVED/GAPS_FOUND) with actionable fix instructions for orchestrators to act on. Can research unclear patterns via web search. Use during continuous execution (ralph, execute-ralph). Contrast with code-reviewer (human-facing, narrative explanations) and review-implementation (spec-focused, requirements checklist).
-# Model Configuration:
-# - inherit: Use the parent's/current model (default)
-# - providerID/modelID: Explicit model selection (e.g., anthropic/claude-opus-4-5)
-# 
-# Recommended: Most capable model (opus, glm-4.7) for final validation and comprehensive review
-# See docs/model-configuration.md for details
-model: inherit
 ---
 
 > 📚 See the main xpowers documentation: [Global README](../README.md)

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -3,13 +3,6 @@
 name: code-reviewer
 description: >
   Human-facing code reviewer for major milestones. Provides detailed explanations, suggestions, and code samples (not just verdicts). Use after completing a logical chunk of work against the original plan. Contrast with autonomous-reviewer (machine-facing, verdict-only) and review-implementation (spec-focused, requirements checklist). Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the xpowers:code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the xpowers:code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the xpowers:code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the xpowers:code-reviewer agent should review the work.</commentary></example>
-# Model Configuration:
-# - inherit: Use the parent's/current model (default)
-# - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-5)
-# 
-# Recommended: Capable model (sonnet, glm-4.7) for complex reasoning and analysis
-# See docs/model-configuration.md for details
-model: inherit
 
 ---
 

--- a/.opencode/agents/codebase-investigator.md
+++ b/.opencode/agents/codebase-investigator.md
@@ -3,7 +3,6 @@
 name: codebase-investigator
 description: >
   Use this agent when planning or designing features and you need to understand current codebase state, find existing patterns, or verify assumptions about what exists. Examples: <example>Context: Starting brainstorming phase and need to understand current authentication implementation. user: "I want to add OAuth support to our app" assistant: "Let me use the xpowers:codebase-investigator agent to understand how authentication currently works before we design the OAuth integration" <commentary>Before designing new features, investigate existing patterns to ensure the design builds on what's already there.</commentary></example> <example>Context: Writing implementation plan and need to verify file locations and current structure. user: "Create a plan for adding user profiles" assistant: "I'll use the xpowers:codebase-investigator agent to verify the current user model structure and find where user-related code lives" <commentary>Investigation prevents hallucinating file paths or assuming structure that doesn't exist.</commentary></example>
-model: inherit
 
 ---
 

--- a/.opencode/agents/devops.md
+++ b/.opencode/agents/devops.md
@@ -1,7 +1,6 @@
 ---
 
 name: devops
-model: inherit
 description: DevOps reviewer - analyzes CI/CD pipelines, pre-commit hooks, build configurations, and diagnoses pipeline failures. Returns PASS or ISSUES_FOUND.
 tools:
   Read: true

--- a/.opencode/agents/internet-researcher.md
+++ b/.opencode/agents/internet-researcher.md
@@ -3,7 +3,6 @@
 name: internet-researcher
 description: >
   Use this agent when planning or designing features and you need current information from the internet, API documentation, library usage patterns, or external knowledge. Examples: <example>Context: Designing integration with external service and need to understand current API. user: "I want to integrate with the Stripe API for payments" assistant: "Let me use the xpowers:internet-researcher agent to find the current Stripe API documentation and best practices for integration" <commentary>Before designing integrations, research current API state to ensure plan matches reality.</commentary></example> <example>Context: Evaluating technology choices for implementation plan. user: "Should we use library X or Y for this feature?" assistant: "I'll use the xpowers:internet-researcher agent to research both libraries' current status, features, and community recommendations" <commentary>Research helps make informed technology decisions based on current information.</commentary></example>
-model: inherit
 
 ---
 

--- a/.opencode/agents/knowledge-aggregator.md
+++ b/.opencode/agents/knowledge-aggregator.md
@@ -3,13 +3,6 @@
 name: knowledge-aggregator
 description: >
   Use this agent when you need to aggregate context from project documentation, issue trackers, and team communications. Gathers knowledge from local docs, Linear, GitHub Issues, Slack, and other MCP sources. Examples: <example>Context: Starting brainstorming and need to understand prior team decisions about a feature area. user: "What has the team discussed about authentication?" assistant: "Let me use the knowledge-aggregator agent to search project docs, issues, and team communications for authentication context" <commentary>Knowledge aggregator checks all available sources, not just code, to find decisions and context.</commentary></example> <example>Context: Debugging an issue and want to find related past bugs or discussions. user: "Has anyone reported this error before?" assistant: "I'll use the knowledge-aggregator agent to search issues, PRs, and team communications for similar reports" <commentary>Aggregating from multiple sources finds context that searching code alone would miss.</commentary></example>
-# Model Configuration:
-# - inherit: Use the parent's/current model (default)
-# - providerID/modelID: Explicit model selection (e.g., anthropic/claude-sonnet-4-6)
-# 
-# Recommended: Capable model (sonnet) for synthesis across multiple sources
-# See docs/model-configuration.md for details
-model: inherit
 tools:
   Read: true
   Grep: true

--- a/.opencode/agents/planner.md
+++ b/.opencode/agents/planner.md
@@ -3,13 +3,6 @@
 name: planner
 description: >
   Use this agent when planning or designing features and you need to decompose goals into architecture and task dependency graphs with exact file paths. Examples: <example>Context: User has validated requirements in brainstorming and needs architectural decomposition. user: "Requirements are clear, now break this into implementable tasks" assistant: "Let me use the planner agent to create an architecture and task dependency graph based on the actual codebase structure" <commentary>Planner reads codebase before planning, ensuring tasks reference real files and follow existing patterns.</commentary></example> <example>Context: Writing implementation plan and need to identify all files that will change. user: "Create a plan for adding WebSocket support" assistant: "I'll use the planner agent to map which files need changes and create a dependency-ordered task graph" <commentary>Planner produces file change maps with exact paths, not guesses.</commentary></example>
-# Model Configuration:
-# - inherit: Use the parent's/current model (default)
-# - providerID/modelID: Explicit model selection (e.g., anthropic/claude-opus-4-6)
-# 
-# Recommended: Most capable model (opus) for deep architectural reasoning
-# See docs/model-configuration.md for details
-model: inherit
 tools:
   Read: true
   Grep: true

--- a/.opencode/agents/ralph.md
+++ b/.opencode/agents/ralph.md
@@ -3,10 +3,6 @@
 name: ralph
 description: >
   YOLO mode autonomous executor. Uses bv robot-triage for smart task selection. Executes continuously without user confirmation. All permissions pre-approved. Only stops on critical failure or when all work is complete. Examples: <example>Context: User wants hands-off execution of an epic. user: "Execute epic bd-1 autonomously" assistant: "I'll use the ralph agent for autonomous YOLO mode execution with smart triage" <commentary>Ralph executes without checkpoints, using test-runner and autonomous-reviewer for quality gates.</commentary></example> <example>Context: User wants to clear all ready tasks without interaction. user: "Work through all ready tasks" assistant: "I'll dispatch ralph to autonomously claim and execute all actionable tasks" <commentary>Ralph uses bv robot-triage and robot-next for optimal task selection.</commentary></example>
-# Model Configuration:
-# - inherit: Use the parent's/current model (default)
-# Ralph should inherit the parent model since it orchestrates other agents
-model: inherit
 
 ---
 

--- a/.opencode/agents/review-documentation.md
+++ b/.opencode/agents/review-documentation.md
@@ -1,7 +1,6 @@
 ---
 
 name: review-documentation
-model: inherit
 description: Documentation reviewer - checks if docs need updates for API changes, new features, config changes. Returns PASS or ISSUES_FOUND.
 tools:
   Read: true

--- a/.opencode/agents/review-implementation.md
+++ b/.opencode/agents/review-implementation.md
@@ -1,7 +1,6 @@
 ---
 
 name: review-implementation
-model: inherit
 description: >
   Spec-focused implementation reviewer - verifies code achieves stated goals and requirements alignment. Checks each requirement against actual code with file:line evidence. Contrast with code-reviewer (human-facing, broad quality) and autonomous-reviewer (machine-facing, verdict-only). Returns PASS or ISSUES_FOUND.
 tools:

--- a/.opencode/agents/review-quality.md
+++ b/.opencode/agents/review-quality.md
@@ -1,7 +1,6 @@
 ---
 
 name: review-quality
-model: inherit
 description: Quality reviewer - finds bugs, race conditions, error handling gaps, resource leaks. Returns PASS or ISSUES_FOUND with severity.
 tools:
   Read: true

--- a/.opencode/agents/review-simplification.md
+++ b/.opencode/agents/review-simplification.md
@@ -1,7 +1,6 @@
 ---
 
 name: review-simplification
-model: inherit
 description: Simplification reviewer - detects over-engineering, unnecessary complexity, premature abstractions. Returns PASS or ISSUES_FOUND.
 tools:
   Read: true

--- a/.opencode/agents/review-testing.md
+++ b/.opencode/agents/review-testing.md
@@ -1,7 +1,6 @@
 ---
 
 name: review-testing
-model: inherit
 description: Testing reviewer - evaluates test coverage, test quality, and testing gaps. Returns PASS or ISSUES_FOUND.
 tools:
   Read: true

--- a/.opencode/agents/security-scanner.md
+++ b/.opencode/agents/security-scanner.md
@@ -1,7 +1,6 @@
 ---
 
 name: security-scanner
-model: inherit
 description: Security scanner - performs OWASP Top 10 scanning, secrets detection, and dependency vulnerability checks. Returns PASS or ISSUES_FOUND with severity.
 tools:
   Read: true

--- a/.opencode/agents/test-effectiveness-analyst.md
+++ b/.opencode/agents/test-effectiveness-analyst.md
@@ -1,7 +1,6 @@
 ---
 
 name: test-effectiveness-analyst
-model: inherit
 description: >
   Use this agent to analyze test effectiveness with Google Fellow SRE-level scrutiny. Identifies tautological tests, coverage gaming, weak assertions, and missing corner cases. Returns actionable plan to remove bad tests, strengthen weak ones, and add missing coverage. Examples: <example>Context: User wants to review test quality in their codebase. user: "Analyze the tests in src/auth/ for effectiveness" assistant: "I'll use the test-effectiveness-analyst agent to analyze your auth tests with expert scrutiny" <commentary>The agent will identify meaningless tests, weak assertions, and missing corner cases, returning a prioritized improvement plan.</commentary></example> <example>Context: User suspects tests are gaming coverage. user: "Our coverage is 90% but we keep finding bugs in production" assistant: "This suggests coverage gaming. Let me use the test-effectiveness-analyst agent to audit test quality" <commentary>High coverage with production bugs indicates tautological or weak tests that the agent will identify.</commentary></example>
 

--- a/.opencode/agents/test-runner.md
+++ b/.opencode/agents/test-runner.md
@@ -3,13 +3,6 @@
 name: test-runner
 description: >
   Use this agent to run tests, pre-commit hooks, or commits without polluting your context with verbose output. Agent runs commands, captures all output in its own context, and returns only summary + failures. Examples: <example>Context: Implementing a feature and need to verify tests pass. user: "Run the test suite to verify everything still works" assistant: "Let me use the test-runner agent to run tests and report only failures" <commentary>Running tests through agent keeps successful test output out of your context.</commentary></example> <example>Context: Before committing, need to run pre-commit hooks. user: "Run pre-commit hooks to verify code quality" assistant: "I'll use the test-runner agent to run pre-commit hooks and report only issues" <commentary>Pre-commit hooks often generate verbose formatting output that pollutes context.</commentary></example> <example>Context: Ready to commit, want to verify hooks pass. user: "Commit these changes and verify hooks pass" assistant: "I'll use the test-runner agent to run git commit and report hook results" <commentary>Commit triggers pre-commit hooks with lots of output.</commentary></example>
-# Model Configuration:
-# - inherit: Use the parent's/current model (default)
-# - providerID/modelID: Explicit model selection (e.g., anthropic/claude-haiku-4-5)
-# 
-# Recommended: Fast model (haiku, glm-4.5) for high-volume, low-complexity tasks
-# See docs/model-configuration.md for details
-model: inherit
 
 ---
 

--- a/.opencode/plugins/task-context-orchestrator.ts
+++ b/.opencode/plugins/task-context-orchestrator.ts
@@ -426,10 +426,12 @@ const readAgentFrontmatterModel = async (rootDir: string, agentName: string) => 
     try {
       const raw = await readFile(agentPath, "utf8")
       const model = parseFrontmatterModel(raw)
-      // Explicit `model: inherit` in a local file is terminal — do not fall
-      // through to global agent files which might override the intent.
+      // The first existing agent file is authoritative. Both `model: inherit`
+      // and a missing `model` field mean "inherit natively" — return null and
+      // do NOT fall through to global agent files, which would override the
+      // project-local intent (OpenCode omits `model` to inherit natively).
       if (model === INHERIT_SENTINEL) return null
-      if (model) return model
+      return model
     } catch {
       // Ignore unreadable agent files and keep searching fallback locations.
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ test("description", () => {
 
 - Use YAML frontmatter with `name`, `description`, and `model`
 - Description should include usage examples in `<example>` tags
-- Set `model: inherit` to use parent's model (recommended)
+- Omit `model` to inherit natively (OpenCode); use `model: inherit` only in Claude Code agent files
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ You can also use `/skills` in Codex UI to discover and select the same wrappers.
 <details>
 <summary><strong>After Installation: Configure Models</strong></summary>
 
-All agents use `model: inherit` by default, meaning they follow your current model selection.
+All agents inherit your top-level `model` by default, meaning they follow your current model selection.
 
 **Quick setup - copy an example config:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ Example configuration files for **OpenCode** and **Claude Code** with different 
 
 - Simplest configuration
 - Just set the `model` field at the top level
-- All agents use `model: inherit` by default
+- All agents inherit your top-level `model` natively (no per-agent `model` needed)
 - Add agent-specific overrides only if needed
 
 #### `opencode.example.anthropic.json`
@@ -128,9 +128,11 @@ model: anthropic/claude-haiku-4-5  # Full providerID/modelID
 
 | Format | Example | Use Case |
 |--------|---------|----------|
-| `inherit` | `model: inherit` | Use parent's/current model (default) |
+| *(omit `model`)* | _(no `model` field)_ | Inherit parent's/current model natively (default) |
 | `providerID/modelID` | `model: proxy1/claude-haiku-4-5` | Explicit provider and model |
 | `modelID` (OpenCode only) | `model: claude-haiku-4-5` | Shorthand for built-in providers |
+
+> **⚠️ Do not use `model: inherit`** in OpenCode agent files — it resolves to `undefined` and causes `ProviderModelNotFoundError`. Omit the `model` field to inherit natively.
 
 **Precedence order:**
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -164,11 +164,14 @@ model: anthropic/claude-haiku-4-5  # Full providerID/modelID format
 
 **Supported model values:**
 
-| Value | Description | Example |
-|-------|-------------|---------|
-| `inherit` | Use the parent's/current model | `model: inherit` |
-| `providerID/modelID` | Explicit provider and model | `model: anthropic/claude-sonnet-4-5` |
-| `modelID` (OpenCode only) | Shorthand for built-in providers | `model: claude-sonnet-4-5` |
+| Value | Description | Example | Host |
+|-------|-------------|---------|------|
+| *(omit `model`)* | Inherit the parent's/current model (native fallback) | _(no `model` field)_ | OpenCode |
+| `inherit` | Use the parent's/current model | `model: inherit` | Claude Code only |
+| `providerID/modelID` | Explicit provider and model | `model: anthropic/claude-sonnet-4-5` | Both |
+
+> **⚠️ OpenCode:** Do NOT use `model: inherit` — it resolves to `undefined` and causes `ProviderModelNotFoundError`.
+> To inherit the parent model on OpenCode, simply omit the `model` field from frontmatter entirely.
 
 **Example agent configurations:**
 
@@ -372,7 +375,7 @@ Claude Code uses a different configuration approach. Models are resolved through
 }
 ```
 
-All agents with `model: inherit` will use `claude-sonnet-4-5`.
+All agents without an explicit `model` in frontmatter (or in `opencode.json` → `agent.<name>.model`) will use `claude-sonnet-4-5`.
 
 ---
 

--- a/docs/opencode.example.inherit.json
+++ b/docs/opencode.example.inherit.json
@@ -33,5 +33,5 @@
     "lsp": "allow",
     "patch": "allow"
   },
-  "note": "No agent section needed - all agents use 'model: inherit' by default. Override specific agents by adding an 'agent' section if desired."
+  "note": "No agent section needed - all agents inherit the top-level 'model' natively. Override specific agents by adding an 'agent' section if desired."
 }

--- a/docs/xp-in-xpowers.md
+++ b/docs/xp-in-xpowers.md
@@ -369,7 +369,7 @@ Standards are enforced at multiple levels:
 **Agent Standards:**
 - YAML frontmatter with `name`, `description`, `model`
 - Description includes `<example>` tags
-- `model: inherit` recommended
+- Omit `model` to inherit natively (OpenCode); use `model: inherit` only in Claude Code agent files
 
 **Validation:**
 - `scripts/sync-codex-skills.js --check` verifies description quality

--- a/tests/opencode-agent-model-inherit.test.js
+++ b/tests/opencode-agent-model-inherit.test.js
@@ -24,7 +24,7 @@ test("no .opencode/agents/*.md contains model: inherit in frontmatter", () => {
     if (!frontmatter) continue
 
     for (const line of frontmatter.split("\n")) {
-      if (/^model:\s*inherit\s*$/.test(line)) {
+      if (/^\s*model\s*:\s*["']?inherit["']?\s*(?:#.*)?$/i.test(line)) {
         violators.push(file)
         break
       }
@@ -49,7 +49,7 @@ test("no .opencode/agents/*.md frontmatter documents inherit as a valid option",
     if (!frontmatter) continue
 
     for (const line of frontmatter.split("\n")) {
-      if (/^#.*inherit/i.test(line)) {
+      if (/^\s*#.*\binherit\b/i.test(line)) {
         violators.push(file)
         break
       }

--- a/tests/opencode-agent-model-inherit.test.js
+++ b/tests/opencode-agent-model-inherit.test.js
@@ -1,0 +1,64 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const path = require("node:path")
+
+const repoRoot = path.resolve(__dirname, "..")
+const opencodeAgentsDir = path.join(repoRoot, ".opencode", "agents")
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return null
+  return match[1]
+}
+
+test("no .opencode/agents/*.md contains model: inherit in frontmatter", () => {
+  const files = fs.readdirSync(opencodeAgentsDir).filter((f) => f.endsWith(".md"))
+  assert.ok(files.length > 0, "expected agent .md files in .opencode/agents/")
+
+  const violators = []
+  for (const file of files) {
+    const fullPath = path.join(opencodeAgentsDir, file)
+    const text = fs.readFileSync(fullPath, "utf8")
+    const frontmatter = parseFrontmatter(text)
+    if (!frontmatter) continue
+
+    for (const line of frontmatter.split("\n")) {
+      if (/^model:\s*inherit\s*$/.test(line)) {
+        violators.push(file)
+        break
+      }
+    }
+  }
+
+  assert.deepEqual(
+    violators,
+    [],
+    `These OpenCode agent files have model: inherit (invalid on OpenCode — omit the model field instead): ${violators.join(", ")}`,
+  )
+})
+
+test("no .opencode/agents/*.md frontmatter documents inherit as a valid option", () => {
+  const files = fs.readdirSync(opencodeAgentsDir).filter((f) => f.endsWith(".md"))
+  const violators = []
+
+  for (const file of files) {
+    const fullPath = path.join(opencodeAgentsDir, file)
+    const text = fs.readFileSync(fullPath, "utf8")
+    const frontmatter = parseFrontmatter(text)
+    if (!frontmatter) continue
+
+    for (const line of frontmatter.split("\n")) {
+      if (/^#.*inherit/i.test(line)) {
+        violators.push(file)
+        break
+      }
+    }
+  }
+
+  assert.deepEqual(
+    violators,
+    [],
+    `These files have frontmatter comments referencing inherit (misleading on OpenCode): ${violators.join(", ")}`,
+  )
+})

--- a/tests/task-context-orchestrator.test.ts
+++ b/tests/task-context-orchestrator.test.ts
@@ -595,11 +595,15 @@ test("task_model_routing_normalizes_prefixed_subagent_type_names", async () => {
 })
 
 test("task_model_routing_preserves_native_inheritance_when_only_top_level_model_exists", async () => {
+  const previousXdg = process.env.XDG_CONFIG_HOME
   const withGlobal = await createTempRootWithConfig({
     opencodeConfig: {
       model: "global/model",
     },
   })
+  // Isolate XDG so the developer's real ~/.config/opencode/agents/*.md does not
+  // leak into native-inheritance assertions.
+  process.env.XDG_CONFIG_HOME = join(withGlobal.root, "xdg-empty")
 
   try {
     const plugin = await taskContextOrchestratorPlugin({
@@ -617,6 +621,11 @@ test("task_model_routing_preserves_native_inheritance_when_only_top_level_model_
 
     expect(output.args.model).toBeUndefined()
   } finally {
+    if (previousXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = previousXdg
+    }
     await withGlobal.cleanup()
   }
 })
@@ -725,6 +734,57 @@ test("task_model_routing_local_inherit_stops_global_fallback", async () => {
     await plugin["tool.execute.before"]({ tool: "task" }, output)
 
     // model: inherit in local file should NOT fall through to global xdg/model
+    expect(output.args.model).toBeUndefined()
+  } finally {
+    if (previousXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = previousXdg
+    }
+    await cleanup()
+  }
+})
+
+test("task_model_routing_local_missing_model_stops_global_fallback", async () => {
+  const previousXdg = process.env.XDG_CONFIG_HOME
+  const { root, cleanup } = await createTempRoot()
+
+  // Create a global agent file with a concrete model
+  const xdgConfigHome = join(root, "xdg")
+  const globalAgentsDir = join(xdgConfigHome, "opencode", "agents")
+  await mkdir(globalAgentsDir, { recursive: true })
+  await writeFile(
+    join(globalAgentsDir, "review-documentation.md"),
+    `---\ndescription: reviewer\nmode: subagent\nmodel: global/should-not-win\n---\nPrompt`,
+    "utf8",
+  )
+  process.env.XDG_CONFIG_HOME = xdgConfigHome
+
+  // Create a local agent file with NO model field (OpenCode native inheritance)
+  const localAgentsDir = join(root, ".opencode", "agents")
+  await mkdir(localAgentsDir, { recursive: true })
+  await writeFile(
+    join(localAgentsDir, "review-documentation.md"),
+    `---\ndescription: reviewer\nmode: subagent\n---\nPrompt`,
+    "utf8",
+  )
+
+  try {
+    const plugin = await taskContextOrchestratorPlugin({
+      directory: root,
+      $: createShell({}).shell,
+    })
+    const output = {
+      args: {
+        prompt: "Review docs",
+        agent: "review-documentation",
+      },
+    }
+
+    await plugin["tool.execute.before"]({ tool: "task" }, output)
+
+    // A local file with no model field should NOT fall through to the global
+    // xdg/model; it is authoritative and inherits natively.
     expect(output.args.model).toBeUndefined()
   } finally {
     if (previousXdg === undefined) {


### PR DESCRIPTION
## Description

model: inherit is valid in Claude Code but resolves to undefined on OpenCode, causing ProviderModelNotFoundError on every subagent dispatch. OpenCode's mergeDeep puts .md frontmatter after opencode.json, so the invalid value also defeats the routing wizard's agent.<name>.model config.

Removed model: inherit from all 16 .opencode/agents/*.md files so agents fall through to the routing wizard's opencode.json models (or inherit the parent model natively).

Also:
- Removed misleading '# inherit' comment blocks from 6 agent files
- Corrected docs/model-configuration.md to mark inherit as Claude Code only
- Added guard test to prevent regression

## Related Issues

This was previously fixed in 7b6ade0 (Feb 2026) but re-introduced as a regression in 0491a80 (Apr 2026, 'Global Agent Synchronization').

## Checklist

- [x ] I have read the project `AGENTS.md` and followed the coding style guidelines.
- [x ] I have run `node --test tests/*.test.js` and all tests pass.
- [x ] I have run `npm run lint` and it passes.
- [x ] I have run `npm run test:ci-local` and it passes.
- [x ] I have run `node scripts/sync-codex-skills.js --check` and it passes.
- [x ] If I modified skills, agents, or commands, I ran `node scripts/sync-codex-skills.js --write` to regenerate Codex wrappers.
- [x ] I have added or updated tests for any new or changed functionality.
- [x ] I have updated relevant documentation (`docs/`, `README.md`, `AGENTS.md`, etc.) if needed.
- [x ] I have verified that CI will pass with these changes (`npm audit --audit-level=moderate` is clean).

## Host Platform Impact

- [ ] Claude Code
- [x ] OpenCode
- [ ] Gemini CLI
- [ ] Kimi CLI
- [ ] Codex CLI
- [ ] Pi
- [ ] Core framework / All hosts



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed invalid `model: inherit` configuration from agent definitions to ensure OpenCode-compatible configuration.
* **Bug Fixes**
  * Updated model resolution so missing/empty agent `model` no longer falls back to other locations when an agent name is found locally.
* **Documentation**
  * Clarified how model inheritance works, including the differences between OpenCode and Claude Code, and updated examples.
* **Tests**
  * Added/updated automated checks to block invalid `model: inherit` usage and prevent unintended model fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->