### PR TITLE
fix(install): Kimi Code installer bash 3.2 compatibility and user-skill safety

### DIFF
--- a/.kimi-code/INSTALL.md
+++ b/.kimi-code/INSTALL.md
@@ -34,27 +34,34 @@ For development (symlinks for live reload):
 | Location | Contents |
 |----------|----------|
 | `~/.kimi-code/skills/` | 20+ XPowers skills (brainstorming, TDD, refactoring, etc.) |
-| `~/.kimi-code/plugins/xpowers/kimi.plugin.json` | Plugin metadata for `kimi plugin list` |
 | `~/.kimi-code/hooks/` | Guard hooks (dangerous bash, env writes, beads truncation, etc.) |
 | `~/.kimi-code/config.toml` | `[[hooks]]` entries for PreToolUse / PostToolUse |
 | `~/.local/bin/tm` | Shared `tm` task-management runtime |
+
+The installer also tries `kimi plugin install` to register `kimi.plugin.json` from the repo root. If your `kimi` binary does not yet have a `plugin` subcommand, the skills and hooks still work; register the plugin later via the Kimi Code TUI (`/plugins install`) or copy `kimi.plugin.json` to `~/.kimi-code/plugins/xpowers/kimi.plugin.json` manually.
+
+### Using the TypeScript Installer
+
+```bash
+bun scripts/install.ts --yes --hosts kimi-code
+```
 
 ### Manual Install
 
 ```bash
 # 1. Create config directories
 mkdir -p ~/.kimi-code/skills
-mkdir -p ~/.kimi-code/plugins/xpowers
 mkdir -p ~/.kimi-code/hooks
 
 # 2. Copy skills (exclude codex-* wrappers and common-patterns)
 cp -r .kimi-code/skills/* ~/.kimi-code/skills/
 
-# 3. Copy plugin metadata
-cp kimi.plugin.json ~/.kimi-code/plugins/xpowers/kimi.plugin.json
-
-# 4. Install guard hooks
+# 3. Install guard hooks
 bash scripts/install-kimi-code-hooks.sh
+
+# 4. Optionally register plugin metadata if plugin install is unavailable
+mkdir -p ~/.kimi-code/plugins/xpowers
+cp kimi.plugin.json ~/.kimi-code/plugins/xpowers/kimi.plugin.json
 
 # 5. Verify the shared tm runtime
 ~/.local/bin/tm --help

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ Use the shared installer to provision the new TypeScript Kimi Code CLI support:
 ./scripts/install.sh --kimi-code
 ```
 
-Or use the interactive TypeScript installer:
+Or use the TypeScript installer non-interactively:
 
 ```bash
 bun scripts/install.ts --yes --hosts kimi-code

--- a/README.md
+++ b/README.md
@@ -514,13 +514,19 @@ Use the shared installer to provision the new TypeScript Kimi Code CLI support:
 ./scripts/install.sh --kimi-code
 ```
 
+Or use the interactive TypeScript installer:
+
+```bash
+bun scripts/install.ts --yes --hosts kimi-code
+```
+
 Or install all detected hosts at once:
 
 ```bash
 ./scripts/install.sh --all
 ```
 
-This copies skills into `~/.kimi-code/skills/`, registers plugin metadata, and installs guard hooks into `~/.kimi-code/config.toml`. After installation, restart Kimi Code or run `kimi /reload`.
+This copies skills into `~/.kimi-code/skills/`, installs guard hooks into `~/.kimi-code/config.toml`, and tries to register plugin metadata with `kimi plugin install`. If your `kimi` binary does not yet expose a `plugin` subcommand, the skills and hooks still work; register the plugin later via the Kimi Code TUI (`/plugins install`) or the manual steps in `.kimi-code/INSTALL.md`. After installation, restart Kimi Code or run `kimi /reload`.
 
 For Kimi Code-specific manual install and troubleshooting, see `.kimi-code/INSTALL.md`.
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,12 @@
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@linear/sdk": "^76.0.0",
+        "js-yaml": "^4.2.0",
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@types/js-yaml": "^4.0.9",
+        "eslint": "^10.2.1",
       },
     },
   },
@@ -15,12 +21,158 @@
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
+
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@linear/sdk": ["@linear/sdk@76.0.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0" } }, "sha512-Xt0x5Kl6qBoWhGFypb8ykyP+c5kT7scmRPs1uJidSPOaRgkMJ/4y41QpmZCWCBUMmZtf/O0VktgQio6rLXT94w=="],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.5.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
     "graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
   }
 }

--- a/scripts/install-kimi-code-hooks.sh
+++ b/scripts/install-kimi-code-hooks.sh
@@ -14,7 +14,7 @@ if [[ -n "$SCRIPT_SOURCE" && -f "$SCRIPT_SOURCE" ]]; then
   REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 fi
 
-KIMI_CODE_HOME="${KIMI_CODE_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/kimi-code}"
+KIMI_CODE_HOME="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
 CONFIG_FILE="${KIMI_CODE_HOME}/config.toml"
 HOOKS_DIR="${KIMI_CODE_HOME}/hooks"
 
@@ -90,7 +90,7 @@ XPOWERS_HOOKS_MARKER="# BEGIN XPOWERS KIMI-CODE HOOKS"
 XPOWERS_HOOKS_END="# END XPOWERS KIMI-CODE HOOKS"
 
 build_hook_config() {
-  cat <<'TOML'
+  cat <<TOML
 
 # BEGIN XPOWERS KIMI-CODE HOOKS
 # Installed by xpowers. These guard hooks block risky operations and beads
@@ -99,41 +99,41 @@ build_hook_config() {
 # Pre-tool hooks: inspect every tool call before execution.
 [[hooks]]
 event = "PreToolUse"
-command = "python3 ~/.kimi-code/hooks/pre-tool-use/block-beads-direct-read.py"
+command = "python3 ${KIMI_CODE_HOME}/hooks/pre-tool-use/block-beads-direct-read.py"
 timeout = 5
 
 [[hooks]]
 event = "PreToolUse"
-command = "python3 ~/.kimi-code/hooks/pre-tool-use/01-block-pre-commit-edits.py"
+command = "python3 ${KIMI_CODE_HOME}/hooks/pre-tool-use/01-block-pre-commit-edits.py"
 timeout = 5
 
 [[hooks]]
 event = "PreToolUse"
-command = "python3 ~/.kimi-code/hooks/pre-tool-use/block-dangerous-bash.py"
+command = "python3 ${KIMI_CODE_HOME}/hooks/pre-tool-use/block-dangerous-bash.py"
 timeout = 5
 
 [[hooks]]
 event = "PreToolUse"
-command = "python3 ~/.kimi-code/hooks/pre-tool-use/block-env-writes.py"
+command = "python3 ${KIMI_CODE_HOME}/hooks/pre-tool-use/block-env-writes.py"
 timeout = 5
 
 # Post-tool hooks: inspect tool results after execution.
 [[hooks]]
 event = "PostToolUse"
 matcher = "Bash"
-command = "python3 ~/.kimi-code/hooks/post-tool-use/02-block-bd-truncation.py"
+command = "python3 ${KIMI_CODE_HOME}/hooks/post-tool-use/02-block-bd-truncation.py"
 timeout = 5
 
 [[hooks]]
 event = "PostToolUse"
 matcher = "Bash"
-command = "python3 ~/.kimi-code/hooks/post-tool-use/03-block-pre-commit-bash.py"
+command = "python3 ${KIMI_CODE_HOME}/hooks/post-tool-use/03-block-pre-commit-bash.py"
 timeout = 5
 
 [[hooks]]
 event = "PostToolUse"
 matcher = "Bash"
-command = "python3 ~/.kimi-code/hooks/post-tool-use/04-block-pre-existing-checks.py"
+command = "python3 ${KIMI_CODE_HOME}/hooks/post-tool-use/04-block-pre-existing-checks.py"
 timeout = 5
 # END XPOWERS KIMI-CODE HOOKS
 TOML

--- a/scripts/install-kimi-code-hooks.sh
+++ b/scripts/install-kimi-code-hooks.sh
@@ -99,41 +99,41 @@ build_hook_config() {
 # Pre-tool hooks: inspect every tool call before execution.
 [[hooks]]
 event = "PreToolUse"
-command = "python3 ${KIMI_CODE_HOME}/hooks/pre-tool-use/block-beads-direct-read.py"
+command = "python3 \"${KIMI_CODE_HOME}/hooks/pre-tool-use/block-beads-direct-read.py\""
 timeout = 5
 
 [[hooks]]
 event = "PreToolUse"
-command = "python3 ${KIMI_CODE_HOME}/hooks/pre-tool-use/01-block-pre-commit-edits.py"
+command = "python3 \"${KIMI_CODE_HOME}/hooks/pre-tool-use/01-block-pre-commit-edits.py\""
 timeout = 5
 
 [[hooks]]
 event = "PreToolUse"
-command = "python3 ${KIMI_CODE_HOME}/hooks/pre-tool-use/block-dangerous-bash.py"
+command = "python3 \"${KIMI_CODE_HOME}/hooks/pre-tool-use/block-dangerous-bash.py\""
 timeout = 5
 
 [[hooks]]
 event = "PreToolUse"
-command = "python3 ${KIMI_CODE_HOME}/hooks/pre-tool-use/block-env-writes.py"
+command = "python3 \"${KIMI_CODE_HOME}/hooks/pre-tool-use/block-env-writes.py\""
 timeout = 5
 
 # Post-tool hooks: inspect tool results after execution.
 [[hooks]]
 event = "PostToolUse"
 matcher = "Bash"
-command = "python3 ${KIMI_CODE_HOME}/hooks/post-tool-use/02-block-bd-truncation.py"
+command = "python3 \"${KIMI_CODE_HOME}/hooks/post-tool-use/02-block-bd-truncation.py\""
 timeout = 5
 
 [[hooks]]
 event = "PostToolUse"
 matcher = "Bash"
-command = "python3 ${KIMI_CODE_HOME}/hooks/post-tool-use/03-block-pre-commit-bash.py"
+command = "python3 \"${KIMI_CODE_HOME}/hooks/post-tool-use/03-block-pre-commit-bash.py\""
 timeout = 5
 
 [[hooks]]
 event = "PostToolUse"
 matcher = "Bash"
-command = "python3 ${KIMI_CODE_HOME}/hooks/post-tool-use/04-block-pre-existing-checks.py"
+command = "python3 \"${KIMI_CODE_HOME}/hooks/post-tool-use/04-block-pre-existing-checks.py\""
 timeout = 5
 # END XPOWERS KIMI-CODE HOOKS
 TOML

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -922,10 +922,10 @@ install_kimi_code() {
     # the two documented installers without losing upgrade/uninstall tracking.
     local owned_skills=""
     if [[ -f "${home}/.xpowers-manifest" ]]; then
-      owned_skills+=" $(grep '^skills/' "${home}/.xpowers-manifest" 2>/dev/null | cut -d/ -f2 | sort -u | tr '\n' ' ')"
+      owned_skills+=" $(grep '^skills/' "${home}/.xpowers-manifest" 2>/dev/null | cut -d/ -f2 | sort -u | tr '\n' ' ' || true)"
     fi
     if [[ -f "${HOME}/.xpowers/manifest.json" ]] && command -v python3 >/dev/null 2>&1; then
-      owned_skills+=" $(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "${HOME}/.xpowers/manifest.json" 2>/dev/null | grep '^skills/' | cut -d/ -f2 | sort -u | tr '\n' ' ')"
+      owned_skills+=" $(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "${HOME}/.xpowers/manifest.json" 2>/dev/null | grep '^skills/' | cut -d/ -f2 | sort -u | tr '\n' ' ' || true)"
     fi
     for skill_dir in "${source_skills}"/*/; do
       [[ -d "$skill_dir" ]] || continue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -920,6 +920,10 @@ install_kimi_code() {
       local dirname; dirname="$(basename "$skill_dir")"
       [[ "$dirname" == codex-* ]] && continue
       [[ "$dirname" == common-patterns ]] && continue
+      if [[ -e "${home}/skills/${dirname}" ]]; then
+        warn "Skipping fallback skill ${dirname}: already exists at ${home}/skills/${dirname}"
+        continue
+      fi
       copy_item "$skill_dir" "${home}/skills/${dirname}"
       manifest_add "skills/${dirname}/"
     done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1062,10 +1062,17 @@ install_kimi_code() {
     fi
 
     # Fallback skills are now provided by the managed plugin. Clear the stale
-    # ownership records from both installers so a later fallback install does
-    # not mistake user-recreated skills for XPowers-owned ones.
+    # per-home text manifest so a later fallback install does not mistake
+    # user-recreated skills for XPowers-owned ones.
     rm -f "${home}/.xpowers-manifest" 2>/dev/null || true
-    clear_kimi_code_json_manifest
+
+    # Only clear the global JSON manifest entry when it refers to this same
+    # home, preserving ownership records for other/custom Kimi Code homes.
+    local json_target_dir
+    json_target_dir=$(read_kimi_json_manifest | head -1)
+    if [[ "$json_target_dir" == "$home" ]]; then
+      clear_kimi_code_json_manifest
+    fi
   fi
 
   # Fallback: copy skills to the canonical user-level skill path. Kimi Code

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -366,10 +366,13 @@ detect_kimi()    {
 detect_kimi_code() {
   if [[ -d "${HOME}/.kimi-code" ]]; then
     AGENT_PATHS_kimi_code="${HOME}/.kimi-code"
-  elif [[ -d "${KIMI_CODE_HOME:-${HOME}/.kimi-code}" ]]; then
-    AGENT_PATHS_kimi_code="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
+  elif [[ -n "${KIMI_CODE_HOME:-}" && -d "${KIMI_CODE_HOME}" ]]; then
+    AGENT_PATHS_kimi_code="${KIMI_CODE_HOME}"
+  elif [[ -d "${XDG_CFG}/kimi-code" ]]; then
+    # Legacy XDG location used by earlier versions of this installer.
+    AGENT_PATHS_kimi_code="${XDG_CFG}/kimi-code"
   elif command -v kimi &>/dev/null; then
-    AGENT_PATHS_kimi_code="$(command -v kimi)"
+    AGENT_PATHS_kimi_code="${HOME}/.kimi-code"
   fi
 }
 detect_codex()   {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -925,6 +925,12 @@ install_kimi_code() {
       done < <(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "${HOME}/.xpowers/manifest.json" 2>/dev/null | grep '^skills/' | cut -d/ -f2 || true)
     fi
     for dirname in "${prev_owned[@]}"; do
+      case "$dirname" in
+        ""|"."|".."|*/*|*..*)
+          warn "Ignoring unsafe Kimi Code fallback skill entry from manifest: ${dirname}"
+          continue
+          ;;
+      esac
       local skill_path="${home}/skills/${dirname}"
       if [[ -e "$skill_path" ]]; then
         rm -rf "$skill_path"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -534,6 +534,23 @@ uninstall_from_json_manifest() {
       rm -rf "${home}/${f}" 2>/dev/null || true
     fi
   done <<< "$files"
+
+  # Remove the kimi_code host entry so stale ownership records do not affect
+  # later installs. Delete the manifest entirely when no hosts remain.
+  if [[ "$DRY_RUN" != true ]]; then
+    python3 -c "
+import json, sys, os
+path = sys.argv[1]
+with open(path) as fh:
+    d = json.load(fh)
+d.setdefault('hosts', {}).pop('kimi_code', None)
+if not d.get('hosts') and not d.get('features'):
+    os.remove(path)
+else:
+    with open(path, 'w') as fh:
+        json.dump(d, fh, indent=2)
+" "$json_manifest" 2>/dev/null || true
+  fi
 }
 
 uninstall_from_manifest() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -503,6 +503,39 @@ write_manifest() {
   } > "$manifest"
 }
 
+# uninstall_from_json_manifest <agent_home>  — remove entries recorded by the
+# TypeScript installer in ~/.xpowers/manifest.json. This keeps shell and TS
+# uninstall paths consistent.
+uninstall_from_json_manifest() {
+  local home="$1"
+  local json_manifest="${HOME}/.xpowers/manifest.json"
+  [[ -f "$json_manifest" ]] || return 0
+  if ! command -v python3 >/dev/null 2>&1; then
+    warn "Skipping JSON manifest cleanup: python3 not available"
+    return 0
+  fi
+
+  local files
+  files=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "$json_manifest" 2>/dev/null || true)
+  [[ -n "$files" ]] || return 0
+
+  local f
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    # Only accept relative, single-component-or-subpath entries.
+    case "$f" in
+      /*|*..*|"."|".") continue ;;
+    esac
+    if [[ "$DRY_RUN" == true ]]; then
+      if [[ -e "${home}/${f}" ]]; then
+        info "Would remove (JSON manifest): ${home}/${f}"
+      fi
+    else
+      rm -rf "${home}/${f}" 2>/dev/null || true
+    fi
+  done <<< "$files"
+}
+
 uninstall_from_manifest() {
   # uninstall_from_manifest <agent_home>  — remove only manifest-listed entries
   local home="$1"
@@ -1232,6 +1265,10 @@ uninstall_kimi_code() {
   if [[ -f "${home}/.xpowers-manifest" ]]; then
     uninstall_from_manifest "$home"
   fi
+
+  # The TypeScript installer records files in ~/.xpowers/manifest.json; make
+  # sure the shell uninstaller cleans those up too.
+  uninstall_from_json_manifest "$home"
 
   # Remove XPowers hooks block from config.toml
   local config_file="${home}/config.toml"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -506,13 +506,13 @@ write_manifest() {
 # Read the TypeScript installer's global JSON manifest for the kimi_code host.
 # Prints the recorded targetDir on the first line, then one file entry per line.
 # Returns empty output if the manifest or host entry is missing.
+# Falls back to node if python3 is not available so cleanup does not silently
+# skip TS-installed files.
 read_kimi_json_manifest() {
   local json_manifest="${HOME}/.xpowers/manifest.json"
   [[ -f "$json_manifest" ]] || return 0
-  if ! command -v python3 >/dev/null 2>&1; then
-    return 0
-  fi
-  python3 -c "
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c "
 import json, sys
 try:
     d = json.load(open(sys.argv[1]))
@@ -523,6 +523,61 @@ try:
 except Exception:
     pass
 " "$json_manifest" 2>/dev/null || true
+  elif command -v node >/dev/null 2>&1; then
+    node -e "
+const fs = require('fs');
+const p = process.argv[1];
+try {
+  const d = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const h = (d.hosts && d.hosts.kimi_code) || {};
+  console.log(h.targetDir || '');
+  (h.files || []).forEach(f => console.log(f));
+} catch (e) {}
+" "$json_manifest" 2>/dev/null || true
+  fi
+}
+
+# Remove the hosts.kimi_code entry from the TypeScript installer's global
+# manifest. Delete the manifest entirely when no hosts remain. Falls back to
+# node if python3 is not available.
+clear_kimi_code_json_manifest() {
+  local json_manifest="${HOME}/.xpowers/manifest.json"
+  [[ -f "$json_manifest" ]] || return 0
+  if [[ "$DRY_RUN" == true ]]; then
+    return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c "
+import json, sys, os
+path = sys.argv[1]
+with open(path) as fh:
+    d = json.load(fh)
+d.setdefault('hosts', {}).pop('kimi_code', None)
+if not d.get('hosts') and not d.get('features'):
+    os.remove(path)
+else:
+    with open(path, 'w') as fh:
+        json.dump(d, fh, indent=2)
+" "$json_manifest" 2>/dev/null || true
+  elif command -v node >/dev/null 2>&1; then
+    node -e "
+const fs = require('fs');
+const p = process.argv[1];
+try {
+  const d = JSON.parse(fs.readFileSync(p, 'utf8'));
+  if (d.hosts) delete d.hosts.kimi_code;
+  const hasHosts = d.hosts && Object.keys(d.hosts).length > 0;
+  const hasFeatures = d.features && Object.keys(d.features).length > 0;
+  if (!hasHosts && !hasFeatures) {
+    fs.unlinkSync(p);
+  } else {
+    fs.writeFileSync(p, JSON.stringify(d, null, 2));
+  }
+} catch (e) {}
+" "$json_manifest" 2>/dev/null || true
+  else
+    warn "Cannot update ${json_manifest}: python3 or node required"
+  fi
 }
 
 # uninstall_from_json_manifest <agent_home>  — remove entries recorded by the
@@ -559,22 +614,8 @@ uninstall_from_json_manifest() {
   done <<< "$files"
 
   # Remove the kimi_code host entry so stale ownership records do not affect
-  # later installs. Delete the manifest entirely when no hosts remain.
-  if [[ "$DRY_RUN" != true ]]; then
-    local json_manifest="${HOME}/.xpowers/manifest.json"
-    python3 -c "
-import json, sys, os
-path = sys.argv[1]
-with open(path) as fh:
-    d = json.load(fh)
-d.setdefault('hosts', {}).pop('kimi_code', None)
-if not d.get('hosts') and not d.get('features'):
-    os.remove(path)
-else:
-    with open(path, 'w') as fh:
-        json.dump(d, fh, indent=2)
-" "$json_manifest" 2>/dev/null || true
-  fi
+  # later installs.
+  clear_kimi_code_json_manifest
 }
 
 uninstall_from_manifest() {
@@ -1019,6 +1060,12 @@ install_kimi_code() {
         fi
       done
     fi
+
+    # Fallback skills are now provided by the managed plugin. Clear the stale
+    # ownership records from both installers so a later fallback install does
+    # not mistake user-recreated skills for XPowers-owned ones.
+    rm -f "${home}/.xpowers-manifest" 2>/dev/null || true
+    clear_kimi_code_json_manifest
   fi
 
   # Fallback: copy skills to the canonical user-level skill path. Kimi Code

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -915,12 +915,18 @@ install_kimi_code() {
   if [[ "$plugin_installed" != true ]]; then
     ensure_dir "${home}/skills"
     local source_skills="${REPO_ROOT}/.kimi-code/skills"
+    # Skills already owned by a previous XPowers fallback install may be
+    # refreshed; everything else is treated as a user skill and skipped.
+    local owned_skills=""
+    if [[ -f "${home}/.xpowers-manifest" ]]; then
+      owned_skills="$(grep '^skills/' "${home}/.xpowers-manifest" 2>/dev/null | cut -d/ -f2 | sort -u | tr '\n' ' ')"
+    fi
     for skill_dir in "${source_skills}"/*/; do
       [[ -d "$skill_dir" ]] || continue
       local dirname; dirname="$(basename "$skill_dir")"
       [[ "$dirname" == codex-* ]] && continue
       [[ "$dirname" == common-patterns ]] && continue
-      if [[ -e "${home}/skills/${dirname}" ]]; then
+      if [[ -e "${home}/skills/${dirname}" && " ${owned_skills} " != *" ${dirname} "* ]]; then
         warn "Skipping fallback skill ${dirname}: already exists at ${home}/skills/${dirname}"
         continue
       fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1216,6 +1216,18 @@ uninstall_kimi_code() {
     fi
   fi
 
+  # `kimi plugin remove` leaves the managed directory behind, so clean it up
+  # explicitly to match the user's expectation that uninstall removes the
+  # XPowers code.
+  local managed_dir="${home}/plugins/managed/xpowers"
+  if [[ "$DRY_RUN" == true ]]; then
+    if [[ -e "$managed_dir" ]]; then
+      info "Would remove managed plugin directory: ${managed_dir}"
+    fi
+  else
+    rm -rf "$managed_dir" 2>/dev/null || true
+  fi
+
   # Remove fallback user-level skills and version marker tracked by manifest.
   if [[ -f "${home}/.xpowers-manifest" ]]; then
     uninstall_from_manifest "$home"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -300,7 +300,7 @@ remove_legacy() {
             local count
             count=$(remove_legacy_from_manifest "$agent_home" "$legacy_manifest")
             total_removed=$((total_removed + count))
-            processed_manifests="${processed_manifests}${legacy_manifest}$'\n'"
+            processed_manifests="${processed_manifests}${legacy_manifest}"$'\n'
           fi
         done
       fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,6 +89,9 @@ bootstrap_from_checkout "$@"
 VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' \
   "$REPO_ROOT/.claude-plugin/plugin.json" | grep -o '"[^"]*"$' | tr -d '"')
 
+# Bash 3.2-compatible lowercase helper
+lowercase() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
 # Colors (respect NO_COLOR and non-tty)
 if [[ -n "${NO_COLOR:-}" ]] || ! [[ -t 1 ]]; then
   RED='' GREEN='' YELLOW='' BLUE='' BOLD='' DIM='' CYAN='' RESET=''
@@ -258,7 +261,7 @@ remove_legacy_from_manifest() {
 
 remove_legacy() {
   local total_removed=0
-  declare -A processed_manifests
+  local processed_manifests=""
 
   for name in "${CONFLICT_NAMES[@]}"; do
     while IFS= read -r candidate; do
@@ -277,7 +280,7 @@ remove_legacy() {
       if [[ -n "$agent_home" ]]; then
         for legacy_name in hyperpowers myhyperpowers superpowers; do
           local legacy_manifest="${agent_home}/.${legacy_name}-manifest"
-          if [[ -f "$legacy_manifest" && -z "${processed_manifests[$legacy_manifest]:-}" ]]; then
+          if [[ -f "$legacy_manifest" && "$processed_manifests" != *"${legacy_manifest}"* ]]; then
             if [[ "$DRY_RUN" != true ]] && [[ "$PURGE" != true ]]; then
               while IFS= read -r entry; do
                 [[ -z "$entry" ]] && continue
@@ -297,7 +300,7 @@ remove_legacy() {
             local count
             count=$(remove_legacy_from_manifest "$agent_home" "$legacy_manifest")
             total_removed=$((total_removed + count))
-            processed_manifests[$legacy_manifest]=1
+            processed_manifests="${processed_manifests}${legacy_manifest}$'\n'"
           fi
         done
       fi
@@ -331,51 +334,59 @@ remove_legacy() {
 # Agent detection
 # ---------------------------------------------------------------------------
 
-declare -A AGENT_PATHS=()
-declare -A AGENT_LABELS=(
-  [claude]="Claude Code"
-  [opencode]="OpenCode"
-  [kimi_code]="Kimi Code CLI"
-  [kimi]="Kimi CLI (legacy)"
-  [codex]="Codex CLI"
-  [gemini]="Gemini CLI"
-  [pi]="Pi Agent"
-)
 AGENT_ORDER=(claude opencode kimi_code kimi codex gemini pi)
 
-detect_claude()  { [[ -d "${HOME}/.claude" ]] && AGENT_PATHS[claude]="${HOME}/.claude" || true; }
-detect_opencode(){ [[ -d "${XDG_CFG}/opencode" ]] && AGENT_PATHS[opencode]="${XDG_CFG}/opencode" || true; }
+agent_label() {
+  case "$1" in
+    claude)    echo "Claude Code" ;;
+    opencode)  echo "OpenCode" ;;
+    kimi_code) echo "Kimi Code CLI" ;;
+    kimi)      echo "Kimi CLI (legacy)" ;;
+    codex)     echo "Codex CLI" ;;
+    gemini)    echo "Gemini CLI" ;;
+    pi)        echo "Pi Agent" ;;
+    *)         echo "$1" ;;
+  esac
+}
+
+agent_path() {
+  local var="AGENT_PATHS_$1"
+  echo "${!var:-}"
+}
+
+detect_claude()  { [[ -d "${HOME}/.claude" ]] && AGENT_PATHS_claude="${HOME}/.claude" || true; }
+detect_opencode(){ [[ -d "${XDG_CFG}/opencode" ]] && AGENT_PATHS_opencode="${XDG_CFG}/opencode" || true; }
 detect_kimi()    {
   if [[ -d "${XDG_CFG}/agents" ]]; then
-    AGENT_PATHS[kimi]="${XDG_CFG}/agents"
+    AGENT_PATHS_kimi="${XDG_CFG}/agents"
   elif [[ -d "${HOME}/.kimi" ]]; then
-    AGENT_PATHS[kimi]="${HOME}/.kimi"
+    AGENT_PATHS_kimi="${HOME}/.kimi"
   fi
 }
 detect_kimi_code() {
-  if command -v kimi &>/dev/null; then
-    AGENT_PATHS[kimi_code]="$(command -v kimi)"
-  elif [[ -d "${XDG_CFG}/kimi-code" ]]; then
-    AGENT_PATHS[kimi_code]="${XDG_CFG}/kimi-code"
-  elif [[ -d "${HOME}/.kimi-code" ]]; then
-    AGENT_PATHS[kimi_code]="${HOME}/.kimi-code"
+  if [[ -d "${HOME}/.kimi-code" ]]; then
+    AGENT_PATHS_kimi_code="${HOME}/.kimi-code"
+  elif [[ -d "${KIMI_CODE_HOME:-${HOME}/.kimi-code}" ]]; then
+    AGENT_PATHS_kimi_code="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
+  elif command -v kimi &>/dev/null; then
+    AGENT_PATHS_kimi_code="$(command -v kimi)"
   fi
 }
 detect_codex()   {
   if [[ -d "${HOME}/.codex" ]]; then
-    AGENT_PATHS[codex]="${HOME}/.codex"
+    AGENT_PATHS_codex="${HOME}/.codex"
   elif [[ -d "${HOME}/.agents" ]]; then
-    AGENT_PATHS[codex]="${HOME}/.agents"
+    AGENT_PATHS_codex="${HOME}/.agents"
   elif command -v codex &>/dev/null; then
-    AGENT_PATHS[codex]="${HOME}/.codex"
+    AGENT_PATHS_codex="${HOME}/.codex"
   fi
 }
-detect_gemini()  { command -v gemini &>/dev/null && AGENT_PATHS[gemini]="$(command -v gemini)" || true; }
+detect_gemini()  { command -v gemini &>/dev/null && AGENT_PATHS_gemini="$(command -v gemini)" || true; }
 detect_pi()      {
   if [[ -d "${HOME}/.pi" ]]; then
-    AGENT_PATHS[pi]="${HOME}/.pi/agent"
+    AGENT_PATHS_pi="${HOME}/.pi/agent"
   elif command -v pi &>/dev/null; then
-    AGENT_PATHS[pi]="${HOME}/.pi/agent"
+    AGENT_PATHS_pi="${HOME}/.pi/agent"
   fi
 }
 
@@ -393,9 +404,10 @@ show_detection() {
   echo -e "  ${BOLD}Detecting agents...${RESET}"
   echo
   for agent in "${AGENT_ORDER[@]}"; do
-    local label="${AGENT_LABELS[$agent]}"
-    if [[ -n "${AGENT_PATHS[$agent]:-}" ]]; then
-      printf "  ${GREEN}✓${RESET} %-16s %s\n" "$label" "${AGENT_PATHS[$agent]}"
+    local label; label="$(agent_label "$agent")"
+    local apath; apath="$(agent_path "$agent")"
+    if [[ -n "${apath}" ]]; then
+      printf "  ${GREEN}✓${RESET} %-16s %s\n" "$label" "$apath"
     else
       printf "  ${DIM}✗ %-16s not found${RESET}\n" "$label"
     fi
@@ -591,7 +603,8 @@ uninstall_from_manifest() {
 # ---------------------------------------------------------------------------
 
 install_claude() {
-  local home="${AGENT_PATHS[claude]:-${HOME}/.claude}"
+  local home; home="$(agent_path "claude")"
+  home="${home:-${HOME}/.claude}"
   MANIFEST_ENTRIES=()
   ensure_dir "${home}/skills"
   ensure_dir "${home}/agents"
@@ -692,7 +705,8 @@ with open('$tmp', 'w') as f:
     echo ""
     echo -n "  Install memsearch? [y/N] "
     read -r answer </dev/tty
-    if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
+    local lc_answer; lc_answer="$(lowercase "$answer")"
+    if [[ "$lc_answer" == "y" || "$lc_answer" == "yes" ]]; then
       if command -v python3 >/dev/null 2>&1; then
         echo "  Installing memsearch[onnx]..."
         python3 -m pip install --user "memsearch[onnx]" --quiet && echo "  memsearch installed." || warn "memsearch install failed — try: python3 -m pip install --user memsearch[onnx]"
@@ -708,7 +722,8 @@ with open('$tmp', 'w') as f:
 }
 
 install_opencode() {
-  local home="${AGENT_PATHS[opencode]:-${XDG_CFG}/opencode}"
+  local home; home="$(agent_path "opencode")"
+  home="${home:-${XDG_CFG}/opencode}"
   MANIFEST_ENTRIES=()
   ensure_dir "${home}/skills"
   ensure_dir "${home}/agents"
@@ -784,7 +799,8 @@ install_opencode() {
     echo ""
     echo -n "  Run routing wizard? [y/N] "
     read -r answer </dev/tty
-    if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
+    local lc_answer; lc_answer="$(lowercase "$answer")"
+    if [[ "$lc_answer" == "y" || "$lc_answer" == "yes" ]]; then
       bun "${REPO_ROOT}/scripts/opencode-routing-wizard.ts" || warn "Routing wizard failed"
     fi
   fi
@@ -798,7 +814,8 @@ install_opencode() {
     echo ""
     echo -n "  Install memsearch? [y/N] "
     read -r answer </dev/tty
-    if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
+    local lc_answer; lc_answer="$(lowercase "$answer")"
+    if [[ "$lc_answer" == "y" || "$lc_answer" == "yes" ]]; then
       if command -v python3 >/dev/null 2>&1; then
         echo "  Installing memsearch[onnx]..."
         python3 -m pip install --user "memsearch[onnx]" --quiet && echo "  memsearch installed." || warn "memsearch install failed"
@@ -814,7 +831,8 @@ install_opencode() {
 }
 
 install_kimi() {
-  local home="${AGENT_PATHS[kimi]:-${XDG_CFG}/agents}"
+  local home; home="$(agent_path "kimi")"
+  home="${home:-${XDG_CFG}/agents}"
   MANIFEST_ENTRIES=()
   ensure_dir "${home}/skills"
   maybe_backup "$home" "${home}/.xpowers-backups"
@@ -870,68 +888,51 @@ install_kimi() {
 }
 
 install_kimi_code() {
-  local home="${XDG_CFG}/kimi-code"
+  local home="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
   MANIFEST_ENTRIES=()
-  ensure_dir "${home}/skills"
-
-  # Canonical user-level skill path for Kimi Code CLI. Kimi Code discovers
-  # skills under ~/.kimi-code/skills/ automatically, so this works even when
-  # the native `kimi plugin` command is unavailable.
-  local source_skills="${REPO_ROOT}/.kimi-code/skills"
-  for skill_dir in "${source_skills}"/*/; do
-    [[ -d "$skill_dir" ]] || continue
-    local dirname; dirname="$(basename "$skill_dir")"
-    [[ "$dirname" == codex-* ]] && continue
-    [[ "$dirname" == common-patterns ]] && continue
-    copy_item "$skill_dir" "${home}/skills/${dirname}"
-    manifest_add "skills/${dirname}/"
-  done
 
   # Plugin registration: when the `kimi` binary is available, register the
-  # repository as a plugin so MCP servers and plugin metadata are loaded.
+  # repository as a plugin. Kimi Code copies the plugin to its managed plugins
+  # directory and loads the manifest (skills, sessionStart, MCP servers) from
+  # there. This is the preferred install path.
+  local plugin_installed=false
   if command -v kimi &>/dev/null; then
     if [[ "$DRY_RUN" == true ]]; then
       info "Would run: kimi plugin install ${REPO_ROOT}"
     else
       local install_stderr
-      install_stderr=$(kimi plugin install "$REPO_ROOT" 2>&1) || {
+      if install_stderr=$(kimi plugin install "$REPO_ROOT" 2>&1); then
+        plugin_installed=true
+      else
         warn "kimi plugin install failed: ${install_stderr}"
-      }
+      fi
     fi
   fi
 
-  # Also copy plugin metadata to a local plugin directory so the repo can be
-  # loaded as a plugin even when the plugin manager did not run.
-  if [[ -f "${REPO_ROOT}/kimi.plugin.json" ]]; then
-    local plugin_dir="${home}/plugins/xpowers"
-    ensure_dir "$plugin_dir"
-    if command -v python3 >/dev/null 2>&1; then
-      python3 -c "
-import json, sys
-src = sys.argv[1]
-dst = sys.argv[2]
-with open(src) as f:
-    data = json.load(f)
-# Local copy keeps skills in the canonical user-level skills directory.
-data['skills'] = '../../skills/'
-with open(dst, 'w') as f:
-    json.dump(data, f, indent=2)
-    f.write('\n')
-" "${REPO_ROOT}/kimi.plugin.json" "${plugin_dir}/kimi.plugin.json"
-    else
-      cp "${REPO_ROOT}/kimi.plugin.json" "${plugin_dir}/kimi.plugin.json"
-      warn "python3 not found — ${plugin_dir}/kimi.plugin.json skills path may need manual adjustment"
-    fi
-    manifest_add "plugins/xpowers/kimi.plugin.json"
+  # Fallback: copy skills to the canonical user-level skill path. Kimi Code
+  # discovers skills under ~/.kimi-code/skills/ automatically, so this works
+  # when the `kimi` binary is unavailable or plugin registration failed.
+  if [[ "$plugin_installed" != true ]]; then
+    ensure_dir "${home}/skills"
+    local source_skills="${REPO_ROOT}/.kimi-code/skills"
+    for skill_dir in "${source_skills}"/*/; do
+      [[ -d "$skill_dir" ]] || continue
+      local dirname; dirname="$(basename "$skill_dir")"
+      [[ "$dirname" == codex-* ]] && continue
+      [[ "$dirname" == common-patterns ]] && continue
+      copy_item "$skill_dir" "${home}/skills/${dirname}"
+      manifest_add "skills/${dirname}/"
+    done
   fi
 
-  # Install guard hooks into ~/.kimi-code/config.toml
+  # Install guard hooks into ~/.kimi-code/config.toml (independent of plugin
+  # registration; hooks are always managed via the user's config file).
   local hook_script="${REPO_ROOT}/scripts/install-kimi-code-hooks.sh"
   if [[ -x "$hook_script" ]]; then
     if [[ "$DRY_RUN" == true ]]; then
       info "Would run: ${hook_script}"
     else
-      bash "$hook_script" || warn "Kimi Code hook installation failed"
+      KIMI_CODE_HOME="$home" bash "$hook_script" || warn "Kimi Code hook installation failed"
     fi
   fi
 
@@ -958,7 +959,8 @@ install_codex() {
   if [[ "$CODEX_SCOPE" == "local" ]]; then
     home=".codex"
   else
-    home="${AGENT_PATHS[codex]:-${HOME}/.codex}"
+    home="$(agent_path "codex")"
+    home="${home:-${HOME}/.codex}"
   fi
   ensure_dir "${home}/skills"
   maybe_backup "$home" "${home}/.xpowers-backups"
@@ -1031,7 +1033,8 @@ install_gemini() {
 # ---------------------------------------------------------------------------
 
 validate_claude() {
-  local home="${AGENT_PATHS[claude]:-${HOME}/.claude}"
+  local home; home="$(agent_path "claude")"
+  home="${home:-${HOME}/.claude}"
   local ok=true
   [[ -d "${home}/hooks/post-tool-use" ]] || { warn "Claude: hooks/post-tool-use/ missing (recursive copy failed?)"; ok=false; }
   [[ -d "${home}/hooks/pre-tool-use" ]] || { warn "Claude: hooks/pre-tool-use/ missing"; ok=false; }
@@ -1043,7 +1046,8 @@ validate_claude() {
 }
 
 validate_opencode() {
-  local home="${AGENT_PATHS[opencode]:-${XDG_CFG}/opencode}"
+  local home; home="$(agent_path "opencode")"
+  home="${home:-${XDG_CFG}/opencode}"
   local ok=true
   local sk; sk=$(count_items "${home}/skills/*/")
   [[ "$sk" -ge 15 ]] || { warn "OpenCode: only ${sk} skills (expected 15+)"; ok=false; }
@@ -1056,7 +1060,8 @@ validate_opencode() {
 }
 
 validate_kimi() {
-  local home="${AGENT_PATHS[kimi]:-${XDG_CFG}/agents}"
+  local home; home="$(agent_path "kimi")"
+  home="${home:-${XDG_CFG}/agents}"
   local ok=true
   local sk; sk=$(count_items "${home}/skills/*/")
   [[ "$sk" -ge 15 ]] || { warn "Kimi: only ${sk} skills (expected 15+)"; ok=false; }
@@ -1071,18 +1076,32 @@ validate_kimi() {
 }
 
 validate_kimi_code() {
-  local home="${XDG_CFG}/kimi-code"
-  local plugin_dir="${home}/plugins/xpowers"
+  local home="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
   local ok=true
-  local sk; sk=$(count_items "${home}/skills/*/")
-  [[ "$sk" -ge 15 ]] || { warn "Kimi Code: only ${sk} skills (expected 15+)"; ok=false; }
-  # shellcheck disable=SC2012,SC2086
-  local codex_count; codex_count=$(ls -1d ${home}/skills/codex-*/ 2>/dev/null | wc -l)
-  [[ "$codex_count" -eq 0 ]] || { warn "Kimi Code: found ${codex_count} codex-* dirs (should be 0)"; ok=false; }
-  if [[ -f "${plugin_dir}/kimi.plugin.json" ]] && command -v python3 >/dev/null 2>&1; then
-    python3 -c "import json,sys; json.load(open(sys.argv[1]))" "${plugin_dir}/kimi.plugin.json" >/dev/null 2>&1 \
-      || { warn "Kimi Code: plugin manifest is invalid JSON"; ok=false; }
+  local plugin_installed=false
+
+  # If the plugin was registered via `kimi plugin install`, the managed copy
+  # contains the skills and manifest. Otherwise skills live in ~/.kimi-code/skills/.
+  if command -v kimi &>/dev/null && kimi plugin list 2>/dev/null | grep -q '^xpowers\s'; then
+    plugin_installed=true
   fi
+
+  if [[ "$plugin_installed" == true ]]; then
+    local managed_dir="${home}/plugins/managed/xpowers"
+    [[ -f "${managed_dir}/kimi.plugin.json" ]] \
+      || { warn "Kimi Code: plugin manifest missing in managed dir"; ok=false; }
+    if [[ -f "${managed_dir}/kimi.plugin.json" ]] && command -v python3 >/dev/null 2>&1; then
+      python3 -c "import json,sys; json.load(open(sys.argv[1]))" "${managed_dir}/kimi.plugin.json" >/dev/null 2>&1 \
+        || { warn "Kimi Code: plugin manifest is invalid JSON"; ok=false; }
+    fi
+  else
+    local sk; sk=$(count_items "${home}/skills/*/")
+    [[ "$sk" -ge 15 ]] || { warn "Kimi Code: only ${sk} skills (expected 15+)"; ok=false; }
+    # shellcheck disable=SC2012,SC2086
+    local codex_count; codex_count=$(ls -1d ${home}/skills/codex-*/ 2>/dev/null | wc -l)
+    [[ "$codex_count" -eq 0 ]] || { warn "Kimi Code: found ${codex_count} codex-* dirs (should be 0)"; ok=false; }
+  fi
+
   local vf="${home}/.xpowers-version"
   [[ -f "$vf" ]] && [[ "$(cat "$vf")" == "$VERSION" ]] || { warn "Kimi Code: version mismatch"; ok=false; }
   $ok
@@ -1093,7 +1112,8 @@ validate_codex() {
   if [[ "$CODEX_SCOPE" == "local" ]]; then
     home=".codex"
   else
-    home="${AGENT_PATHS[codex]:-${HOME}/.codex}"
+    home="$(agent_path "codex")"
+    home="${home:-${HOME}/.codex}"
   fi
   local ok=true
   local sk; sk=$(count_items "${home}/skills/codex-*/")
@@ -1118,11 +1138,13 @@ validate_gemini() {
 # ---------------------------------------------------------------------------
 
 uninstall_claude() {
-  uninstall_from_manifest "${AGENT_PATHS[claude]:-${HOME}/.claude}"
+  local _claude_home; _claude_home="$(agent_path "claude")"; _claude_home="${_claude_home:-${HOME}/.claude}"
+  uninstall_from_manifest "${_claude_home}"
 }
 
 uninstall_opencode() {
-  local home="${AGENT_PATHS[opencode]:-${XDG_CFG}/opencode}"
+  local home; home="$(agent_path "opencode")"
+  home="${home:-${XDG_CFG}/opencode}"
   uninstall_from_manifest "$home"
   # Also clean bun artifacts (not in manifest but generated by bun install)
   if [[ "$DRY_RUN" != true ]]; then
@@ -1132,30 +1154,25 @@ uninstall_opencode() {
 }
 
 uninstall_kimi() {
-  uninstall_from_manifest "${AGENT_PATHS[kimi]:-${XDG_CFG}/agents}"
+  local _kimi_home; _kimi_home="$(agent_path "kimi")"; _kimi_home="${_kimi_home:-${XDG_CFG}/agents}"
+  uninstall_from_manifest "${_kimi_home}"
 }
 
 uninstall_kimi_code() {
-  local home="${XDG_CFG}/kimi-code"
-  local plugin_dir="${home}/plugins/xpowers"
+  local home="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
 
+  # Remove the plugin registered via `kimi plugin install` (managed copy).
   if command -v kimi &>/dev/null; then
     if [[ "$DRY_RUN" == true ]]; then
-      info "Would run: kimi plugin uninstall xpowers"
+      info "Would run: kimi plugin remove xpowers"
     else
-      kimi plugin uninstall xpowers 2>/dev/null || true
+      kimi plugin remove xpowers 2>/dev/null || true
     fi
   fi
 
-  # Remove manually-copied plugin files tracked by manifest (if any)
+  # Remove fallback user-level skills and version marker tracked by manifest.
   if [[ -f "${home}/.xpowers-manifest" ]]; then
     uninstall_from_manifest "$home"
-  elif [[ -d "$plugin_dir" ]]; then
-    if [[ "$DRY_RUN" == true ]]; then
-      echo "  Would remove: ${plugin_dir}/"
-    else
-      rm -rf "$plugin_dir"
-    fi
   fi
 
   # Remove XPowers hooks block from config.toml
@@ -1185,7 +1202,8 @@ uninstall_codex() {
   if [[ "$CODEX_SCOPE" == "local" ]]; then
     home=".codex"
   else
-    home="${AGENT_PATHS[codex]:-${HOME}/.codex}"
+    home="$(agent_path "codex")"
+    home="${home:-${HOME}/.codex}"
   fi
   uninstall_from_manifest "$home"
 }
@@ -1201,7 +1219,8 @@ uninstall_gemini() {
 }
 
 uninstall_pi() {
-  local home="${AGENT_PATHS[pi]:-${HOME}/.pi/agent}"
+  local home; home="$(agent_path "pi")"
+  home="${home:-${HOME}/.pi/agent}"
   local ext_dir="${home}/extensions/xpowers"
 
   # Remove extension directory (includes skills, commands, node_modules, dist)
@@ -1281,7 +1300,8 @@ status_opencode() {
 }
 
 status_kimi() {
-  local home="${AGENT_PATHS[kimi]:-${XDG_CFG}/agents}"
+  local home; home="$(agent_path "kimi")"
+  home="${home:-${XDG_CFG}/agents}"
   local vf="${home}/.xpowers-version"
   if [[ -f "$vf" ]]; then
     local iv; iv=$(cat "$vf")
@@ -1293,19 +1313,28 @@ status_kimi() {
 }
 
 status_kimi_code() {
-  local home="${XDG_CFG}/kimi-code"
+  local home="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
   local vf="${home}/.xpowers-version"
   if [[ -f "$vf" ]]; then
     local iv; iv=$(cat "$vf")
-    local sk; sk=$(count_items "${home}/skills/*/")
-    echo -e "  ${GREEN}✓${RESET} Kimi Code CLI  ${BOLD}v${iv}${RESET}  (${sk} skills)"
+    local plugin_installed=false
+    if command -v kimi &>/dev/null && kimi plugin list 2>/dev/null | grep -q '^xpowers\s'; then
+      plugin_installed=true
+    fi
+    if [[ "$plugin_installed" == true ]]; then
+      echo -e "  ${GREEN}✓${RESET} Kimi Code CLI  ${BOLD}v${iv}${RESET}  (plugin installed)"
+    else
+      local sk; sk=$(count_items "${home}/skills/*/")
+      echo -e "  ${GREEN}✓${RESET} Kimi Code CLI  ${BOLD}v${iv}${RESET}  (${sk} skills, plugin fallback)"
+    fi
   else
     echo -e "  ${DIM}✗ Kimi Code CLI  not installed${RESET}"
   fi
 }
 
 status_codex() {
-  local home="${AGENT_PATHS[codex]:-${HOME}/.codex}"
+  local home; home="$(agent_path "codex")"
+  home="${home:-${HOME}/.codex}"
   local vf="${home}/.xpowers-version"
   if [[ -f "$vf" ]]; then
     local iv; iv=$(cat "$vf")
@@ -1325,7 +1354,8 @@ status_gemini() {
 }
 
 status_pi() {
-  local home="${AGENT_PATHS[pi]:-${HOME}/.pi/agent}"
+  local home; home="$(agent_path "pi")"
+  home="${home:-${HOME}/.pi/agent}"
   local vf="${home}/.xpowers-version"
   if [[ -f "$vf" ]]; then
     local iv; iv=$(cat "$vf")
@@ -1523,7 +1553,7 @@ selected_agents_cover_detected_agents() {
   local selected_agent
 
   for detected_agent in "${AGENT_ORDER[@]}"; do
-    [[ -n "${AGENT_PATHS[$detected_agent]:-}" ]] || continue
+    [[ -n "$(agent_path "$detected_agent")" ]] || continue
     detected_count=$((detected_count + 1))
     local selected=false
     for selected_agent in "${SELECTED_AGENTS[@]}"; do
@@ -1574,8 +1604,8 @@ record_pi_host_independent_third_party_state() {
 }
 
 third_party_features_skipped() {
-  local value="${XPOWERS_SKIP_THIRD_PARTY_FEATURES:-}"
-  case "${value,,}" in
+  local value; value="$(lowercase "${XPOWERS_SKIP_THIRD_PARTY_FEATURES:-}")"
+  case "$value" in
     1|true|yes) return 0 ;;
     *) return 1 ;;
   esac
@@ -1858,7 +1888,7 @@ Unified installer for XPowers across all AI coding agents.
 AGENTS:
     --claude            Install to Claude Code (~/.claude)
     --opencode          Install to OpenCode (~/.config/opencode)
-    --kimi-code         Install to Kimi Code CLI (~/.config/kimi-code)
+    --kimi-code         Install to Kimi Code CLI (~/.kimi-code)
     --kimi              Install to Kimi CLI (legacy, ~/.config/agents)
     --codex             Install to Codex CLI (~/.codex)
     --gemini            Install to Gemini CLI (native extension)
@@ -2053,14 +2083,14 @@ main() {
     # --all or interactive: select all detected
     local -a resolved_agents=()
     for agent in "${AGENT_ORDER[@]}"; do
-      if [[ -n "${AGENT_PATHS[$agent]:-}" ]]; then
+      if [[ -n "$(agent_path "$agent")" ]]; then
         resolved_agents+=("$agent")
       fi
     done
     # Merge explicitly-selected agents (e.g. --hosts all,pi) without duplicates
     for agent in "${SELECTED_AGENTS[@]}"; do
       local already_in=false
-      for r in "${resolved_agents[@]}"; do
+      for r in ${resolved_agents[@]:+${resolved_agents[@]}}; do
         [[ "$r" == "$agent" ]] && already_in=true && break
       done
       [[ "$already_in" != true ]] && resolved_agents+=("$agent")
@@ -2073,7 +2103,7 @@ main() {
     local -a deduped=()
     for agent in "${SELECTED_AGENTS[@]}"; do
       local already=false
-      for d in "${deduped[@]}"; do
+      for d in ${deduped[@]:+${deduped[@]}}; do
         [[ "$d" == "$agent" ]] && already=true && break
       done
       [[ "$already" != true ]] && deduped+=("$agent")
@@ -2165,7 +2195,7 @@ main() {
   local agent_list=""
   for agent in "${SELECTED_AGENTS[@]}"; do
     [[ -n "$agent_list" ]] && agent_list+=", "
-    agent_list+="${AGENT_LABELS[$agent]}"
+    agent_list+="$(agent_label "$agent")"
   done
 
   # --- Uninstall safety: require --force/--yes in non-tty (dry-run exempt) ---
@@ -2241,7 +2271,7 @@ main() {
     if [[ "$agent" == "pi" && "$MODE" == "install" && "$pi_delegated" == true ]]; then
       continue
     fi
-    local label="${AGENT_LABELS[$agent]}"
+    local label; label="$(agent_label "$agent")"
     if [[ "$MODE" == "uninstall" ]]; then
       printf "  Uninstalling from ${BOLD}%-16s${RESET} " "$label..."
       if "uninstall_${agent}"; then
@@ -2298,7 +2328,7 @@ main() {
     local failed_list=""
     for f in "${FAILED_AGENTS[@]}"; do
       [[ -n "$failed_list" ]] && failed_list+=", "
-      failed_list+="${AGENT_LABELS[$f]}"
+      failed_list+="$(agent_label "$f")"
     done
     warn "${action_past} to ${ok_count} agent(s). Failed: ${failed_list}"
     exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1004,19 +1004,21 @@ install_kimi_code() {
         done < <(printf '%s\n' "$json_manifest_data" | tail -n +2 | grep '^skills/' | cut -d/ -f2 || true)
       fi
     fi
-    for dirname in "${prev_owned[@]}"; do
-      case "$dirname" in
-        ""|"."|".."|*/*|*..*)
-          warn "Ignoring unsafe Kimi Code fallback skill entry from manifest: ${dirname}"
-          continue
-          ;;
-      esac
-      local skill_path="${home}/skills/${dirname}"
-      if [[ -e "$skill_path" ]]; then
-        rm -rf "$skill_path"
-        info "Removed managed fallback skill (plugin now provides it): ${dirname}"
-      fi
-    done
+    if (( ${#prev_owned[@]} > 0 )); then
+      for dirname in "${prev_owned[@]}"; do
+        case "$dirname" in
+          ""|"."|".."|*/*|*..*)
+            warn "Ignoring unsafe Kimi Code fallback skill entry from manifest: ${dirname}"
+            continue
+            ;;
+        esac
+        local skill_path="${home}/skills/${dirname}"
+        if [[ -e "$skill_path" ]]; then
+          rm -rf "$skill_path"
+          info "Removed managed fallback skill (plugin now provides it): ${dirname}"
+        fi
+      done
+    fi
   fi
 
   # Fallback: copy skills to the canonical user-level skill path. Kimi Code

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -547,7 +547,7 @@ uninstall_from_json_manifest() {
     [[ -z "$f" ]] && continue
     # Only accept relative, single-component-or-subpath entries.
     case "$f" in
-      /*|*..*|"."|".") continue ;;
+      ""|"."|".."|/*|*/*|*..*) continue ;;
     esac
     if [[ "$DRY_RUN" == true ]]; then
       if [[ -e "${home}/${f}" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -503,20 +503,43 @@ write_manifest() {
   } > "$manifest"
 }
 
+# Read the TypeScript installer's global JSON manifest for the kimi_code host.
+# Prints the recorded targetDir on the first line, then one file entry per line.
+# Returns empty output if the manifest or host entry is missing.
+read_kimi_json_manifest() {
+  local json_manifest="${HOME}/.xpowers/manifest.json"
+  [[ -f "$json_manifest" ]] || return 0
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 0
+  fi
+  python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    h = d.get('hosts', {}).get('kimi_code', {})
+    print(h.get('targetDir', ''))
+    for f in h.get('files', []):
+        print(f)
+except Exception:
+    pass
+" "$json_manifest" 2>/dev/null || true
+}
+
 # uninstall_from_json_manifest <agent_home>  — remove entries recorded by the
 # TypeScript installer in ~/.xpowers/manifest.json. This keeps shell and TS
 # uninstall paths consistent.
 uninstall_from_json_manifest() {
   local home="$1"
-  local json_manifest="${HOME}/.xpowers/manifest.json"
-  [[ -f "$json_manifest" ]] || return 0
-  if ! command -v python3 >/dev/null 2>&1; then
-    warn "Skipping JSON manifest cleanup: python3 not available"
-    return 0
-  fi
+  local manifest_data
+  manifest_data=$(read_kimi_json_manifest)
+  [[ -n "$manifest_data" ]] || return 0
+
+  local target_dir
+  target_dir=$(printf '%s\n' "$manifest_data" | head -1)
+  [[ "$target_dir" == "$home" ]] || return 0
 
   local files
-  files=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "$json_manifest" 2>/dev/null || true)
+  files=$(printf '%s\n' "$manifest_data" | tail -n +2)
   [[ -n "$files" ]] || return 0
 
   local f
@@ -538,6 +561,7 @@ uninstall_from_json_manifest() {
   # Remove the kimi_code host entry so stale ownership records do not affect
   # later installs. Delete the manifest entirely when no hosts remain.
   if [[ "$DRY_RUN" != true ]]; then
+    local json_manifest="${HOME}/.xpowers/manifest.json"
     python3 -c "
 import json, sys, os
 path = sys.argv[1]
@@ -969,10 +993,16 @@ install_kimi_code() {
         [[ -n "$line" ]] && prev_owned+=("$line")
       done < <(grep '^skills/' "${home}/.xpowers-manifest" 2>/dev/null | cut -d/ -f2 || true)
     fi
-    if [[ -f "${HOME}/.xpowers/manifest.json" ]] && command -v python3 >/dev/null 2>&1; then
-      while IFS= read -r line; do
-        [[ -n "$line" ]] && prev_owned+=("$line")
-      done < <(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "${HOME}/.xpowers/manifest.json" 2>/dev/null | grep '^skills/' | cut -d/ -f2 || true)
+    local json_manifest_data
+    json_manifest_data=$(read_kimi_json_manifest)
+    if [[ -n "$json_manifest_data" ]]; then
+      local json_target_dir
+      json_target_dir=$(printf '%s\n' "$json_manifest_data" | head -1)
+      if [[ "$json_target_dir" == "$home" ]]; then
+        while IFS= read -r line; do
+          [[ -n "$line" ]] && prev_owned+=("$line")
+        done < <(printf '%s\n' "$json_manifest_data" | tail -n +2 | grep '^skills/' | cut -d/ -f2 || true)
+      fi
     fi
     for dirname in "${prev_owned[@]}"; do
       case "$dirname" in
@@ -1004,8 +1034,14 @@ install_kimi_code() {
     if [[ -f "${home}/.xpowers-manifest" ]]; then
       owned_skills+=" $(grep '^skills/' "${home}/.xpowers-manifest" 2>/dev/null | cut -d/ -f2 | sort -u | tr '\n' ' ' || true)"
     fi
-    if [[ -f "${HOME}/.xpowers/manifest.json" ]] && command -v python3 >/dev/null 2>&1; then
-      owned_skills+=" $(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "${HOME}/.xpowers/manifest.json" 2>/dev/null | grep '^skills/' | cut -d/ -f2 | sort -u | tr '\n' ' ' || true)"
+    local json_manifest_data
+    json_manifest_data=$(read_kimi_json_manifest)
+    if [[ -n "$json_manifest_data" ]]; then
+      local json_target_dir
+      json_target_dir=$(printf '%s\n' "$json_manifest_data" | head -1)
+      if [[ "$json_target_dir" == "$home" ]]; then
+        owned_skills+=" $(printf '%s\n' "$json_manifest_data" | tail -n +2 | grep '^skills/' | cut -d/ -f2 | sort -u | tr '\n' ' ' || true)"
+      fi
     fi
     for skill_dir in "${source_skills}"/*/; do
       [[ -d "$skill_dir" ]] || continue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1122,7 +1122,7 @@ validate_kimi_code() {
 
   # If the plugin was registered via `kimi plugin install`, the managed copy
   # contains the skills and manifest. Otherwise skills live in ~/.kimi-code/skills/.
-  if command -v kimi &>/dev/null && kimi plugin list 2>/dev/null | grep -q '^xpowers\s'; then
+  if command -v kimi &>/dev/null && kimi plugin list 2>/dev/null | grep -q '^xpowers[[:space:]]'; then
     plugin_installed=true
   fi
 
@@ -1358,7 +1358,7 @@ status_kimi_code() {
   if [[ -f "$vf" ]]; then
     local iv; iv=$(cat "$vf")
     local plugin_installed=false
-    if command -v kimi &>/dev/null && kimi plugin list 2>/dev/null | grep -q '^xpowers\s'; then
+    if command -v kimi &>/dev/null && kimi plugin list 2>/dev/null | grep -q '^xpowers[[:space:]]'; then
       plugin_installed=true
     fi
     if [[ "$plugin_installed" == true ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -916,10 +916,16 @@ install_kimi_code() {
     ensure_dir "${home}/skills"
     local source_skills="${REPO_ROOT}/.kimi-code/skills"
     # Skills already owned by a previous XPowers fallback install may be
-    # refreshed; everything else is treated as a user skill and skipped.
+    # refreshed; everything else is treated as a user skill and skipped. We
+    # inspect both the shell installer's per-home text manifest and the
+    # TypeScript installer's global JSON manifest so users can switch between
+    # the two documented installers without losing upgrade/uninstall tracking.
     local owned_skills=""
     if [[ -f "${home}/.xpowers-manifest" ]]; then
-      owned_skills="$(grep '^skills/' "${home}/.xpowers-manifest" 2>/dev/null | cut -d/ -f2 | sort -u | tr '\n' ' ')"
+      owned_skills+=" $(grep '^skills/' "${home}/.xpowers-manifest" 2>/dev/null | cut -d/ -f2 | sort -u | tr '\n' ' ')"
+    fi
+    if [[ -f "${HOME}/.xpowers/manifest.json" ]] && command -v python3 >/dev/null 2>&1; then
+      owned_skills+=" $(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "${HOME}/.xpowers/manifest.json" 2>/dev/null | grep '^skills/' | cut -d/ -f2 | sort -u | tr '\n' ' ')"
     fi
     for skill_dir in "${source_skills}"/*/; do
       [[ -d "$skill_dir" ]] || continue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -545,9 +545,9 @@ uninstall_from_json_manifest() {
   local f
   while IFS= read -r f; do
     [[ -z "$f" ]] && continue
-    # Only accept relative, single-component-or-subpath entries.
+    # Only accept relative paths and reject traversal markers.
     case "$f" in
-      ""|"."|".."|/*|*/*|*..*) continue ;;
+      ""|"."|".."|/*|*..*) continue ;;
     esac
     if [[ "$DRY_RUN" == true ]]; then
       if [[ -e "${home}/${f}" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1292,17 +1292,9 @@ uninstall_kimi() {
   uninstall_from_manifest "${_kimi_home}"
 }
 
-uninstall_kimi_code() {
-  local home="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
-
-  # Remove the plugin registered via `kimi plugin install` (managed copy).
-  if command -v kimi &>/dev/null; then
-    if [[ "$DRY_RUN" == true ]]; then
-      info "Would run: kimi plugin remove xpowers"
-    else
-      kimi plugin remove xpowers 2>/dev/null || true
-    fi
-  fi
+# Clean a single Kimi Code home (current or legacy) during uninstall.
+_clean_kimi_home() {
+  local home="$1"
 
   # `kimi plugin remove` leaves the managed directory behind, so clean it up
   # explicitly to match the user's expectation that uninstall removes the
@@ -1344,6 +1336,29 @@ uninstall_kimi_code() {
   # Remove version marker if manifest removal missed it
   if [[ "$DRY_RUN" != true ]]; then
     rm -f "${home}/.xpowers-version"
+  fi
+}
+
+uninstall_kimi_code() {
+  local home="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
+  local legacy_home="${XDG_CFG}/kimi-code"
+
+  # Remove the plugin registered via `kimi plugin install` (managed copy).
+  if command -v kimi &>/dev/null; then
+    if [[ "$DRY_RUN" == true ]]; then
+      info "Would run: kimi plugin remove xpowers"
+    else
+      kimi plugin remove xpowers 2>/dev/null || true
+    fi
+  fi
+
+  _clean_kimi_home "$home"
+
+  # Older versions of this installer used the XDG config home
+  # (~/.config/kimi-code). Clean that up too when it differs from the current
+  # canonical home so upgrades from the legacy path do not leave stale files.
+  if [[ "$home" != "$legacy_home" ]]; then
+    _clean_kimi_home "$legacy_home"
   fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -280,7 +280,7 @@ remove_legacy() {
       if [[ -n "$agent_home" ]]; then
         for legacy_name in hyperpowers myhyperpowers superpowers; do
           local legacy_manifest="${agent_home}/.${legacy_name}-manifest"
-          if [[ -f "$legacy_manifest" && "$processed_manifests" != *"${legacy_manifest}"* ]]; then
+          if [[ -f "$legacy_manifest" && "$processed_manifests" != *"${legacy_manifest}"$'\n'* ]]; then
             if [[ "$DRY_RUN" != true ]] && [[ "$PURGE" != true ]]; then
               while IFS= read -r entry; do
                 [[ -z "$entry" ]] && continue
@@ -907,6 +907,30 @@ install_kimi_code() {
         warn "kimi plugin install failed: ${install_stderr}"
       fi
     fi
+  fi
+
+  # If a previous fallback install left XPowers-owned skills on disk and the
+  # plugin path now succeeds, remove those managed copies so they don't
+  # duplicate the plugin's own skills or become untracked orphans.
+  if [[ "$plugin_installed" == true ]]; then
+    local -a prev_owned=()
+    if [[ -f "${home}/.xpowers-manifest" ]]; then
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && prev_owned+=("$line")
+      done < <(grep '^skills/' "${home}/.xpowers-manifest" 2>/dev/null | cut -d/ -f2 || true)
+    fi
+    if [[ -f "${HOME}/.xpowers/manifest.json" ]] && command -v python3 >/dev/null 2>&1; then
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && prev_owned+=("$line")
+      done < <(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('\\n'.join(d.get('hosts',{}).get('kimi_code',{}).get('files',[])))" "${HOME}/.xpowers/manifest.json" 2>/dev/null | grep '^skills/' | cut -d/ -f2 || true)
+    fi
+    for dirname in "${prev_owned[@]}"; do
+      local skill_path="${home}/skills/${dirname}"
+      if [[ -e "$skill_path" ]]; then
+        rm -rf "$skill_path"
+        info "Removed managed fallback skill (plugin now provides it): ${dirname}"
+      fi
+    done
   fi
 
   # Fallback: copy skills to the canonical user-level skill path. Kimi Code
@@ -2106,9 +2130,11 @@ main() {
     # Merge explicitly-selected agents (e.g. --hosts all,pi) without duplicates
     for agent in "${SELECTED_AGENTS[@]}"; do
       local already_in=false
-      for r in ${resolved_agents[@]:+${resolved_agents[@]}}; do
-        [[ "$r" == "$agent" ]] && already_in=true && break
-      done
+      if (( ${#resolved_agents[@]} > 0 )); then
+        for r in "${resolved_agents[@]}"; do
+          [[ "$r" == "$agent" ]] && already_in=true && break
+        done
+      fi
       [[ "$already_in" != true ]] && resolved_agents+=("$agent")
     done
     SELECTED_AGENTS=("${resolved_agents[@]}")
@@ -2119,9 +2145,11 @@ main() {
     local -a deduped=()
     for agent in "${SELECTED_AGENTS[@]}"; do
       local already=false
-      for d in ${deduped[@]:+${deduped[@]}}; do
-        [[ "$d" == "$agent" ]] && already=true && break
-      done
+      if (( ${#deduped[@]} > 0 )); then
+        for d in "${deduped[@]}"; do
+          [[ "$d" == "$agent" ]] && already=true && break
+        done
+      fi
       [[ "$already" != true ]] && deduped+=("$agent")
     done
     SELECTED_AGENTS=("${deduped[@]}")

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -305,13 +305,24 @@ const HOSTS: HostConfig[] = [
         if (existsSync(sourceSkills)) {
           await mkdir(targetSkills, { recursive: true })
           // Refresh skills owned by a previous XPowers fallback install; skip
-          // anything else so we do not overwrite unrelated user skills.
+          // anything else so we do not overwrite unrelated user skills. We
+          // inspect both the TypeScript installer JSON manifest and the shell
+          // installer's per-home text manifest so users can switch between the
+          // two documented installers without losing upgrade/uninstall tracking.
           const prevManifest = await readManifest()
-          const ownedSkills = new Set(
+          const ownedFromJson =
             prevManifest?.hosts?.kimi_code?.files
               ?.filter((f) => f.startsWith("skills/"))
-              ?.map((f) => f.split("/")[1]) ?? [],
-          )
+              ?.map((f) => f.split("/")[1]) ?? []
+          const shellManifestPath = join(target, ".xpowers-manifest")
+          const ownedFromShell = existsSync(shellManifestPath)
+            ? (await readFile(shellManifestPath, "utf8"))
+                .split(/\n/)
+                .map((l) => l.trim())
+                .filter((l) => l.startsWith("skills/"))
+                .map((l) => l.split("/")[1])
+            : []
+          const ownedSkills = new Set([...ownedFromJson, ...ownedFromShell])
           const items = await listItems(sourceSkills, undefined, ["common-patterns"])
           for (const item of items) {
             if (item.startsWith("codex-")) continue

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -29,7 +29,7 @@ type HostConfig = {
   detect: () => boolean
   targetDir: () => string
   sources: Record<string, SourceMapping>
-  postInstall?: (targetDir: string) => Promise<void>
+  postInstall?: (targetDir: string, installedFiles: string[]) => Promise<void>
   postUninstall?: (targetDir: string) => Promise<void>
   availableFeatures: string[]
 }
@@ -284,15 +284,29 @@ const HOSTS: HostConfig[] = [
       skills: { from: ".kimi-code/skills", exclude: ["common-patterns"] },
     },
     availableFeatures: [],
-    postInstall: async (target) => {
+    postInstall: async (target, installedFiles) => {
       // Register the plugin with Kimi Code so MCP servers and sessionStart load.
+      let pluginInstalled = false
       if (commandExists("kimi")) {
         const installResult = Bun.spawnSync(["kimi", "plugin", "install", REPO_ROOT], { stdout: "pipe", stderr: "pipe" })
-        if (installResult.exitCode !== 0) {
+        pluginInstalled = installResult.exitCode === 0
+        if (!pluginInstalled) {
           const stderr = installResult.stderr.toString().trim()
           console.warn(`kimi plugin install failed${stderr ? `: ${stderr}` : ""}`)
         }
       }
+
+      if (pluginInstalled) {
+        // Managed plugin provides skills; remove the fallback copies.
+        const skillsDir = join(target, "skills")
+        if (existsSync(skillsDir)) {
+          await rm(skillsDir, { recursive: true, force: true })
+          for (let i = installedFiles.length - 1; i >= 0; i--) {
+            if (installedFiles[i].startsWith("skills/")) installedFiles.splice(i, 1)
+          }
+        }
+      }
+
       // Install guard hooks into ~/.kimi-code/config.toml
       const hookScript = join(REPO_ROOT, "scripts", "install-kimi-code-hooks.sh")
       if (existsSync(hookScript)) {
@@ -869,7 +883,7 @@ const installHost = async (host: HostConfig): Promise<string[]> => {
 
     // Run post-install and track additional files (before writing version marker)
     if (host.postInstall) {
-      await host.postInstall(target)
+      await host.postInstall(target, installedFiles)
       // Re-scan for files that postInstall may have added
       if (host.id === "opencode") {
         for (const f of ["package.json", "task-context.json", "cass-memory.json"]) {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -280,9 +280,7 @@ const HOSTS: HostConfig[] = [
     name: "Kimi Code CLI",
     detect: () => existsSync(join(homedir(), ".kimi-code")) || existsSync(join(xdgConfig(), "kimi-code")) || commandExists("kimi"),
     targetDir: () => process.env.KIMI_CODE_HOME || join(homedir(), ".kimi-code"),
-    sources: {
-      skills: { from: ".kimi-code/skills", exclude: ["common-patterns"] },
-    },
+    sources: {},
     availableFeatures: [],
     postInstall: async (target, installedFiles) => {
       // Register the plugin with Kimi Code so MCP servers and sessionStart load.
@@ -296,14 +294,29 @@ const HOSTS: HostConfig[] = [
         }
       }
 
-      if (pluginInstalled) {
-        // Managed plugin provides skills; remove only the fallback copies we
-        // just installed, leaving any pre-existing user skills untouched.
-        for (let i = installedFiles.length - 1; i >= 0; i--) {
-          const entry = installedFiles[i]
-          if (entry.startsWith("skills/")) {
-            await rm(join(target, entry), { recursive: true, force: true })
-            installedFiles.splice(i, 1)
+      if (!pluginInstalled) {
+        // Fallback: copy skills to the canonical user-level path. Kimi Code
+        // discovers skills under ~/.kimi-code/skills/ automatically, so this
+        // works when the `kimi` binary is unavailable or plugin registration
+        // failed. We only copy here to avoid clobbering/restoring backups when
+        // the managed plugin path succeeds.
+        const sourceSkills = join(REPO_ROOT, ".kimi-code", "skills")
+        const targetSkills = join(target, "skills")
+        if (existsSync(sourceSkills)) {
+          await mkdir(targetSkills, { recursive: true })
+          const items = await listItems(sourceSkills, undefined, ["common-patterns"])
+          for (const item of items) {
+            if (item.startsWith("codex-")) continue
+            const srcPath = join(sourceSkills, item)
+            const destPath = join(targetSkills, item)
+            const s = await stat(srcPath)
+            if (s.isDirectory()) {
+              await copyDir(srcPath, destPath)
+              installedFiles.push(`skills/${item}/`)
+            } else {
+              await copyFile(srcPath, destPath)
+              installedFiles.push(`skills/${item}`)
+            }
           }
         }
       }

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -283,6 +283,27 @@ const HOSTS: HostConfig[] = [
     sources: {},
     availableFeatures: [],
     postInstall: async (target, installedFiles) => {
+      // Determine which fallback skills (if any) are already owned by a
+      // previous XPowers install, so we can refresh them safely or remove them
+      // when the plugin path takes over. We inspect both the TypeScript
+      // installer JSON manifest and the shell installer's per-home text
+      // manifest so users can switch between the two documented installers
+      // without losing upgrade/uninstall tracking.
+      const prevManifest = await readManifest()
+      const ownedFromJson =
+        prevManifest?.hosts?.kimi_code?.files
+          ?.filter((f) => f.startsWith("skills/"))
+          ?.map((f) => f.split("/")[1]) ?? []
+      const shellManifestPath = join(target, ".xpowers-manifest")
+      const ownedFromShell = existsSync(shellManifestPath)
+        ? (await readFile(shellManifestPath, "utf8"))
+            .split(/\n/)
+            .map((l) => l.trim())
+            .filter((l) => l.startsWith("skills/"))
+            .map((l) => l.split("/")[1])
+        : []
+      const ownedSkills = new Set([...ownedFromJson, ...ownedFromShell])
+
       // Register the plugin with Kimi Code so MCP servers and sessionStart load.
       let pluginInstalled = false
       if (commandExists("kimi")) {
@@ -291,6 +312,19 @@ const HOSTS: HostConfig[] = [
         if (!pluginInstalled) {
           const stderr = installResult.stderr.toString().trim()
           console.warn(`kimi plugin install failed${stderr ? `: ${stderr}` : ""}`)
+        }
+      }
+
+      if (pluginInstalled) {
+        // Managed plugin provides skills. If a previous fallback install left
+        // XPowers-owned skill copies on disk, remove them so they don't
+        // duplicate the plugin's skills or become untracked orphans.
+        for (const dirname of ownedSkills) {
+          const skillPath = join(target, "skills", dirname)
+          if (existsSync(skillPath)) {
+            await rm(skillPath, { recursive: true, force: true })
+            p.log.info(`Removed managed fallback skill (plugin now provides it): ${dirname}`)
+          }
         }
       }
 
@@ -304,25 +338,6 @@ const HOSTS: HostConfig[] = [
         const targetSkills = join(target, "skills")
         if (existsSync(sourceSkills)) {
           await mkdir(targetSkills, { recursive: true })
-          // Refresh skills owned by a previous XPowers fallback install; skip
-          // anything else so we do not overwrite unrelated user skills. We
-          // inspect both the TypeScript installer JSON manifest and the shell
-          // installer's per-home text manifest so users can switch between the
-          // two documented installers without losing upgrade/uninstall tracking.
-          const prevManifest = await readManifest()
-          const ownedFromJson =
-            prevManifest?.hosts?.kimi_code?.files
-              ?.filter((f) => f.startsWith("skills/"))
-              ?.map((f) => f.split("/")[1]) ?? []
-          const shellManifestPath = join(target, ".xpowers-manifest")
-          const ownedFromShell = existsSync(shellManifestPath)
-            ? (await readFile(shellManifestPath, "utf8"))
-                .split(/\n/)
-                .map((l) => l.trim())
-                .filter((l) => l.startsWith("skills/"))
-                .map((l) => l.split("/")[1])
-            : []
-          const ownedSkills = new Set([...ownedFromJson, ...ownedFromShell])
           const items = await listItems(sourceSkills, undefined, ["common-patterns"])
           for (const item of items) {
             if (item.startsWith("codex-")) continue
@@ -355,6 +370,20 @@ const HOSTS: HostConfig[] = [
         if (hookResult.exitCode !== 0) {
           const stderr = hookResult.stderr.toString().trim()
           console.warn(`Kimi Code hook installation failed${stderr ? `: ${stderr}` : ""}`)
+        } else {
+          // Track the guard hooks so uninstall can remove them cleanly.
+          const guardHooks = [
+            "hooks/pre-tool-use/block-beads-direct-read.py",
+            "hooks/pre-tool-use/01-block-pre-commit-edits.py",
+            "hooks/pre-tool-use/block-dangerous-bash.py",
+            "hooks/pre-tool-use/block-env-writes.py",
+            "hooks/post-tool-use/02-block-bd-truncation.py",
+            "hooks/post-tool-use/03-block-pre-commit-bash.py",
+            "hooks/post-tool-use/04-block-pre-existing-checks.py",
+          ]
+          for (const hook of guardHooks) {
+            installedFiles.push(hook)
+          }
         }
       }
     },

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -395,6 +395,13 @@ const HOSTS: HostConfig[] = [
           console.warn(`kimi plugin remove failed${stderr ? `: ${stderr}` : ""}`)
         }
       }
+      // `kimi plugin remove` leaves the managed directory behind, so clean it
+      // up explicitly to match the user's expectation that uninstall removes
+      // the XPowers code.
+      const managedDir = join(target, "plugins", "managed", "xpowers")
+      if (existsSync(managedDir)) {
+        await rm(managedDir, { recursive: true, force: true })
+      }
       // Remove XPowers hooks block from config.toml
       const configFile = join(target, "config.toml")
       if (existsSync(configFile)) {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -290,10 +290,13 @@ const HOSTS: HostConfig[] = [
       // manifest so users can switch between the two documented installers
       // without losing upgrade/uninstall tracking.
       const prevManifest = await readManifest()
+      const prevKimiHost = prevManifest?.hosts?.kimi_code
       const ownedFromJson =
-        prevManifest?.hosts?.kimi_code?.files
-          ?.filter((f) => f.startsWith("skills/"))
-          ?.map((f) => f.split("/")[1]) ?? []
+        prevKimiHost?.targetDir === target
+          ? (prevKimiHost.files
+              ?.filter((f) => f.startsWith("skills/"))
+              ?.map((f) => f.split("/")[1]) ?? [])
+          : []
       const shellManifestPath = join(target, ".xpowers-manifest")
       const ownedFromShell = existsSync(shellManifestPath)
         ? (await readFile(shellManifestPath, "utf8"))

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -297,12 +297,13 @@ const HOSTS: HostConfig[] = [
       }
 
       if (pluginInstalled) {
-        // Managed plugin provides skills; remove the fallback copies.
-        const skillsDir = join(target, "skills")
-        if (existsSync(skillsDir)) {
-          await rm(skillsDir, { recursive: true, force: true })
-          for (let i = installedFiles.length - 1; i >= 0; i--) {
-            if (installedFiles[i].startsWith("skills/")) installedFiles.splice(i, 1)
+        // Managed plugin provides skills; remove only the fallback copies we
+        // just installed, leaving any pre-existing user skills untouched.
+        for (let i = installedFiles.length - 1; i >= 0; i--) {
+          const entry = installedFiles[i]
+          if (entry.startsWith("skills/")) {
+            await rm(join(target, entry), { recursive: true, force: true })
+            installedFiles.splice(i, 1)
           }
         }
       }

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -318,8 +318,14 @@ const HOSTS: HostConfig[] = [
       if (pluginInstalled) {
         // Managed plugin provides skills. If a previous fallback install left
         // XPowers-owned skill copies on disk, remove them so they don't
-        // duplicate the plugin's skills or become untracked orphans.
+        // duplicate the plugin's skills or become untracked orphans. Validate
+        // names first to avoid path traversal from corrupt manifests.
+        const safeSkillName = /^[a-z0-9_-]+$/i
         for (const dirname of ownedSkills) {
+          if (!safeSkillName.test(dirname)) {
+            p.log.warn(`Ignoring unsafe Kimi Code fallback skill entry from manifest: ${dirname}`)
+            continue
+          }
           const skillPath = join(target, "skills", dirname)
           if (existsSync(skillPath)) {
             await rm(skillPath, { recursive: true, force: true })

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -304,12 +304,20 @@ const HOSTS: HostConfig[] = [
         const targetSkills = join(target, "skills")
         if (existsSync(sourceSkills)) {
           await mkdir(targetSkills, { recursive: true })
+          // Refresh skills owned by a previous XPowers fallback install; skip
+          // anything else so we do not overwrite unrelated user skills.
+          const prevManifest = await readManifest()
+          const ownedSkills = new Set(
+            prevManifest?.hosts?.kimi_code?.files
+              ?.filter((f) => f.startsWith("skills/"))
+              ?.map((f) => f.split("/")[1]) ?? [],
+          )
           const items = await listItems(sourceSkills, undefined, ["common-patterns"])
           for (const item of items) {
             if (item.startsWith("codex-")) continue
             const srcPath = join(sourceSkills, item)
             const destPath = join(targetSkills, item)
-            if (existsSync(destPath)) {
+            if (existsSync(destPath) && !ownedSkills.has(item)) {
               p.log.warn(`Skipping fallback skill ${item}: already exists at ${destPath}`)
               continue
             }

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -276,6 +276,63 @@ const HOSTS: HostConfig[] = [
     },
   },
   {
+    id: "kimi_code",
+    name: "Kimi Code CLI",
+    detect: () => existsSync(join(homedir(), ".kimi-code")) || existsSync(join(xdgConfig(), "kimi-code")) || commandExists("kimi"),
+    targetDir: () => process.env.KIMI_CODE_HOME || join(homedir(), ".kimi-code"),
+    sources: {
+      skills: { from: ".kimi-code/skills", exclude: ["common-patterns"] },
+    },
+    availableFeatures: [],
+    postInstall: async (target) => {
+      // Register the plugin with Kimi Code so MCP servers and sessionStart load.
+      if (commandExists("kimi")) {
+        const installResult = Bun.spawnSync(["kimi", "plugin", "install", REPO_ROOT], { stdout: "pipe", stderr: "pipe" })
+        if (installResult.exitCode !== 0) {
+          const stderr = installResult.stderr.toString().trim()
+          console.warn(`kimi plugin install failed${stderr ? `: ${stderr}` : ""}`)
+        }
+      }
+      // Install guard hooks into ~/.kimi-code/config.toml
+      const hookScript = join(REPO_ROOT, "scripts", "install-kimi-code-hooks.sh")
+      if (existsSync(hookScript)) {
+        const hookResult = Bun.spawnSync(["bash", hookScript], {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env, KIMI_CODE_HOME: target },
+        })
+        if (hookResult.exitCode !== 0) {
+          const stderr = hookResult.stderr.toString().trim()
+          console.warn(`Kimi Code hook installation failed${stderr ? `: ${stderr}` : ""}`)
+        }
+      }
+    },
+    postUninstall: async (target) => {
+      if (commandExists("kimi")) {
+        const removeResult = Bun.spawnSync(["kimi", "plugin", "remove", "xpowers"], { stdout: "pipe", stderr: "pipe" })
+        if (removeResult.exitCode !== 0) {
+          const stderr = removeResult.stderr.toString().trim()
+          console.warn(`kimi plugin remove failed${stderr ? `: ${stderr}` : ""}`)
+        }
+      }
+      // Remove XPowers hooks block from config.toml
+      const configFile = join(target, "config.toml")
+      if (existsSync(configFile)) {
+        let config = await readFile(configFile, "utf8")
+        config = config
+          .split(/\n/)
+          .filter((line, index, lines) => {
+            const startIdx = lines.findIndex((l) => l.includes("# BEGIN XPOWERS KIMI-CODE HOOKS"))
+            const endIdx = lines.findIndex((l) => l.includes("# END XPOWERS KIMI-CODE HOOKS"))
+            if (startIdx === -1 || endIdx === -1) return true
+            return index < startIdx || index > endIdx
+          })
+          .join("\n")
+        await writeFile(configFile, config, "utf8")
+      }
+    },
+  },
+  {
     id: "gemini",
     name: "Gemini CLI",
     detect: () => commandExists("gemini"),
@@ -921,6 +978,12 @@ type CliArgs = {
   allowConflicts: boolean
 }
 
+const HOST_ID_ALIASES: Record<string, string> = {
+  "kimi-code": "kimi_code",
+}
+
+const normalizeHostId = (id: string) => HOST_ID_ALIASES[id] || id
+
 const parseArgs = (): CliArgs => {
   const args: CliArgs = { yes: false, uninstall: false, json: false, hosts: [], features: [], help: false, allowConflicts: false }
   const argv = process.argv.slice(2)
@@ -941,7 +1004,7 @@ const parseArgs = (): CliArgs => {
         args.yes = true // JSON implies non-interactive
         break
       case "--hosts":
-        args.hosts = (argv[++i] || "").split(",").filter(Boolean)
+        args.hosts = (argv[++i] || "").split(",").filter(Boolean).map(normalizeHostId)
         break
       case "--features":
         args.features = (argv[++i] || "").split(",").filter(Boolean)
@@ -989,7 +1052,7 @@ Options:
   --yes, -y          Auto-install all detected hosts and features
   --json, -j         Output structured JSON (implies --yes, for AI agents)
   --uninstall        Remove all installed files and features
-  --hosts <list>     Comma-separated host IDs: claude,opencode,kimi,gemini,pi
+  --hosts <list>     Comma-separated host IDs: claude,opencode,kimi,kimi_code,gemini,pi (kimi-code is also accepted)
   --features <list>  Comma-separated feature IDs: memsearch,br,bv,graphify,claude-mem,supermemory,statusline,routing-wizard,tm-cli
   --allow-conflicts  Advanced: continue despite detected hyperpowers/myhyperpowers/superpowers installs
   --help, -h         Show this help

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -309,6 +309,10 @@ const HOSTS: HostConfig[] = [
             if (item.startsWith("codex-")) continue
             const srcPath = join(sourceSkills, item)
             const destPath = join(targetSkills, item)
+            if (existsSync(destPath)) {
+              p.log.warn(`Skipping fallback skill ${item}: already exists at ${destPath}`)
+              continue
+            }
             const s = await stat(srcPath)
             if (s.isDirectory()) {
               await copyDir(srcPath, destPath)

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -335,6 +335,14 @@ const HOSTS: HostConfig[] = [
             p.log.info(`Removed managed fallback skill (plugin now provides it): ${dirname}`)
           }
         }
+
+        // Clear the stale per-home text manifest from a previous shell fallback
+        // install so a later fallback install doesn't treat user-recreated
+        // skills as XPowers-owned.
+        const shellManifest = join(target, ".xpowers-manifest")
+        if (existsSync(shellManifest)) {
+          await rm(shellManifest, { force: true })
+        }
       }
 
       if (!pluginInstalled) {

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -2332,11 +2332,15 @@ test("setup-pi.sh shim rejects piped execution with helpful error", { timeout: 6
 test("install.sh --kimi-code installs skills, hooks, and version marker", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-kimi-code-test-"))
   const kimiHome = path.join(home, ".kimi-code")
+  const pathWithoutKimi = (process.env.PATH || "")
+    .split(path.delimiter)
+    .filter((dir) => !fs.existsSync(path.join(dir, "kimi")))
+    .join(path.delimiter)
 
   const result = spawnSync("bash", ["scripts/install.sh", "--kimi-code", "--yes"], {
     cwd: repoRoot,
     encoding: "utf8",
-    env: installEnv(home),
+    env: installEnv(home, { PATH: pathWithoutKimi }),
     timeout: 120000,
   })
 

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -2329,10 +2329,9 @@ test("setup-pi.sh shim rejects piped execution with helpful error", { timeout: 6
   assert.match(output, /universal installer instead/i)
 })
 
-test("install.sh --kimi-code installs skills, plugin metadata, and guard hooks", { timeout: 120000 }, () => {
+test("install.sh --kimi-code installs skills, hooks, and version marker", { timeout: 120000 }, () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-kimi-code-test-"))
-  const kimiHome = path.join(home, ".config", "kimi-code")
-  const pluginDir = path.join(kimiHome, "plugins", "xpowers")
+  const kimiHome = path.join(home, ".kimi-code")
 
   const result = spawnSync("bash", ["scripts/install.sh", "--kimi-code", "--yes"], {
     cwd: repoRoot,
@@ -2344,21 +2343,13 @@ test("install.sh --kimi-code installs skills, plugin metadata, and guard hooks",
   const output = combinedOutput(result)
   assert.equal(result.status, 0, output)
 
-  // Skills copied to canonical user-level path (exclude codex-* and common-patterns)
+  // Fallback: skills copied to canonical user-level path when `kimi` binary is unavailable
   const skillsDir = path.join(kimiHome, "skills")
   assert.equal(fs.existsSync(skillsDir), true)
   const skills = fs.readdirSync(skillsDir).filter((n) => fs.statSync(path.join(skillsDir, n)).isDirectory())
   assert.ok(skills.length >= 15, `expected 15+ skills, found ${skills.length}`)
   assert.equal(skills.some((n) => n.startsWith("codex-")), false, "codex-* skills should not be installed")
   assert.equal(skills.includes("common-patterns"), false, "common-patterns should not be installed")
-
-  // Plugin manifest copied and valid JSON
-  const manifestPath = path.join(pluginDir, "kimi.plugin.json")
-  assert.equal(fs.existsSync(manifestPath), true, "kimi.plugin.json should be installed")
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"))
-  assert.equal(typeof manifest.name, "string")
-  assert.equal(typeof manifest.version, "string")
-  assert.equal(manifest.skills, "../../skills/")
 
   // Version marker
   const versionPath = path.join(kimiHome, ".xpowers-version")


### PR DESCRIPTION
This PR addresses the follow-up issues found after landing the initial Kimi Code CLI support in #60.

## Changes

- **scripts/install.sh**: bash 3.2 compatibility (no associative arrays, no `${var,,}`), canonical `~/.kimi-code` home, plugin-install fallback, and cross-installer manifest awareness.
- **scripts/install.ts**: full `kimi_code` host support, plugin + fallback behavior, user-skill collision safety, and `kimi-code` CLI alias.
- **scripts/install-kimi-code-hooks.sh**: absolute `KIMI_CODE_HOME` hook paths.
- **Docs**: fallback behavior and TypeScript installer example in `.kimi-code/INSTALL.md` and `README.md`.
- **Tests**: updated Kimi Code install target path and refreshed dependencies.

## Safety notes

- Fallback skills are only copied when `kimi plugin install` fails.
- Existing user skills are skipped unless they appear in a previous XPowers manifest.
- Both installers read each other's manifest format so upgrades/uninstalls stay consistent.

## Verification

- `node --test --test-name-pattern="install.sh --kimi-code installs skills" tests/install-script.test.js` passes.
- Cross-installer upgrade scenarios tested manually.
- `codex review` passed with no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-interactive TypeScript installer for Kimi Code, including the `kimi-code` alias.
* **Documentation**
  * Updated the Kimi Code manual install guide to clarify what gets installed (skills, guard hooks/config, and shared runtime) and improved fallback guidance when plugin registration isn’t available.
  * Expanded the README with the new command and post-install restart/reload step.
* **Bug Fixes**
  * Improved Kimi Code hook/config generation and ensured managed vs fallback installs clean up guard hooks correctly.
* **Tests**
  * Updated coverage to verify fallback skill copying behavior when the Kimi plugin subcommand is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->