### PR TITLE
feat(install): add ZCode host support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This document provides essential information for AI coding agents working with t
 
 ## Project Overview
 
-**XPowers** supports multiple developer hosts (Claude Code, OpenCode, Gemini CLI, Kimi Code CLI, Kimi CLI, Codex CLI, and Pi), providing structured workflows, best practices, and specialized agents for software development. Think of it as a pair programming partner that ensures proven development patterns are followed.
+**XPowers** supports multiple developer hosts (Claude Code, OpenCode, Gemini CLI, Kimi Code CLI, Kimi CLI, Codex CLI, Pi, and ZCode), providing structured workflows, best practices, and specialized agents for software development. Think of it as a pair programming partner that ensures proven development patterns are followed.
 
 ### Key Components
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to XPowers are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **ZCode host support** in both installers (`scripts/install.sh --zcode`, `bun scripts/install.ts --hosts zcode`): installs skills to `~/.zcode/skills` and slash commands to `~/.zcode/commands` with manifest-tracked uninstall. Agents and hooks are not installed (ZCode loads them from plugins only).
+
 ## [2.14.2] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">XPowers</h1>
 
 <p align="center">
-  <strong>Structured engineering workflows for Claude Code, OpenCode, Gemini CLI, Kimi Code CLI, Kimi CLI, Codex CLI, and Pi.</strong>
+  <strong>Structured engineering workflows for Claude Code, OpenCode, Gemini CLI, Kimi Code CLI, Kimi CLI, Codex CLI, Pi, and ZCode.</strong>
 </p>
 
 <p align="center">
@@ -251,7 +251,7 @@ bun scripts/install.ts --yes --json
 bun scripts/install.ts --uninstall
 ```
 
-Available hosts: `claude`, `opencode`, `kimi`, `gemini`, `pi`
+Available hosts: `claude`, `opencode`, `kimi`, `gemini`, `pi`, `zcode`
 Available features: `memsearch`, `br`, `bv`, `graphify`, `claude-mem`, `supermemory`, `statusline`, `routing-wizard`, `tm-cli`
 
 `--yes` includes third-party tool installers. `br` and `bv` bootstrap from pinned upstream installer refs; maintainers can override them with `XPOWERS_BEADS_RUST_INSTALL_REF` and `XPOWERS_BEADS_VIEWER_INSTALL_REF` when intentionally updating. `graphify` runs its upstream platform setup only for supported selected hosts (Claude Code, Codex via `install.sh`, OpenCode, Gemini CLI, and Pi). Set `XPOWERS_SKIP_THIRD_PARTY_FEATURES=1` when you need a host-only install without external downloads.
@@ -556,6 +556,25 @@ $codex-skill-executing-plans Continue from current tm ready task.
 ```
 
 You can also use `/skills` in Codex UI to discover and select the same wrappers.
+
+</details>
+
+<details>
+<summary><strong>ZCode</strong></summary>
+
+Use the unified installer to install skills and slash commands to `~/.zcode/skills` and `~/.zcode/commands`:
+
+```bash
+./scripts/install.sh --zcode
+```
+
+Or install to all detected agents at once:
+
+```bash
+./scripts/install.sh --all
+```
+
+ZCode discovers the skills and `/commands` at session start, so restart any open sessions after installing. ZCode loads agents and hooks from plugins only, so those XPowers surfaces are not part of this host install.
 
 </details>
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # XPowers Unified Multi-Agent Installer
 # Detects installed AI coding agents and installs xpowers to all of them.
-# Supports: Claude Code, OpenCode, Kimi Code CLI, Kimi CLI (legacy), Codex CLI, Gemini CLI, Pi Agent
+# Supports: Claude Code, OpenCode, Kimi Code CLI, Kimi CLI (legacy), Codex CLI, Gemini CLI, Pi Agent, ZCode
 
 # ---------------------------------------------------------------------------
 # Common infrastructure
@@ -334,7 +334,7 @@ remove_legacy() {
 # Agent detection
 # ---------------------------------------------------------------------------
 
-AGENT_ORDER=(claude opencode kimi_code kimi codex gemini pi)
+AGENT_ORDER=(claude opencode kimi_code kimi codex gemini pi zcode)
 
 agent_label() {
   case "$1" in
@@ -345,6 +345,7 @@ agent_label() {
     codex)     echo "Codex CLI" ;;
     gemini)    echo "Gemini CLI" ;;
     pi)        echo "Pi Agent" ;;
+    zcode)     echo "ZCode" ;;
     *)         echo "$1" ;;
   esac
 }
@@ -392,6 +393,7 @@ detect_pi()      {
     AGENT_PATHS_pi="${HOME}/.pi/agent"
   fi
 }
+detect_zcode()   { [[ -d "${HOME}/.zcode" ]] && AGENT_PATHS_zcode="${HOME}/.zcode" || true; }
 
 detect_all() {
   detect_claude
@@ -401,6 +403,7 @@ detect_all() {
   detect_codex
   detect_gemini
   detect_pi
+  detect_zcode
 }
 
 show_detection() {
@@ -1219,6 +1222,39 @@ install_gemini() {
   fi
 }
 
+# ZCode discovers user-scope skills in ~/.zcode/skills/ and slash commands in
+# ~/.zcode/commands/. Agents and hooks are plugin-managed by ZCode, so this
+# host installs only the skills and commands subsets.
+install_zcode() {
+  local home; home="$(agent_path "zcode")"
+  home="${home:-${HOME}/.zcode}"
+  MANIFEST_ENTRIES=()
+  ensure_dir "${home}/skills"
+  ensure_dir "${home}/commands"
+  maybe_backup "$home" "${home}/.xpowers-backups"
+
+  # Skills (recursive copy of each skill dir)
+  for d in "${REPO_ROOT}"/skills/*/; do
+    [[ -d "$d" ]] || continue
+    local name; name="$(basename "$d")"
+    [[ "$name" == "common-patterns" ]] && continue
+    copy_item "$d" "${home}/skills/${name}"
+    manifest_add "skills/${name}/"
+  done
+
+  # Slash commands
+  for f in "${REPO_ROOT}"/commands/*.md; do
+    [[ -f "$f" ]] || continue
+    local name; name="$(basename "$f")"
+    copy_item "$f" "${home}/commands/${name}"
+    manifest_add "commands/${name}"
+  done
+
+  manifest_add ".xpowers-version"
+  echo "${VERSION}" > "${home}/.xpowers-version"
+  write_manifest "$home"
+}
+
 # ---------------------------------------------------------------------------
 # Validation functions
 # ---------------------------------------------------------------------------
@@ -1322,6 +1358,19 @@ validate_gemini() {
     }
   fi
   return 0
+}
+
+validate_zcode() {
+  local home; home="$(agent_path "zcode")"
+  home="${home:-${HOME}/.zcode}"
+  local ok=true
+  local sk; sk=$(count_items "${home}/skills/*/")
+  [[ "$sk" -ge 15 ]] || { warn "ZCode: only ${sk} skills (expected 15+)"; ok=false; }
+  local cm; cm=$(count_items "${home}/commands/*.md")
+  [[ "$cm" -ge 5 ]] || { warn "ZCode: only ${cm} commands (expected 5+)"; ok=false; }
+  local vf="${home}/.xpowers-version"
+  [[ -f "$vf" ]] && [[ "$(cat "$vf")" == "$VERSION" ]] || { warn "ZCode: version mismatch"; ok=false; }
+  $ok
 }
 
 # ---------------------------------------------------------------------------
@@ -1491,6 +1540,12 @@ uninstall_pi() {
   done
 }
 
+uninstall_zcode() {
+  local home; home="$(agent_path "zcode")"
+  home="${home:-${HOME}/.zcode}"
+  uninstall_from_manifest "$home"
+}
+
 # ---------------------------------------------------------------------------
 # Status functions
 # ---------------------------------------------------------------------------
@@ -1584,6 +1639,20 @@ status_pi() {
     echo -e "  ${GREEN}✓${RESET} Pi Agent       ${BOLD}v${iv}${RESET}"
   else
     echo -e "  ${DIM}✗ Pi Agent       not installed${RESET}"
+  fi
+}
+
+status_zcode() {
+  local home; home="$(agent_path "zcode")"
+  home="${home:-${HOME}/.zcode}"
+  local vf="${home}/.xpowers-version"
+  if [[ -f "$vf" ]]; then
+    local iv; iv=$(cat "$vf")
+    local sk; sk=$(count_items "${home}/skills/*/")
+    local cm; cm=$(count_items "${home}/commands/*.md")
+    echo -e "  ${GREEN}✓${RESET} ZCode          ${BOLD}v${iv}${RESET}  (${sk} skills, ${cm} commands)"
+  else
+    echo -e "  ${DIM}✗ ZCode          not installed${RESET}"
   fi
 }
 
@@ -2114,7 +2183,8 @@ AGENTS:
     --kimi              Install to Kimi CLI (legacy, ~/.config/agents)
     --codex             Install to Codex CLI (~/.codex)
     --gemini            Install to Gemini CLI (native extension)
-    --hosts <list>      Comma-separated agents: claude,opencode,kimi-code,kimi,codex,gemini,pi,all
+    --zcode             Install to ZCode (~/.zcode, skills + commands only)
+    --hosts <list>      Comma-separated agents: claude,opencode,kimi-code,kimi,codex,gemini,pi,zcode,all
     --all               Install to all detected agents
 
 MODES:
@@ -2185,6 +2255,7 @@ main() {
       --kimi)       SELECTED_AGENTS+=(kimi);      INTERACTIVE=false; shift ;;
       --codex)      SELECTED_AGENTS+=(codex);     INTERACTIVE=false; shift ;;
       --gemini)     SELECTED_AGENTS+=(gemini);    INTERACTIVE=false; shift ;;
+      --zcode)      SELECTED_AGENTS+=(zcode);     INTERACTIVE=false; shift ;;
       --hosts)
         shift
         if [[ $# -eq 0 ]]; then
@@ -2202,6 +2273,7 @@ main() {
             codex)     SELECTED_AGENTS+=(codex);     INTERACTIVE=false ;;
             gemini)    SELECTED_AGENTS+=(gemini);    INTERACTIVE=false ;;
             pi)        SELECTED_AGENTS+=(pi);        INTERACTIVE=false ;;
+            zcode)     SELECTED_AGENTS+=(zcode);     INTERACTIVE=false ;;
             all)       SELECT_ALL=true; INTERACTIVE=false ;;
             *)         error "Unknown host: $h"; usage >&2; exit 1 ;;
           esac
@@ -2296,6 +2368,7 @@ main() {
     status_codex
     status_gemini
     status_pi
+    status_zcode
     echo
     exit 0
   fi

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -543,6 +543,19 @@ const HOSTS: HostConfig[] = [
       }
     },
   },
+  {
+    id: "zcode",
+    name: "ZCode",
+    detect: () => existsSync(join(homedir(), ".zcode")),
+    targetDir: () => join(homedir(), ".zcode"),
+    // ZCode loads agents and hooks from plugins only, so this host installs
+    // just the user-scope skills and slash commands surfaces.
+    sources: {
+      skills: { from: "skills", exclude: ["common-patterns"] },
+      commands: { from: "commands" },
+    },
+    availableFeatures: [],
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -1156,7 +1169,7 @@ Options:
   --yes, -y          Auto-install all detected hosts and features
   --json, -j         Output structured JSON (implies --yes, for AI agents)
   --uninstall        Remove all installed files and features
-  --hosts <list>     Comma-separated host IDs: claude,opencode,kimi,kimi_code,gemini,pi (kimi-code is also accepted)
+  --hosts <list>     Comma-separated host IDs: claude,opencode,kimi,kimi_code,gemini,pi,zcode (kimi-code is also accepted)
   --features <list>  Comma-separated feature IDs: memsearch,br,bv,graphify,claude-mem,supermemory,statusline,routing-wizard,tm-cli
   --allow-conflicts  Advanced: continue despite detected hyperpowers/myhyperpowers/superpowers installs
   --help, -h         Show this help

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -2373,3 +2373,123 @@ test("install.sh --kimi-code installs skills, hooks, and version marker", { time
   assert.match(config, /event = "PreToolUse"/)
   assert.match(config, /event = "PostToolUse"/)
 })
+
+test("install.sh --zcode installs skills and commands with version marker", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-zcode-test-"))
+  const zcodeHome = path.join(home, ".zcode")
+  fs.mkdirSync(zcodeHome, { recursive: true })
+
+  const result = spawnSync("bash", ["scripts/install.sh", "--zcode", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+
+  // Skills copied to ~/.zcode/skills (common-patterns is a reference dir, not a skill)
+  const skillsDir = path.join(zcodeHome, "skills")
+  assert.equal(fs.existsSync(skillsDir), true)
+  const skills = fs.readdirSync(skillsDir).filter((n) => fs.statSync(path.join(skillsDir, n)).isDirectory())
+  assert.ok(skills.length >= 15, `expected 15+ skills, found ${skills.length}`)
+  assert.equal(skills.includes("common-patterns"), false, "common-patterns should not be installed")
+
+  // Slash commands copied to ~/.zcode/commands
+  const commandsDir = path.join(zcodeHome, "commands")
+  assert.equal(fs.existsSync(commandsDir), true)
+  const commands = fs.readdirSync(commandsDir).filter((n) => n.endsWith(".md"))
+  assert.ok(commands.length >= 10, `expected 10+ commands, found ${commands.length}`)
+  assert.equal(fs.existsSync(path.join(commandsDir, "brainstorm.md")), true)
+  assert.equal(fs.existsSync(path.join(commandsDir, "write-plan.md")), true)
+
+  // ZCode loads agents and hooks from plugins only, so neither is installed
+  assert.equal(fs.existsSync(path.join(zcodeHome, "agents")), false, "agents should not be installed for ZCode")
+  assert.equal(fs.existsSync(path.join(zcodeHome, "hooks")), false, "hooks should not be installed for ZCode")
+
+  // Version marker matches the plugin manifest
+  const versionPath = path.join(zcodeHome, ".xpowers-version")
+  assert.equal(fs.existsSync(versionPath), true)
+  assert.equal(
+    fs.readFileSync(versionPath, "utf8").trim(),
+    JSON.parse(fs.readFileSync(path.join(repoRoot, ".claude-plugin", "plugin.json"), "utf8")).version,
+  )
+  assert.equal(fs.existsSync(path.join(zcodeHome, ".xpowers-manifest")), true)
+
+  // --status reports the ZCode install
+  const status = spawnSync("bash", ["scripts/install.sh", "--status"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 60000,
+  })
+  const statusOutput = combinedOutput(status)
+  assert.equal(status.status, 0, statusOutput)
+  assert.match(statusOutput, /ZCode/)
+})
+
+test("install.sh --hosts zcode --uninstall removes managed files and preserves user skills", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-sh-zcode-uninstall-test-"))
+  const zcodeHome = path.join(home, ".zcode")
+  fs.mkdirSync(zcodeHome, { recursive: true })
+
+  const install = spawnSync("bash", ["scripts/install.sh", "--hosts", "zcode", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+  assert.equal(install.status, 0, combinedOutput(install))
+
+  // User-created skill must survive uninstall (manifest-driven removal)
+  const userSkill = path.join(zcodeHome, "skills", "my-own-skill", "SKILL.md")
+  fs.mkdirSync(path.dirname(userSkill), { recursive: true })
+  fs.writeFileSync(userSkill, "---\nname: my-own-skill\ndescription: mine\n---\n", "utf8")
+
+  const uninstall = spawnSync("bash", ["scripts/install.sh", "--hosts", "zcode", "--uninstall", "--yes"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(uninstall)
+  assert.equal(uninstall.status, 0, output)
+  assert.equal(fs.existsSync(path.join(zcodeHome, "skills", "test-driven-development")), false, "managed skills should be removed")
+  assert.equal(fs.existsSync(userSkill), true, "user skills must be preserved")
+  assert.equal(fs.existsSync(path.join(zcodeHome, "commands", "brainstorm.md")), false, "managed commands should be removed")
+  assert.equal(fs.existsSync(path.join(zcodeHome, ".xpowers-version")), false)
+  assert.equal(fs.existsSync(path.join(zcodeHome, ".xpowers-manifest")), false)
+})
+
+test("bun installer --hosts zcode installs skills and commands", { timeout: 120000 }, () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "install-ts-zcode-test-"))
+  const zcodeHome = path.join(home, ".zcode")
+  fs.mkdirSync(zcodeHome, { recursive: true })
+  const bunPath = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" }).stdout.trim()
+
+  const result = spawnSync(bunPath, ["scripts/install.ts", "--hosts", "zcode", "--yes", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: installEnv(home),
+    timeout: 120000,
+  })
+
+  const output = combinedOutput(result)
+  assert.equal(result.status, 0, output)
+  const payload = JSON.parse(result.stdout.trim())
+  assert.equal(payload.ok, true)
+  assert.ok(payload.hosts.includes("zcode"), `expected zcode in hosts: ${JSON.stringify(payload.hosts)}`)
+
+  const skillsDir = path.join(zcodeHome, "skills")
+  assert.equal(fs.existsSync(path.join(skillsDir, "test-driven-development", "SKILL.md")), true)
+  const skills = fs.readdirSync(skillsDir).filter((n) => fs.statSync(path.join(skillsDir, n)).isDirectory())
+  assert.ok(skills.length >= 15, `expected 15+ skills, found ${skills.length}`)
+  assert.equal(skills.includes("common-patterns"), false, "common-patterns should not be installed")
+  assert.equal(fs.existsSync(path.join(zcodeHome, "commands", "brainstorm.md")), true)
+  assert.equal(fs.existsSync(path.join(zcodeHome, "hooks")), false, "hooks should not be installed for ZCode")
+
+  const manifest = JSON.parse(fs.readFileSync(path.join(home, ".xpowers", "manifest.json"), "utf8"))
+  assert.ok(manifest.hosts.zcode.targetDir.includes(".zcode"), `expected zcode targetDir: ${JSON.stringify(manifest.hosts.zcode)}`)
+})

--- a/tests/tm-docs-contract.test.js
+++ b/tests/tm-docs-contract.test.js
@@ -91,7 +91,7 @@ test("README and AGENTS agree on Codex wrapper location and host support", () =>
   assert.equal(readme.includes("Generated output is written to `.agents/skills`"), true)
   assert.equal(readme.includes(".kimi/skills"), false)
   assert.equal(agentsGuide.includes(".agents/               # Codex-compatible generated wrappers"), true)
-  assert.equal(agentsGuide.includes("supports multiple developer hosts (Claude Code, OpenCode, Gemini CLI, Kimi Code CLI, Kimi CLI, Codex CLI, and Pi)"), true)
+  assert.equal(agentsGuide.includes("supports multiple developer hosts (Claude Code, OpenCode, Gemini CLI, Kimi Code CLI, Kimi CLI, Codex CLI, Pi, and ZCode)"), true)
   assert.equal(codexSection.includes("./scripts/install.sh --codex"), true)
   assert.equal(codexSection.includes("~/.codex/skills"), true)
 })


### PR DESCRIPTION
## Description

Adds **ZCode** as an installer host in both installers, alongside the existing seven hosts:

- `scripts/install.sh --zcode` (or `--hosts zcode`, included in `--all` detection via `~/.zcode`)
- `bun scripts/install.ts --hosts zcode`

ZCode discovers user-scope skills from `~/.zcode/skills/` and slash commands from `~/.zcode/commands/`, so the host installs exactly those two surfaces with the standard manifest-tracked uninstall (user-created skills are preserved). **Agents and hooks are intentionally not installed** — ZCode loads both from plugins only, so copying them into `~/.zcode` would be dead weight. This also avoids `~/.agents/skills`, which the Codex fallback path already claims.

Install shape per host follows the existing conventions: skills copied from `skills/` (minus `common-patterns`, matching Claude), commands from `commands/*.md`, `.xpowers-version` marker, `.xpowers-manifest` for uninstall, plus detect/validate/uninstall/status parity in `install.sh` and a data-driven entry in the `install.ts` `HOSTS[]` array.

## Related Issues

None filed — happy to link one if preferred.

## Checklist

- [x] I have read the project `AGENTS.md` and followed the coding style guidelines.
- [x] I have added or updated tests for any new or changed functionality (3 new tests in `tests/install-script.test.js`: install + status, uninstall preserves user skills, bun installer; all green).
- [x] I have updated relevant documentation (`README.md` host list + ZCode section, `CHANGELOG.md` Unreleased, `AGENTS.md` host overview, `tm-docs-contract` pinned host list).
- [x] `node scripts/sync-codex-skills.js --check` passes (no skills changed).
- [x] `npm run lint` passes.
- [ ] `node --test tests/*.test.js` — 474/478 pass. The 4 failures are pre-existing on `main` (verified by stashing this branch's changes and re-running: `bun installer pins br and bv…`, `bun installer treats failed br and bv downloads…`, `Pi installed runtime resolves execute-ralph…`, and the Pi fallback-runner module resolution). This branch introduces no new failures.
- [ ] `npm run test:ci-local` not run in full locally (it includes the pre-existing bun failures above).
- [x] `npm audit --audit-level=moderate` — no dependency changes in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ZCode as a supported developer host.
  * Installers can add ZCode skills and slash commands, report installation status, and safely uninstall tracked files.
  * Added ZCode detection, validation, version tracking, and CLI support.
  * ZCode installations exclude agents and hooks.

* **Documentation**
  * Updated the README, project overview, and changelog with ZCode installation, update, restart, and limitation details.

* **Tests**
  * Added coverage for ZCode installation, status reporting, manifests, uninstall behavior, and host support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->